### PR TITLE
feat: campfire cooking

### DIFF
--- a/steel-core/src/behavior/blocks/building/campfire_block.rs
+++ b/steel-core/src/behavior/blocks/building/campfire_block.rs
@@ -39,6 +39,16 @@ pub struct CampfireBlock {
     fire_damage: i32,
 }
 
+/// Outcome of attempting to place a held item onto a campfire.
+enum CampfirePlaceOutcome {
+    /// The item was placed onto a free slot and consumed from the hand.
+    Placed,
+    /// The item is cookable but all slots are occupied.
+    NoSlot,
+    /// The held item is not a campfire cooking ingredient.
+    NotCookable,
+}
+
 impl CampfireBlock {
     /// Creates a campfire block behavior.
     #[must_use]
@@ -220,34 +230,30 @@ impl BlockBehavior for CampfireBlock {
             return InteractionResult::TryEmptyHandInteraction;
         };
 
-        // Check whether the held item is campfire-cookable and, if so, attempt to
-        // place it onto the campfire.
-        let recipe_time = inv.with_item(|stack| {
-            REGISTRY
-                .recipes
-                .find_campfire_recipe(stack)
-                .map(|recipe| recipe.cooking_time)
-        });
-        let Some(cooking_time) = recipe_time else {
-            return InteractionResult::TryEmptyHandInteraction;
-        };
-
-        let placed = inv.with_item(|stack| {
-            let placed = campfire.place_food(stack.clone(), cooking_time);
-            if placed {
+        // Look up the campfire recipe for the held item and, if cookable, place
+        // a single item onto the campfire and consume it from the hand.
+        let outcome = inv.with_item(|stack| {
+            let Some(recipe) = REGISTRY.recipes.find_campfire_recipe(stack) else {
+                return CampfirePlaceOutcome::NotCookable;
+            };
+            if campfire.place_food(stack.clone(), recipe.cooking_time) {
                 stack.shrink(1);
+                CampfirePlaceOutcome::Placed
+            } else {
+                CampfirePlaceOutcome::NoSlot
             }
-            placed
         });
 
-        if placed {
-            world.send_block_updated(pos);
-            let context = GameEventContext::new(Some(player), Some(state));
-            world.game_event(&vanilla_game_events::BLOCK_CHANGE, pos, &context);
-            // The INTERACT_WITH_CAMPFIRE stat awaits Steel's statistics foundation.
-            InteractionResult::SuccessServer
-        } else {
-            InteractionResult::Consume
+        match outcome {
+            CampfirePlaceOutcome::Placed => {
+                world.send_block_updated(pos);
+                let context = GameEventContext::new(Some(player), Some(state));
+                world.game_event(&vanilla_game_events::BLOCK_CHANGE, pos, &context);
+                // The INTERACT_WITH_CAMPFIRE stat awaits Steel's statistics foundation.
+                InteractionResult::SuccessServer
+            }
+            CampfirePlaceOutcome::NoSlot => InteractionResult::Consume,
+            CampfirePlaceOutcome::NotCookable => InteractionResult::TryEmptyHandInteraction,
         }
     }
 

--- a/steel-core/src/behavior/blocks/building/campfire_block.rs
+++ b/steel-core/src/behavior/blocks/building/campfire_block.rs
@@ -5,12 +5,17 @@ use steel_registry::block_entity_type::BlockEntityTypeRef;
 use steel_registry::blocks::properties::{BlockStateProperties, Direction};
 use steel_registry::blocks::{BlockRef, block_state_ext::BlockStateExt as _};
 use steel_registry::fluid::FluidState;
+use steel_registry::items::item::BlockHitResult;
 use steel_registry::vanilla_damage_types;
 use steel_registry::{
-    sound_events, vanilla_block_entity_types, vanilla_blocks, vanilla_fluids, vanilla_game_events,
+    REGISTRY, sound_events, vanilla_block_entity_types, vanilla_blocks, vanilla_fluids,
+    vanilla_game_events,
 };
-use steel_utils::{BlockPos, BlockStateId, types::UpdateFlags};
+use steel_utils::types::InteractionHand;
+use steel_utils::{BlockPos, BlockStateId, Downcast as _, types::UpdateFlags};
 
+use crate::behavior::{InteractionResult, InventoryAccess};
+use crate::player::Player;
 use crate::{
     behavior::{
         BlockBehavior, BlockEntityCreation, BlockPlaceContext, block::schedule_placed_liquid_tick,
@@ -196,6 +201,54 @@ impl BlockBehavior for CampfireBlock {
         );
         schedule_placed_liquid_tick(level, pos, fluid_state);
         true
+    }
+
+    fn use_item_on(
+        &self,
+        state: BlockStateId,
+        world: &Arc<World>,
+        pos: BlockPos,
+        player: &Player,
+        _hand: InteractionHand,
+        _hit_result: &BlockHitResult,
+        inv: &mut InventoryAccess,
+    ) -> InteractionResult {
+        let Some(block_entity) = world.get_block_entity(pos) else {
+            return InteractionResult::TryEmptyHandInteraction;
+        };
+        let Some(campfire) = block_entity.downcast_ref::<CampfireBlockEntity>() else {
+            return InteractionResult::TryEmptyHandInteraction;
+        };
+
+        // Check whether the held item is campfire-cookable and, if so, attempt to
+        // place it onto the campfire.
+        let recipe_time = inv.with_item(|stack| {
+            REGISTRY
+                .recipes
+                .find_campfire_recipe(stack)
+                .map(|recipe| recipe.cooking_time)
+        });
+        let Some(cooking_time) = recipe_time else {
+            return InteractionResult::TryEmptyHandInteraction;
+        };
+
+        let placed = inv.with_item(|stack| {
+            let placed = campfire.place_food(stack.clone(), cooking_time);
+            if placed {
+                stack.shrink(1);
+            }
+            placed
+        });
+
+        if placed {
+            world.send_block_updated(pos);
+            let context = GameEventContext::new(Some(player), Some(state));
+            world.game_event(&vanilla_game_events::BLOCK_CHANGE, pos, &context);
+            // The INTERACT_WITH_CAMPFIRE stat awaits Steel's statistics foundation.
+            InteractionResult::SuccessServer
+        } else {
+            InteractionResult::Consume
+        }
     }
 
     fn new_block_entity(

--- a/steel-core/src/behavior/blocks/building/campfire_block.rs
+++ b/steel-core/src/behavior/blocks/building/campfire_block.rs
@@ -28,8 +28,6 @@ use crate::{
 };
 
 /// Behavior for campfires and soul campfires.
-///
-/// TODO: Add campfire cooking, smoke particles, and dowse item ejection.
 #[block_behavior]
 pub struct CampfireBlock {
     block: BlockRef,

--- a/steel-core/src/behavior/blocks/building/campfire_block.rs
+++ b/steel-core/src/behavior/blocks/building/campfire_block.rs
@@ -1,15 +1,21 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use steel_macros::block_behavior;
+use steel_registry::block_entity_type::BlockEntityTypeRef;
 use steel_registry::blocks::properties::{BlockStateProperties, Direction};
 use steel_registry::blocks::{BlockRef, block_state_ext::BlockStateExt as _};
 use steel_registry::fluid::FluidState;
 use steel_registry::vanilla_damage_types;
-use steel_registry::{sound_events, vanilla_blocks, vanilla_fluids, vanilla_game_events};
+use steel_registry::{
+    sound_events, vanilla_block_entity_types, vanilla_blocks, vanilla_fluids, vanilla_game_events,
+};
 use steel_utils::{BlockPos, BlockStateId, types::UpdateFlags};
 
 use crate::{
-    behavior::{BlockBehavior, BlockPlaceContext, block::schedule_placed_liquid_tick},
+    behavior::{
+        BlockBehavior, BlockEntityCreation, BlockPlaceContext, block::schedule_placed_liquid_tick,
+    },
+    block_entity::{BlockEntityTicker, entities::CampfireBlockEntity},
     entity::{Entity, InsideBlockEffectCollector, damage::DamageSource, projectile::Projectile},
     world::{
         ClipHitResult, LevelAccessor, ScheduledTickAccess, World, game_event::GameEventContext,
@@ -190,6 +196,27 @@ impl BlockBehavior for CampfireBlock {
         );
         schedule_placed_liquid_tick(level, pos, fluid_state);
         true
+    }
+
+    fn new_block_entity(
+        &self,
+        level: Weak<World>,
+        pos: BlockPos,
+        state: BlockStateId,
+    ) -> BlockEntityCreation {
+        BlockEntityCreation::Created(Arc::new(CampfireBlockEntity::new(level, pos, state)))
+    }
+
+    fn get_block_entity_ticker(
+        &self,
+        _world: &Arc<World>,
+        _state: BlockStateId,
+        block_entity_type: BlockEntityTypeRef,
+    ) -> Option<BlockEntityTicker> {
+        BlockEntityTicker::for_matching_entity_tick(
+            block_entity_type,
+            &vanilla_block_entity_types::CAMPFIRE,
+        )
     }
 }
 

--- a/steel-core/src/block_entity/entities/campfire.rs
+++ b/steel-core/src/block_entity/entities/campfire.rs
@@ -67,9 +67,6 @@ impl CampfireBlockEntity {
     ///
     /// Mirrors `CampfireBlockEntity.placeFood`. The caller supplies `recipe_time`
     /// (the recipe's cooking time) after a cookable lookup succeeds.
-    ///
-    /// # Returns
-    /// `true` if the item was placed, `false` if all slots are occupied.
     #[must_use]
     pub fn place_food(&self, mut stack: ItemStack, recipe_time: i32) -> bool {
         stack.set_count(1);

--- a/steel-core/src/block_entity/entities/campfire.rs
+++ b/steel-core/src/block_entity/entities/campfire.rs
@@ -117,9 +117,11 @@ impl CampfireBlockEntity {
         if changed {
             self.set_changed();
         }
+
         for result in finished {
             world.pop_resource(pos, result);
         }
+
         if has_finished {
             world.send_block_updated(pos);
             let context = GameEventContext::new(None, Some(state));

--- a/steel-core/src/block_entity/entities/campfire.rs
+++ b/steel-core/src/block_entity/entities/campfire.rs
@@ -1,0 +1,316 @@
+//! `CampfireBlockEntity` for campfire cooking.
+
+use std::array::from_fn;
+use std::sync::{Arc, Weak};
+
+use simdnbt::ToNbtTag;
+use simdnbt::borrow::{BaseNbtCompound as BorrowedNbtCompound, NbtCompound as NbtCompoundView};
+use simdnbt::owned::{NbtCompound, NbtList, NbtTag};
+use steel_registry::blocks::block_state_ext::BlockStateExt as _;
+use steel_registry::blocks::properties::BlockStateProperties;
+use steel_registry::item_stack::ItemStack;
+use steel_registry::vanilla_block_entity_types;
+use steel_registry::{REGISTRY, vanilla_game_events};
+use steel_utils::{BlockPos, BlockStateId, DowncastType, DowncastTypeKey, locks::SyncMutex};
+
+use crate::block_entity::{BlockEntity, BlockEntityBase};
+use crate::world::World;
+use crate::world::game_event::GameEventContext;
+
+/// Number of cooking slots on a campfire.
+pub const CAMPFIRE_SLOTS: usize = 4;
+
+/// Ticks a cooled cooking slot loses per campfire tick, mirroring vanilla `BURN_COOL_SPEED`.
+const BURN_COOL_SPEED: i32 = 2;
+
+/// Block entity for `campfire` blocks.
+pub struct CampfireBlockEntity {
+    base: BlockEntityBase,
+    data: SyncMutex<CampfireData>,
+}
+
+struct CampfireData {
+    /// The items cooking on the fire, one per slot (each held as a single item).
+    items: [ItemStack; CAMPFIRE_SLOTS],
+    /// Ticks each slot has cooked so far.
+    cooking_progress: [i32; CAMPFIRE_SLOTS],
+    /// Total cooking time in ticks for each slot's current recipe.
+    cooking_time: [i32; CAMPFIRE_SLOTS],
+}
+
+impl Default for CampfireData {
+    fn default() -> Self {
+        Self {
+            items: from_fn(|_| ItemStack::empty()),
+            cooking_progress: [0; CAMPFIRE_SLOTS],
+            cooking_time: [0; CAMPFIRE_SLOTS],
+        }
+    }
+}
+
+// SAFETY: This key is owned by Steel and uniquely identifies `CampfireBlockEntity`.
+unsafe impl DowncastType for CampfireBlockEntity {
+    const TYPE_KEY: DowncastTypeKey = DowncastTypeKey::new("steel:block_entity/campfire");
+}
+
+impl CampfireBlockEntity {
+    /// Creates a new `CampfireBlockEntity`.
+    #[must_use]
+    pub fn new(world: Weak<World>, pos: BlockPos, state: BlockStateId) -> Self {
+        Self {
+            base: BlockEntityBase::new(&vanilla_block_entity_types::CAMPFIRE, world, pos, state),
+            data: SyncMutex::new(CampfireData::default()),
+        }
+    }
+
+    /// Places a single `stack` into the first empty slot and starts cooking it.
+    ///
+    /// Mirrors `CampfireBlockEntity.placeFood`. The caller supplies `recipe_time`
+    /// (the recipe's cooking time) after a cookable lookup succeeds.
+    ///
+    /// # Returns
+    /// `true` if the item was placed, `false` if all slots are occupied.
+    #[must_use]
+    pub fn place_food(&self, mut stack: ItemStack, recipe_time: i32) -> bool {
+        stack.set_count(1);
+        let mut data = self.data.lock();
+        for slot in 0..CAMPFIRE_SLOTS {
+            if data.items[slot].is_empty() {
+                data.items[slot] = stack;
+                data.cooking_time[slot] = recipe_time;
+                data.cooking_progress[slot] = 0;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Advances cooking for each occupied slot while the campfire is lit.
+    ///
+    /// Mirrors vanilla `CampfireBlockEntity.cookTick`. When a slot reaches its
+    /// recipe's cooking time, the cooked result is dropped at the campfire.
+    fn tick_cooking(&self, world: &Arc<World>, state: BlockStateId) {
+        let pos = self.get_block_pos();
+        let mut changed = false;
+        let mut finished = Vec::new();
+        {
+            let mut data = self.data.lock();
+            for slot in 0..CAMPFIRE_SLOTS {
+                if data.items[slot].is_empty() {
+                    continue;
+                }
+                changed = true;
+                data.cooking_progress[slot] += 1;
+                if data.cooking_progress[slot] < data.cooking_time[slot] {
+                    continue;
+                }
+                let result = REGISTRY
+                    .recipes
+                    .find_campfire_recipe(&data.items[slot])
+                    .map_or_else(
+                        || data.items[slot].clone(),
+                        |recipe| recipe.assemble_result(data.items[slot].count(), false),
+                    );
+                data.items[slot] = ItemStack::empty();
+                finished.push(result);
+            }
+        }
+
+        let has_finished = !finished.is_empty();
+        if changed {
+            self.set_changed();
+        }
+        for result in finished {
+            world.pop_resource(pos, result);
+        }
+        if has_finished {
+            world.send_block_updated(pos);
+            let context = GameEventContext::new(None, Some(state));
+            world.game_event(&vanilla_game_events::BLOCK_CHANGE, pos, &context);
+        }
+    }
+
+    /// Cools down cooking progress while the campfire is unlit.
+    ///
+    /// Mirrors vanilla `CampfireBlockEntity.cooldownTick`.
+    fn tick_cooldown(&self) {
+        let mut changed = false;
+        {
+            let mut data = self.data.lock();
+            for slot in 0..CAMPFIRE_SLOTS {
+                if data.cooking_progress[slot] <= 0 {
+                    continue;
+                }
+                changed = true;
+                data.cooking_progress[slot] = data.cooking_progress[slot]
+                    .saturating_sub(BURN_COOL_SPEED)
+                    .min(data.cooking_time[slot]);
+            }
+        }
+        if changed {
+            self.set_changed();
+        }
+    }
+
+    /// Clears and returns all cooked/uncooked items, dropping them on removal.
+    #[must_use]
+    fn clear_items(&self) -> Vec<ItemStack> {
+        let mut data = self.data.lock();
+        let items: Vec<ItemStack> = data
+            .items
+            .iter()
+            .filter(|item| !item.is_empty())
+            .cloned()
+            .collect();
+        *data = CampfireData::default();
+        items
+    }
+}
+
+impl BlockEntity for CampfireBlockEntity {
+    fn base(&self) -> &BlockEntityBase {
+        &self.base
+    }
+
+    fn load_additional(&self, nbt: &BorrowedNbtCompound<'_>) {
+        let nbt_view: NbtCompoundView<'_, '_> = nbt.into();
+        let mut data = self.data.lock();
+        *data = CampfireData::default();
+
+        if let Some(items_list) = nbt_view.list("Items")
+            && let Some(compounds) = items_list.compounds()
+        {
+            for compound in compounds {
+                if let Some(slot) = compound.byte("Slot")
+                    && let Some(item) = ItemStack::from_borrowed_compound(&compound)
+                    && (slot as usize) < CAMPFIRE_SLOTS
+                {
+                    data.items[slot as usize] = item;
+                }
+            }
+        }
+
+        if let Some(times) = nbt_view.int_array("CookingTimes") {
+            for (i, value) in times.iter().enumerate().take(CAMPFIRE_SLOTS) {
+                data.cooking_progress[i] = *value;
+            }
+        }
+        if let Some(times) = nbt_view.int_array("CookingTotalTimes") {
+            for (i, value) in times.iter().enumerate().take(CAMPFIRE_SLOTS) {
+                data.cooking_time[i] = *value;
+            }
+        }
+    }
+
+    fn save_additional(&self, nbt: &mut NbtCompound) {
+        let data = self.data.lock();
+        let mut items: Vec<NbtCompound> = Vec::new();
+        for (slot, item) in data.items.iter().enumerate() {
+            if !item.is_empty()
+                && let NbtTag::Compound(mut item_nbt) = item.clone().to_nbt_tag()
+            {
+                item_nbt.insert("Slot", slot as i8);
+                items.push(item_nbt);
+            }
+        }
+        nbt.insert("Items", NbtList::Compound(items));
+        nbt.insert(
+            "CookingTimes",
+            NbtTag::IntArray(data.cooking_progress.to_vec()),
+        );
+        nbt.insert(
+            "CookingTotalTimes",
+            NbtTag::IntArray(data.cooking_time.to_vec()),
+        );
+    }
+
+    fn pre_remove_side_effects(&self, pos: BlockPos, _state: BlockStateId) {
+        let items = self.clear_items();
+        let Some(world) = self.get_level() else {
+            return;
+        };
+        for item in items {
+            world.pop_resource(pos, item);
+        }
+    }
+
+    fn get_update_tag(&self) -> Option<NbtCompound> {
+        Some(self.save_custom_only())
+    }
+
+    fn tick(&self, world: &Arc<World>) {
+        let state = self.get_block_state();
+        if state.get_value(&BlockStateProperties::LIT) {
+            self.tick_cooking(world, state);
+        } else {
+            self.tick_cooldown();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::test_support::init_test_registry;
+    use steel_registry::{vanilla_blocks, vanilla_items};
+    use steel_utils::{ChunkPos, types::UpdateFlags};
+
+    use super::*;
+    use crate::behavior::init_behaviors;
+    use crate::test_support::{fresh_test_world, insert_ready_full_chunk};
+
+    fn lit_campfire_entity(
+        world: &Arc<World>,
+        pos: BlockPos,
+    ) -> (BlockStateId, CampfireBlockEntity) {
+        let state = vanilla_blocks::CAMPFIRE
+            .default_state()
+            .set_value(&BlockStateProperties::LIT, true);
+        world.set_block(pos, state, UpdateFlags::UPDATE_ALL);
+        (
+            state,
+            CampfireBlockEntity::new(Arc::downgrade(world), pos, state),
+        )
+    }
+
+    #[test]
+    fn lit_campfire_cooks_item_and_clears_the_slot_when_done() {
+        init_test_registry();
+        init_behaviors();
+        let world = fresh_test_world("campfire_cook");
+        let pos = BlockPos::new(4, 64, 4);
+        insert_ready_full_chunk(&world, ChunkPos::from_block_pos(pos));
+        let (state, entity) = lit_campfire_entity(&world, pos);
+
+        assert!(entity.place_food(ItemStack::new(&vanilla_items::BEEF), 2));
+        assert!(!entity.data.lock().items[0].is_empty());
+
+        entity.tick(&world);
+        assert!(!entity.data.lock().items[0].is_empty());
+        assert_eq!(entity.data.lock().cooking_progress[0], 1);
+
+        entity.tick(&world);
+        assert!(entity.data.lock().items[0].is_empty());
+        assert!(state.get_value(&BlockStateProperties::LIT));
+    }
+
+    #[test]
+    fn unlit_campfire_cools_down_progress_without_dropping() {
+        init_test_registry();
+        init_behaviors();
+        let world = fresh_test_world("campfire_cooldown");
+        let pos = BlockPos::new(4, 64, 4);
+        insert_ready_full_chunk(&world, ChunkPos::from_block_pos(pos));
+        let state = vanilla_blocks::CAMPFIRE
+            .default_state()
+            .set_value(&BlockStateProperties::LIT, false);
+        world.set_block(pos, state, UpdateFlags::UPDATE_ALL);
+        let entity = CampfireBlockEntity::new(Arc::downgrade(&world), pos, state);
+
+        let _ = entity.place_food(ItemStack::new(&vanilla_items::BEEF), 10);
+        entity.data.lock().cooking_progress[0] = 6;
+
+        entity.tick(&world);
+        assert_eq!(entity.data.lock().cooking_progress[0], 4);
+        assert!(!entity.data.lock().items[0].is_empty());
+    }
+}

--- a/steel-core/src/block_entity/entities/mod.rs
+++ b/steel-core/src/block_entity/entities/mod.rs
@@ -2,6 +2,7 @@
 
 mod barrel;
 mod beehive;
+mod campfire;
 mod comparator;
 mod daylight_detector;
 mod end_gateway;
@@ -15,6 +16,7 @@ pub use barrel::{BARREL_SLOTS, BarrelBlockEntity};
 pub use beehive::{
     BEEHIVE_MAX_OCCUPANTS, BEEHIVE_MIN_OCCUPATION_TICKS_NECTARLESS, BeehiveBlockEntity,
 };
+pub use campfire::CampfireBlockEntity;
 pub use comparator::ComparatorBlockEntity;
 pub use daylight_detector::DaylightDetectorBlockEntity;
 pub use end_gateway::EndGatewayBlockEntity;

--- a/steel-registry/build/recipes.rs
+++ b/steel-registry/build/recipes.rs
@@ -263,7 +263,7 @@ fn parse_shapeless_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<Shap
 }
 
 /// Parses a furnace smelting recipe from JSON.
-fn parse_smelting_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<CookingRecipeData> {
+fn parse_cooking_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<CookingRecipeData> {
     let ingredient = recipe.ingredient.as_ref()?;
     let result = recipe.result.as_ref()?;
 
@@ -317,6 +317,7 @@ pub(crate) fn build() -> TokenStream {
     let mut shaped_recipes: Vec<ShapedRecipeData> = Vec::new();
     let mut shapeless_recipes: Vec<ShapelessRecipeData> = Vec::new();
     let mut smelting_recipes: Vec<CookingRecipeData> = Vec::new();
+    let mut campfire_recipes: Vec<CookingRecipeData> = Vec::new();
 
     // Read all recipe files
     fn read_recipes(
@@ -324,13 +325,14 @@ pub(crate) fn build() -> TokenStream {
         shaped: &mut Vec<ShapedRecipeData>,
         shapeless: &mut Vec<ShapelessRecipeData>,
         smelting: &mut Vec<CookingRecipeData>,
+        campfire: &mut Vec<CookingRecipeData>,
     ) {
         for entry in fs::read_dir(dir).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();
 
             if path.is_dir() {
-                read_recipes(&path, shaped, shapeless, smelting);
+                read_recipes(&path, shaped, shapeless, smelting, campfire);
             } else if path.extension().and_then(|s| s.to_str()) == Some("json") {
                 let recipe_name = path
                     .file_stem()
@@ -359,8 +361,13 @@ pub(crate) fn build() -> TokenStream {
                         }
                     }
                     "minecraft:smelting" => {
-                        if let Some(r) = parse_smelting_recipe(recipe_name, &recipe) {
+                        if let Some(r) = parse_cooking_recipe(recipe_name, &recipe) {
                             smelting.push(r);
+                        }
+                    }
+                    "minecraft:campfire_cooking" => {
+                        if let Some(r) = parse_cooking_recipe(recipe_name, &recipe) {
+                            campfire.push(r);
                         }
                     }
                     // Skip other recipe types for now (stonecutting, smithing, etc.)
@@ -375,6 +382,7 @@ pub(crate) fn build() -> TokenStream {
         &mut shaped_recipes,
         &mut shapeless_recipes,
         &mut smelting_recipes,
+        &mut campfire_recipes,
     );
 
     // Generate individual creator functions for each shaped recipe.
@@ -493,6 +501,35 @@ pub(crate) fn build() -> TokenStream {
         })
         .collect();
 
+    let campfire_creator_fns: Vec<TokenStream> = campfire_recipes
+        .iter()
+        .map(|r| {
+            let fn_ident = Ident::new(&format!("create_campfire_{}", r.ident), Span::call_site());
+            let name = &r.name;
+            let ingredient = generate_ingredient_tokens(&r.ingredient);
+            let result_item_ident = &r.result_item_ident;
+            let result_count = r.result_count;
+            let experience = r.experience;
+            let cooking_time = r.cooking_time;
+
+            quote! {
+                #[inline(never)]
+                fn #fn_ident() -> CookingRecipe {
+                    CookingRecipe {
+                        id: Identifier::vanilla_static(#name),
+                        ingredient: #ingredient,
+                        result: RecipeResult {
+                            item: &*vanilla_items::#result_item_ident,
+                            count: #result_count,
+                        },
+                        experience: #experience,
+                        cooking_time: #cooking_time,
+                    }
+                }
+            }
+        })
+        .collect();
+
     // Generate struct fields
     let shaped_fields: Vec<TokenStream> = shaped_recipes
         .iter()
@@ -511,6 +548,14 @@ pub(crate) fn build() -> TokenStream {
         .collect();
 
     let smelting_fields: Vec<TokenStream> = smelting_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            quote! { pub #ident: CookingRecipe, }
+        })
+        .collect();
+
+    let campfire_fields: Vec<TokenStream> = campfire_recipes
         .iter()
         .map(|r| {
             let ident = &r.ident;
@@ -546,6 +591,15 @@ pub(crate) fn build() -> TokenStream {
         })
         .collect();
 
+    let cooking_field_inits: Vec<TokenStream> = campfire_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            let fn_ident = Ident::new(&format!("create_campfire_{}", r.ident), Span::call_site());
+            quote! { #ident: #fn_ident(), }
+        })
+        .collect();
+
     // Generate registration calls
     let shaped_registers: Vec<TokenStream> = shaped_recipes
         .iter()
@@ -568,6 +622,14 @@ pub(crate) fn build() -> TokenStream {
         .map(|r| {
             let ident = &r.ident;
             quote! { registry.register_smelting(&RECIPES.smelting.#ident); }
+        })
+        .collect();
+
+    let campfire_registers: Vec<TokenStream> = campfire_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            quote! { registry.register_campfire(&RECIPES.campfire.#ident); }
         })
         .collect();
 
@@ -597,14 +659,19 @@ pub(crate) fn build() -> TokenStream {
             #(#shapeless_fields)*
         }
 
-        pub struct CookingRecipes {
+        pub struct SmeltingRecipes {
             #(#smelting_fields)*
+        }
+
+        pub struct CampfireRecipes {
+            #(#campfire_fields)*
         }
 
         pub struct Recipes {
             pub shaped: ShapedRecipes,
             pub shapeless: ShapelessRecipes,
-            pub smelting: CookingRecipes,
+            pub smelting: SmeltingRecipes,
+            pub campfire: CampfireRecipes,
         }
 
         // Individual recipe creator functions.
@@ -621,6 +688,7 @@ pub(crate) fn build() -> TokenStream {
         #(#shaped_creator_fns)*
         #(#shapeless_creator_fns)*
         #(#smelting_creator_fns)*
+        #(#campfire_creator_fns)*
 
         impl Recipes {
             fn init() -> Self {
@@ -631,8 +699,11 @@ pub(crate) fn build() -> TokenStream {
                     shapeless: ShapelessRecipes {
                         #(#shapeless_field_inits)*
                     },
-                    smelting: CookingRecipes {
+                    smelting: SmeltingRecipes {
                         #(#smelting_field_inits)*
+                    },
+                    campfire: CampfireRecipes {
+                        #(#cooking_field_inits)*
                     },
                 }
             }
@@ -645,6 +716,7 @@ pub(crate) fn build() -> TokenStream {
             #(#shaped_registers)*
             #(#shapeless_registers)*
             #(#smelting_registers)*
+            #(#campfire_registers)*
         }
     }
 }

--- a/steel-registry/build/recipes.rs
+++ b/steel-registry/build/recipes.rs
@@ -130,7 +130,7 @@ struct ShapelessRecipeData {
     result_count: i32,
 }
 
-struct SmeltingRecipeData {
+struct CookingRecipeData {
     name: String,
     ident: Ident,
     ingredient: ParsedIngredient,
@@ -263,7 +263,7 @@ fn parse_shapeless_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<Shap
 }
 
 /// Parses a furnace smelting recipe from JSON.
-fn parse_smelting_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<SmeltingRecipeData> {
+fn parse_smelting_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<CookingRecipeData> {
     let ingredient = recipe.ingredient.as_ref()?;
     let result = recipe.result.as_ref()?;
 
@@ -271,7 +271,7 @@ fn parse_smelting_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<Smelt
     let result_item_ident = Ident::new(&result_item_id.to_shouty_snake_case(), Span::call_site());
     let snake_name = recipe_name.to_snake_case();
 
-    Some(SmeltingRecipeData {
+    Some(CookingRecipeData {
         name: recipe_name.to_string(),
         ident: Ident::new(&snake_name, Span::call_site()),
         ingredient: parse_ingredient(ingredient),
@@ -316,14 +316,14 @@ pub(crate) fn build() -> TokenStream {
 
     let mut shaped_recipes: Vec<ShapedRecipeData> = Vec::new();
     let mut shapeless_recipes: Vec<ShapelessRecipeData> = Vec::new();
-    let mut smelting_recipes: Vec<SmeltingRecipeData> = Vec::new();
+    let mut smelting_recipes: Vec<CookingRecipeData> = Vec::new();
 
     // Read all recipe files
     fn read_recipes(
         dir: &Path,
         shaped: &mut Vec<ShapedRecipeData>,
         shapeless: &mut Vec<ShapelessRecipeData>,
-        smelting: &mut Vec<SmeltingRecipeData>,
+        smelting: &mut Vec<CookingRecipeData>,
     ) {
         for entry in fs::read_dir(dir).unwrap() {
             let entry = entry.unwrap();
@@ -477,8 +477,8 @@ pub(crate) fn build() -> TokenStream {
 
             quote! {
                 #[inline(never)]
-                fn #fn_ident() -> SmeltingRecipe {
-                    SmeltingRecipe {
+                fn #fn_ident() -> CookingRecipe {
+                    CookingRecipe {
                         id: Identifier::vanilla_static(#name),
                         ingredient: #ingredient,
                         result: RecipeResult {
@@ -514,7 +514,7 @@ pub(crate) fn build() -> TokenStream {
         .iter()
         .map(|r| {
             let ident = &r.ident;
-            quote! { pub #ident: SmeltingRecipe, }
+            quote! { pub #ident: CookingRecipe, }
         })
         .collect();
 
@@ -575,7 +575,7 @@ pub(crate) fn build() -> TokenStream {
         use crate::{
             recipe::{
                 CraftingCategory, Ingredient, RecipeRegistry, RecipeResult,
-                ShapedRecipe, ShapelessRecipe, SmeltingRecipe,
+                ShapedRecipe, ShapelessRecipe, CookingRecipe,
             },
             vanilla_items,
         };
@@ -597,14 +597,14 @@ pub(crate) fn build() -> TokenStream {
             #(#shapeless_fields)*
         }
 
-        pub struct SmeltingRecipes {
+        pub struct CookingRecipes {
             #(#smelting_fields)*
         }
 
         pub struct Recipes {
             pub shaped: ShapedRecipes,
             pub shapeless: ShapelessRecipes,
-            pub smelting: SmeltingRecipes,
+            pub smelting: CookingRecipes,
         }
 
         // Individual recipe creator functions.
@@ -631,7 +631,7 @@ pub(crate) fn build() -> TokenStream {
                     shapeless: ShapelessRecipes {
                         #(#shapeless_field_inits)*
                     },
-                    smelting: SmeltingRecipes {
+                    smelting: CookingRecipes {
                         #(#smelting_field_inits)*
                     },
                 }

--- a/steel-registry/build/recipes.rs
+++ b/steel-registry/build/recipes.rs
@@ -310,6 +310,77 @@ fn generate_ingredient_tokens(ingredient: &ParsedIngredient) -> TokenStream {
     }
 }
 
+/// Generates the creator functions, struct fields, field initializers and
+/// registration calls shared by every cooking recipe group (furnace smelting
+/// and campfire). They differ only in the member name used for identifiers.
+fn generate_cooking_group(
+    recipes: &[CookingRecipeData],
+    member: &str,
+) -> (
+    Vec<TokenStream>,
+    Vec<TokenStream>,
+    Vec<TokenStream>,
+    Vec<TokenStream>,
+) {
+    let creator_fns: Vec<TokenStream> = recipes
+        .iter()
+        .map(|r| {
+            let fn_ident = Ident::new(&format!("create_{member}_{}", r.ident), Span::call_site());
+            let name = &r.name;
+            let ingredient = generate_ingredient_tokens(&r.ingredient);
+            let result_item_ident = &r.result_item_ident;
+            let result_count = r.result_count;
+            let experience = r.experience;
+            let cooking_time = r.cooking_time;
+
+            quote! {
+                #[inline(never)]
+                fn #fn_ident() -> CookingRecipe {
+                    CookingRecipe {
+                        id: Identifier::vanilla_static(#name),
+                        ingredient: #ingredient,
+                        result: RecipeResult {
+                            item: &*vanilla_items::#result_item_ident,
+                            count: #result_count,
+                        },
+                        experience: #experience,
+                        cooking_time: #cooking_time,
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let fields: Vec<TokenStream> = recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            quote! { pub #ident: CookingRecipe, }
+        })
+        .collect();
+
+    let field_inits: Vec<TokenStream> = recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            let fn_ident = Ident::new(&format!("create_{member}_{}", r.ident), Span::call_site());
+            quote! { #ident: #fn_ident(), }
+        })
+        .collect();
+
+    let register_method = Ident::new(&format!("register_{member}"), Span::call_site());
+    let member_ident = Ident::new(member, Span::call_site());
+    let registers: Vec<TokenStream> = recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            quote! { registry.#register_method(&RECIPES.#member_ident.#ident); }
+        })
+        .collect();
+
+    (creator_fns, fields, field_inits, registers)
+}
+
 pub(crate) fn build() -> TokenStream {
     let recipe_dir = "../steel-utils/build_assets/builtin_datapacks/minecraft/recipe";
     println!("cargo:rerun-if-changed={recipe_dir}");
@@ -472,63 +543,12 @@ pub(crate) fn build() -> TokenStream {
         })
         .collect();
 
-    let smelting_creator_fns: Vec<TokenStream> = smelting_recipes
-        .iter()
-        .map(|r| {
-            let fn_ident = Ident::new(&format!("create_smelting_{}", r.ident), Span::call_site());
-            let name = &r.name;
-            let ingredient = generate_ingredient_tokens(&r.ingredient);
-            let result_item_ident = &r.result_item_ident;
-            let result_count = r.result_count;
-            let experience = r.experience;
-            let cooking_time = r.cooking_time;
-
-            quote! {
-                #[inline(never)]
-                fn #fn_ident() -> CookingRecipe {
-                    CookingRecipe {
-                        id: Identifier::vanilla_static(#name),
-                        ingredient: #ingredient,
-                        result: RecipeResult {
-                            item: &*vanilla_items::#result_item_ident,
-                            count: #result_count,
-                        },
-                        experience: #experience,
-                        cooking_time: #cooking_time,
-                    }
-                }
-            }
-        })
-        .collect();
-
-    let campfire_creator_fns: Vec<TokenStream> = campfire_recipes
-        .iter()
-        .map(|r| {
-            let fn_ident = Ident::new(&format!("create_campfire_{}", r.ident), Span::call_site());
-            let name = &r.name;
-            let ingredient = generate_ingredient_tokens(&r.ingredient);
-            let result_item_ident = &r.result_item_ident;
-            let result_count = r.result_count;
-            let experience = r.experience;
-            let cooking_time = r.cooking_time;
-
-            quote! {
-                #[inline(never)]
-                fn #fn_ident() -> CookingRecipe {
-                    CookingRecipe {
-                        id: Identifier::vanilla_static(#name),
-                        ingredient: #ingredient,
-                        result: RecipeResult {
-                            item: &*vanilla_items::#result_item_ident,
-                            count: #result_count,
-                        },
-                        experience: #experience,
-                        cooking_time: #cooking_time,
-                    }
-                }
-            }
-        })
-        .collect();
+    // Both cooking recipe groups (furnace smelting and campfire) share the same
+    // structure, so we use a helper
+    let (smelting_creator_fns, smelting_fields, smelting_field_inits, smelting_registers) =
+        generate_cooking_group(&smelting_recipes, "smelting");
+    let (campfire_creator_fns, campfire_fields, campfire_field_inits, campfire_registers) =
+        generate_cooking_group(&campfire_recipes, "campfire");
 
     // Generate struct fields
     let shaped_fields: Vec<TokenStream> = shaped_recipes
@@ -544,22 +564,6 @@ pub(crate) fn build() -> TokenStream {
         .map(|r| {
             let ident = &r.ident;
             quote! { pub #ident: ShapelessRecipe, }
-        })
-        .collect();
-
-    let smelting_fields: Vec<TokenStream> = smelting_recipes
-        .iter()
-        .map(|r| {
-            let ident = &r.ident;
-            quote! { pub #ident: CookingRecipe, }
-        })
-        .collect();
-
-    let campfire_fields: Vec<TokenStream> = campfire_recipes
-        .iter()
-        .map(|r| {
-            let ident = &r.ident;
-            quote! { pub #ident: CookingRecipe, }
         })
         .collect();
 
@@ -582,24 +586,6 @@ pub(crate) fn build() -> TokenStream {
         })
         .collect();
 
-    let smelting_field_inits: Vec<TokenStream> = smelting_recipes
-        .iter()
-        .map(|r| {
-            let ident = &r.ident;
-            let fn_ident = Ident::new(&format!("create_smelting_{}", r.ident), Span::call_site());
-            quote! { #ident: #fn_ident(), }
-        })
-        .collect();
-
-    let cooking_field_inits: Vec<TokenStream> = campfire_recipes
-        .iter()
-        .map(|r| {
-            let ident = &r.ident;
-            let fn_ident = Ident::new(&format!("create_campfire_{}", r.ident), Span::call_site());
-            quote! { #ident: #fn_ident(), }
-        })
-        .collect();
-
     // Generate registration calls
     let shaped_registers: Vec<TokenStream> = shaped_recipes
         .iter()
@@ -614,22 +600,6 @@ pub(crate) fn build() -> TokenStream {
         .map(|r| {
             let ident = &r.ident;
             quote! { registry.register_shapeless(&RECIPES.shapeless.#ident); }
-        })
-        .collect();
-
-    let smelting_registers: Vec<TokenStream> = smelting_recipes
-        .iter()
-        .map(|r| {
-            let ident = &r.ident;
-            quote! { registry.register_smelting(&RECIPES.smelting.#ident); }
-        })
-        .collect();
-
-    let campfire_registers: Vec<TokenStream> = campfire_recipes
-        .iter()
-        .map(|r| {
-            let ident = &r.ident;
-            quote! { registry.register_campfire(&RECIPES.campfire.#ident); }
         })
         .collect();
 
@@ -703,7 +673,7 @@ pub(crate) fn build() -> TokenStream {
                         #(#smelting_field_inits)*
                     },
                     campfire: CampfireRecipes {
-                        #(#cooking_field_inits)*
+                        #(#campfire_field_inits)*
                     },
                 }
             }

--- a/steel-registry/src/recipe/cooking.rs
+++ b/steel-registry/src/recipe/cooking.rs
@@ -6,9 +6,9 @@ use crate::item_stack::ItemStack;
 
 use super::{Ingredient, RecipeResult};
 
-/// A furnace smelting recipe.
+/// A recipe for cooking/smelting items.
 #[derive(Debug)]
-pub struct SmeltingRecipe {
+pub struct CookingRecipe {
     pub id: Identifier,
     pub ingredient: Ingredient,
     pub result: RecipeResult,
@@ -16,7 +16,7 @@ pub struct SmeltingRecipe {
     pub cooking_time: i32,
 }
 
-impl SmeltingRecipe {
+impl CookingRecipe {
     /// Returns whether this smelting recipe accepts `input`.
     #[must_use]
     pub fn matches(&self, input: &ItemStack) -> bool {
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn smelting_result_uses_input_count_when_requested() {
         init_test_registry();
-        let recipe = SmeltingRecipe {
+        let recipe = CookingRecipe {
             id: Identifier::vanilla_static("test"),
             ingredient: Ingredient::Item(&vanilla_items::RAW_IRON),
             result: RecipeResult {
@@ -69,7 +69,7 @@ mod tests {
     #[test]
     fn smelting_result_can_ignore_input_count() {
         init_test_registry();
-        let recipe = SmeltingRecipe {
+        let recipe = CookingRecipe {
             id: Identifier::vanilla_static("test"),
             ingredient: Ingredient::Item(&vanilla_items::RAW_IRON),
             result: RecipeResult {

--- a/steel-registry/src/recipe/mod.rs
+++ b/steel-registry/src/recipe/mod.rs
@@ -8,7 +8,7 @@ mod crafting;
 mod ingredient;
 mod registry;
 
-pub use cooking::SmeltingRecipe;
+pub use cooking::CookingRecipe;
 pub use crafting::{
     CraftingCategory, CraftingInput, CraftingRecipe, PositionedCraftingInput, RecipeResult,
     ShapedRecipe, ShapelessRecipe,

--- a/steel-registry/src/recipe/registry.rs
+++ b/steel-registry/src/recipe/registry.rs
@@ -3,7 +3,7 @@
 use rustc_hash::FxHashMap;
 use steel_utils::Identifier;
 
-use super::cooking::SmeltingRecipe;
+use super::cooking::CookingRecipe;
 use super::crafting::{CraftingInput, CraftingRecipe, ShapedRecipe, ShapelessRecipe};
 use crate::item_stack::ItemStack;
 
@@ -18,7 +18,7 @@ pub struct RecipeRegistry {
     /// All shapeless crafting recipes (for type-specific iteration).
     shapeless_recipes: Vec<&'static ShapelessRecipe>,
     /// All furnace smelting recipes.
-    smelting_recipes: Vec<&'static SmeltingRecipe>,
+    smelting_recipes: Vec<&'static CookingRecipe>,
     /// Whether registration is still allowed.
     allows_registering: bool,
 }
@@ -70,7 +70,7 @@ impl RecipeRegistry {
     }
 
     /// Registers a furnace smelting recipe.
-    pub fn register_smelting(&mut self, recipe: &'static SmeltingRecipe) {
+    pub fn register_smelting(&mut self, recipe: &'static CookingRecipe) {
         assert!(
             self.allows_registering,
             "Cannot register recipes after the registry has been frozen"
@@ -174,7 +174,7 @@ impl RecipeRegistry {
     }
 
     /// Iterates over all furnace smelting recipes.
-    pub fn iter_smelting(&self) -> impl Iterator<Item = &'static SmeltingRecipe> + '_ {
+    pub fn iter_smelting(&self) -> impl Iterator<Item = &'static CookingRecipe> + '_ {
         self.smelting_recipes.iter().copied()
     }
 }

--- a/steel-registry/src/recipe/registry.rs
+++ b/steel-registry/src/recipe/registry.rs
@@ -157,17 +157,19 @@ impl RecipeRegistry {
             .map(|recipe| recipe.assemble_result(input.count(), use_input_count))
     }
 
-    /// Finds the first campfire cooking result stack for `input`.
+    /// Finds the first campfire cooking recipe matching `input`.
     #[must_use]
-    pub fn find_campfire_result(
-        &self,
-        input: &ItemStack,
-        use_input_count: bool,
-    ) -> Option<ItemStack> {
+    pub fn find_campfire_recipe(&self, input: &ItemStack) -> Option<&'static CookingRecipe> {
         self.campfire_recipes
             .iter()
+            .copied()
             .find(|recipe| recipe.matches(input))
-            .map(|recipe| recipe.assemble_result(input.count(), use_input_count))
+    }
+
+    /// Returns whether any campfire recipe accepts `input` as an ingredient.
+    #[must_use]
+    pub fn is_campfire_input(&self, input: &ItemStack) -> bool {
+        self.find_campfire_recipe(input).is_some()
     }
 
     /// Returns the number of shaped recipes.

--- a/steel-registry/src/recipe/registry.rs
+++ b/steel-registry/src/recipe/registry.rs
@@ -19,6 +19,8 @@ pub struct RecipeRegistry {
     shapeless_recipes: Vec<&'static ShapelessRecipe>,
     /// All furnace smelting recipes.
     smelting_recipes: Vec<&'static CookingRecipe>,
+    /// All campfire cooking recipes.
+    campfire_recipes: Vec<&'static CookingRecipe>,
     /// Whether registration is still allowed.
     allows_registering: bool,
 }
@@ -39,6 +41,7 @@ impl RecipeRegistry {
             shaped_recipes: Vec::new(),
             shapeless_recipes: Vec::new(),
             smelting_recipes: Vec::new(),
+            campfire_recipes: Vec::new(),
             allows_registering: true,
         }
     }
@@ -76,6 +79,15 @@ impl RecipeRegistry {
             "Cannot register recipes after the registry has been frozen"
         );
         self.smelting_recipes.push(recipe);
+    }
+
+    /// Registers a campfire cooking recipe.
+    pub fn register_campfire(&mut self, recipe: &'static CookingRecipe) {
+        assert!(
+            self.allows_registering,
+            "Cannot register recipes after the registry has been frozen"
+        );
+        self.campfire_recipes.push(recipe);
     }
 
     /// Finds a matching crafting recipe for the given positioned input.
@@ -145,6 +157,19 @@ impl RecipeRegistry {
             .map(|recipe| recipe.assemble_result(input.count(), use_input_count))
     }
 
+    /// Finds the first campfire cooking result stack for `input`.
+    #[must_use]
+    pub fn find_campfire_result(
+        &self,
+        input: &ItemStack,
+        use_input_count: bool,
+    ) -> Option<ItemStack> {
+        self.campfire_recipes
+            .iter()
+            .find(|recipe| recipe.matches(input))
+            .map(|recipe| recipe.assemble_result(input.count(), use_input_count))
+    }
+
     /// Returns the number of shaped recipes.
     #[must_use]
     pub const fn shaped_count(&self) -> usize {
@@ -161,6 +186,11 @@ impl RecipeRegistry {
     #[must_use]
     pub const fn smelting_count(&self) -> usize {
         self.smelting_recipes.len()
+    }
+
+    #[must_use]
+    pub const fn campfire_count(&self) -> usize {
+        self.campfire_recipes.len()
     }
 
     /// Iterates over all shaped recipes.

--- a/steel-registry/src/recipe/registry.rs
+++ b/steel-registry/src/recipe/registry.rs
@@ -166,12 +166,6 @@ impl RecipeRegistry {
             .find(|recipe| recipe.matches(input))
     }
 
-    /// Returns whether any campfire recipe accepts `input` as an ingredient.
-    #[must_use]
-    pub fn is_campfire_input(&self, input: &ItemStack) -> bool {
-        self.find_campfire_recipe(input).is_some()
-    }
-
     /// Returns the number of shaped recipes.
     #[must_use]
     pub const fn shaped_count(&self) -> usize {


### PR DESCRIPTION
Adds campfire cooking

# Remarks

* Renamed `SmeltingRecipe` (and similar) to `CookingRecipe` because it is more generic (and it is now shared)
  * I will also note the smelting/campfire codegen helper. I added that because they share the same recipe shape and it's otherwise a bit repetitious, but I can revert if desired.
* The TODO mentioned ejecting items on douse but that's not actually vanilla behavior
* Also tested on soul campfires!

https://github.com/user-attachments/assets/0a17af53-d839-4c1b-b739-1da09298da2c

