### PR TITLE
Add player command packet

### DIFF
--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -1709,7 +1709,7 @@ impl Player {
     }
 
     /// Handles a player command packet (sprinting, elytra, leaving bed, etc).
-    // this is just temporary there because the logic is not yet implemented completly for the other branches
+    // this is just temporary there because the logic is not yet implemented complete for the other branches
     #[allow(clippy::match_same_arms)]
     pub fn handle_player_command(&self, packet: SPlayerCommand) {
         match packet.action {

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -34,8 +34,8 @@ use std::{
 use steel_protocol::packets::game::CSystemChatMessage;
 use steel_protocol::packets::game::{
     AnimateAction, CAnimate, CEntityPositionSync, COpenSignEditor, CPlayerPosition, CSetEntityData,
-    CSetHeldSlot, PlayerAction, SAcceptTeleportation, SPickItemFromBlock, SPlayerAbilities,
-    SPlayerAction, SSetCarriedItem, SUseItem, SUseItemOn,
+    CSetHeldSlot, PlayerAction, PlayerCommandAction, SAcceptTeleportation, SPickItemFromBlock,
+    SPlayerAbilities, SPlayerAction, SPlayerCommand, SSetCarriedItem, SUseItem, SUseItemOn,
 };
 use steel_registry::blocks::block_state_ext::BlockStateExt;
 use steel_registry::blocks::shapes::AABBd;
@@ -1706,7 +1706,38 @@ impl Player {
     /// Handles a player input packet (movement keys, sneaking, sprinting).
     pub fn handle_player_input(&self, packet: SPlayerInput) {
         self.shift_key_down.store(packet.shift(), Ordering::Relaxed);
-        // Note: sprinting is handled via SPlayerCommand packet
+    }
+
+    /// Handles a player command packet (sprinting, elytra, leaving bed, etc).
+    pub fn handle_player_command(&self, packet: SPlayerCommand) {
+        match packet.action {
+            PlayerCommandAction::StartSprinting => {
+                self.sprinting.store(true, Ordering::Relaxed);
+            }
+            PlayerCommandAction::StopSprinting => {
+                self.sprinting.store(false, Ordering::Relaxed);
+            }
+            PlayerCommandAction::StartFallFlying => {
+                // TODO: check if player has elytra equipped and is falling
+                self.fall_flying.store(true, Ordering::Relaxed);
+            }
+            PlayerCommandAction::LeaveBed => {
+                if self.sleeping.load(Ordering::Relaxed) {
+                    self.sleeping.store(false, Ordering::Relaxed);
+                    // TODO: update pose and notify other players
+                }
+            }
+            PlayerCommandAction::StartRidingJump => {
+                // TODO: implement horse jumping when vehicles are added
+                let _jump_boost = packet.jump_boost;
+            }
+            PlayerCommandAction::StopRidingJump => {
+                // TODO: implement horse jumping when vehicles are added
+            }
+            PlayerCommandAction::OpenVehicleInventory => {
+                // TODO: implement vehicle inventory when vehicles are added
+            }
+        }
     }
 
     /// Handles the use of an item on a block.

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -1709,6 +1709,8 @@ impl Player {
     }
 
     /// Handles a player command packet (sprinting, elytra, leaving bed, etc).
+    // this is just temporary there because the logic is not yet implemented completly for the other branches
+    #[allow(clippy::match_same_arms)]
     pub fn handle_player_command(&self, packet: SPlayerCommand) {
         match packet.action {
             PlayerCommandAction::StartSprinting => {
@@ -1729,7 +1731,7 @@ impl Player {
             }
             PlayerCommandAction::StartRidingJump => {
                 // TODO: implement horse jumping when vehicles are added
-                let _jump_boost = packet.jump_boost;
+                // let _jump_boost = packet.jump_boost;
             }
             PlayerCommandAction::StopRidingJump => {
                 // TODO: implement horse jumping when vehicles are added

--- a/steel-core/src/player/networking.rs
+++ b/steel-core/src/player/networking.rs
@@ -16,8 +16,8 @@ use steel_protocol::packets::game::{
     SChunkBatchReceived, SClientTickEnd, SCommandSuggestion, SContainerButtonClick,
     SContainerClick, SContainerClose, SContainerSlotStateChanged, SMovePlayerPos,
     SMovePlayerPosRot, SMovePlayerRot, SMovePlayerStatusOnly, SPickItemFromBlock, SPlayerAbilities,
-    SPlayerAction, SPlayerInput, SPlayerLoad, SSetCarriedItem, SSetCreativeModeSlot, SSignUpdate,
-    SSwing, SUseItem, SUseItemOn,
+    SPlayerAction, SPlayerCommand, SPlayerInput, SPlayerLoad, SSetCarriedItem,
+    SSetCreativeModeSlot, SSignUpdate, SSwing, SUseItem, SUseItemOn,
 };
 use steel_protocol::utils::{ConnectionProtocol, PacketError, RawPacket};
 use steel_registry::packets::play;
@@ -366,6 +366,10 @@ impl JavaConnection {
                 player
                     .connection
                     .send_packet(CPongResponse::new(packet.time));
+            }
+            play::S_PLAYER_COMMAND => {
+                let packet = SPlayerCommand::read_packet(data)?;
+                player.handle_player_command(packet);
             }
             id => log::info!("play packet id {id} is not known"),
         }

--- a/steel-protocol/src/packets/game/c_update_attributes.rs
+++ b/steel-protocol/src/packets/game/c_update_attributes.rs
@@ -1,0 +1,104 @@
+//! Clientbound update attributes packet - syncs entity attribute values and modifiers.
+//!
+//! Sent when an entity's attributes change (e.g., movement speed modifier from sprinting).
+//! Matches vanilla `ClientboundUpdateAttributesPacket`.
+
+use std::io::{Result, Write};
+
+use steel_macros::ClientPacket;
+use steel_registry::packets::play::C_UPDATE_ATTRIBUTES;
+use steel_utils::{Identifier, codec::VarInt, serial::WriteTo};
+
+/// An attribute modifier operation type.
+///
+/// Matches vanilla `AttributeModifier.Operation` ordinal values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum AttributeModifierOperation {
+    /// Adds the value directly to the base: `base + value`
+    AddValue = 0,
+    /// Adds `base * value` to the result (additive with other multiplied_base modifiers)
+    AddMultipliedBase = 1,
+    /// Multiplies the current result by `(1 + value)` (multiplicative with others)
+    AddMultipliedTotal = 2,
+}
+
+/// A single attribute modifier sent over the network.
+#[derive(Clone, Debug)]
+pub struct AttributeModifierData {
+    /// The modifier's unique resource location ID (e.g., `minecraft:sprinting`).
+    pub id: Identifier,
+    /// The modifier amount.
+    pub amount: f64,
+    /// The modifier operation.
+    pub operation: AttributeModifierOperation,
+}
+
+impl WriteTo for AttributeModifierData {
+    fn write(&self, writer: &mut impl Write) -> Result<()> {
+        self.id.write(writer)?;
+        self.amount.write(writer)?;
+        (self.operation as u8).write(writer)?;
+        Ok(())
+    }
+}
+
+/// A single attribute snapshot sent in the packet.
+#[derive(Clone, Debug)]
+pub struct AttributeSnapshot {
+    /// The attribute's registry ID (e.g., 22 for `minecraft:movement_speed`).
+    pub attribute_id: i32,
+    /// The base value of the attribute (before modifiers).
+    pub base_value: f64,
+    /// Active modifiers on this attribute.
+    pub modifiers: Vec<AttributeModifierData>,
+}
+
+impl WriteTo for AttributeSnapshot {
+    fn write(&self, writer: &mut impl Write) -> Result<()> {
+        VarInt(self.attribute_id).write(writer)?;
+        self.base_value.write(writer)?;
+        VarInt(self.modifiers.len() as i32).write(writer)?;
+        for modifier in &self.modifiers {
+            modifier.write(writer)?;
+        }
+        Ok(())
+    }
+}
+
+/// Sent to synchronize entity attribute values and their modifiers with the client.
+///
+/// Used for movement speed (sprint modifier), max health, attack damage, etc.
+/// The client uses this to update its local attribute instances.
+///
+/// Matches vanilla `ClientboundUpdateAttributesPacket`.
+#[derive(ClientPacket, Clone, Debug)]
+#[packet_id(Play = C_UPDATE_ATTRIBUTES)]
+pub struct CUpdateAttributes {
+    /// The entity ID whose attributes are being updated.
+    pub entity_id: i32,
+    /// The attribute snapshots to sync.
+    pub attributes: Vec<AttributeSnapshot>,
+}
+
+impl CUpdateAttributes {
+    /// Creates a new update attributes packet.
+    #[must_use]
+    pub fn new(entity_id: i32, attributes: Vec<AttributeSnapshot>) -> Self {
+        Self {
+            entity_id,
+            attributes,
+        }
+    }
+}
+
+impl WriteTo for CUpdateAttributes {
+    fn write(&self, writer: &mut impl Write) -> Result<()> {
+        VarInt(self.entity_id).write(writer)?;
+        VarInt(self.attributes.len() as i32).write(writer)?;
+        for attr in &self.attributes {
+            attr.write(writer)?;
+        }
+        Ok(())
+    }
+}

--- a/steel-protocol/src/packets/game/mod.rs
+++ b/steel-protocol/src/packets/game/mod.rs
@@ -64,6 +64,7 @@ mod s_move_player;
 mod s_pick_item_from_block;
 mod s_player_abilities;
 mod s_player_action;
+mod s_player_command;
 mod s_player_input;
 mod s_player_load;
 mod s_set_carried_item;
@@ -151,6 +152,7 @@ pub use s_move_player::{
 pub use s_pick_item_from_block::SPickItemFromBlock;
 pub use s_player_abilities::SPlayerAbilities;
 pub use s_player_action::{PlayerAction, SPlayerAction};
+pub use s_player_command::{PlayerCommandAction, SPlayerCommand};
 pub use s_player_input::SPlayerInput;
 pub use s_player_load::SPlayerLoad;
 pub use s_set_carried_item::SSetCarriedItem;

--- a/steel-protocol/src/packets/game/mod.rs
+++ b/steel-protocol/src/packets/game/mod.rs
@@ -46,6 +46,7 @@ mod c_tab_list;
 mod c_take_item_entity;
 mod c_ticking_state;
 mod c_ticking_step;
+mod c_update_attributes;
 mod chat_session_data;
 mod s_accept_teleportation;
 mod s_chat;
@@ -132,6 +133,9 @@ pub use c_tab_list::CTabList;
 pub use c_take_item_entity::CTakeItemEntity;
 pub use c_ticking_state::CTickingState;
 pub use c_ticking_step::CTickingStep;
+pub use c_update_attributes::{
+    AttributeModifierData, AttributeModifierOperation, AttributeSnapshot, CUpdateAttributes,
+};
 pub use chat_session_data::ProtocolRemoteChatSessionData;
 pub use s_accept_teleportation::SAcceptTeleportation;
 pub use s_chat::SChat;

--- a/steel-protocol/src/packets/game/s_player_command.rs
+++ b/steel-protocol/src/packets/game/s_player_command.rs
@@ -1,0 +1,36 @@
+use steel_macros::{ReadFrom, ServerPacket};
+
+/// Action types for the player command packet.
+#[derive(ReadFrom, Clone, Copy, Debug, PartialEq, Eq)]
+#[read(as = VarInt)]
+pub enum PlayerCommandAction {
+    /// Player leaves bed (only when clicking "Leave Bed" button).
+    LeaveBed = 0,
+    /// Player starts sprinting.
+    StartSprinting = 1,
+    /// Player stops sprinting.
+    StopSprinting = 2,
+    /// Player starts jumping while riding a horse (data = jump boost 0-100).
+    StartRidingJump = 3,
+    /// Player stops jumping while riding a horse.
+    StopRidingJump = 4,
+    /// Player opens vehicle inventory (horse/chest boat) via inventory key.
+    OpenVehicleInventory = 5,
+    /// Player starts flying with elytra.
+    StartFallFlying = 6,
+}
+
+/// Serverbound packet sent when a player performs a command action.
+///
+/// This handles actions like sprinting, sleeping, elytra, and horse riding.
+#[derive(ReadFrom, ServerPacket, Clone, Debug)]
+pub struct SPlayerCommand {
+    /// The entity ID of the player (should match the player's ID).
+    #[read(as = VarInt)]
+    pub entity_id: i32,
+    /// The action being performed.
+    pub action: PlayerCommandAction,
+    /// Jump boost for StartRidingJump (0-100), otherwise 0.
+    #[read(as = VarInt)]
+    pub jump_boost: i32,
+}


### PR DESCRIPTION
This pull request introduces support for handling player command actions such as sprinting, elytra flight, leaving bed, and horse riding. The main changes involve adding a new packet type (`SPlayerCommand`) and its associated logic to the player module and networking layer.

### Player command handling

* Added a new packet type `SPlayerCommand` and its associated action enum `PlayerCommandAction`, which represents various player command actions (e.g., sprinting, leaving bed, elytra flight, horse riding). (`steel-protocol/src/packets/game/s_player_command.rs`)
* Implemented the `handle_player_command` method in the `Player` struct to respond to these actions, updating player state accordingly (e.g., toggling sprinting, fall flying, sleeping). (`steel-core/src/player/mod.rs`)

### Networking integration

* Registered the new `SPlayerCommand` packet in the networking layer and added logic to handle it, invoking the new player command handler when received. (`steel-core/src/player/networking.rs`)
* Updated packet imports in both `steel-core/src/player/mod.rs` and `steel-core/src/player/networking.rs` to include `SPlayerCommand` and `PlayerCommandAction`. [[1]](diffhunk://#diff-07c449e0f74630d0a303e13736757d704bf4d6d5ba40b618d397a1875e76c93dL37-R38) [[2]](diffhunk://#diff-579312c66b64797518e4976e8a525f59d68593c642595c3d0ad7e63d5d60d7e5L19-R20)

### Protocol module updates

* Added the new module `s_player_command` and exported `SPlayerCommand` and `PlayerCommandAction` from the protocol packet module. (`steel-protocol/src/packets/game/mod.rs`) [[1]](diffhunk://#diff-6c7aeb35d4f195dbb6898be4ab19533839b305970a5edc6b43af4de1908522e8R67) [[2]](diffhunk://#diff-6c7aeb35d4f195dbb6898be4ab19533839b305970a5edc6b43af4de1908522e8R155)

it was annoying all the time to see in console "Unknown packet" so i did that