### PR TITLE
allow flint to process chunks

### DIFF
--- a/steel-core/src/chunk/chunk_map/mod.rs
+++ b/steel-core/src/chunk/chunk_map/mod.rs
@@ -468,16 +468,6 @@ impl ChunkMap {
         Some(holder)
     }
 
-    /// Drives one scheduling step (ticket propagation, holder creation, and
-    /// generation-epoch commit).
-    ///
-    /// Exposed for Flint's synchronous chunk-loading test harness, which has
-    /// no server run loop to drive scheduling on its behalf.
-    #[cfg(feature = "flint")]
-    pub fn drive_scheduling_for_flint(self: &Arc<Self>) {
-        let _ = self.advance_scheduling();
-    }
-
     /// Inserts a non-simulated holder into an empty gameplay view for worldgen benchmarks.
     ///
     /// Runtime lifecycle code must use ticket-driven insertion. Benchmark holders
@@ -970,7 +960,7 @@ impl ChunkMap {
     /// committed chunk state remains authoritative until that epoch is ready at
     /// a later boundary.
     #[instrument(level = "trace", skip(self), name = "advance_chunk_scheduling")]
-    pub(crate) fn advance_scheduling(self: &Arc<Self>) -> ChunkMapSchedulingTimings {
+    pub fn advance_scheduling(self: &Arc<Self>) -> ChunkMapSchedulingTimings {
         match self.scheduling.take_boundary_step() {
             ChunkSchedulingBoundaryStep::Running => ChunkMapSchedulingTimings::default(),
             ChunkSchedulingBoundaryStep::Start {

--- a/steel-core/src/chunk/chunk_map/mod.rs
+++ b/steel-core/src/chunk/chunk_map/mod.rs
@@ -468,6 +468,16 @@ impl ChunkMap {
         Some(holder)
     }
 
+    /// Drives one scheduling step (ticket propagation, holder creation, and
+    /// generation-epoch commit).
+    ///
+    /// Exposed for Flint's synchronous chunk-loading test harness, which has
+    /// no server run loop to drive scheduling on its behalf.
+    #[cfg(feature = "flint")]
+    pub fn drive_scheduling_for_flint(self: &Arc<Self>) {
+        let _ = self.advance_scheduling();
+    }
+
     /// Inserts a non-simulated holder into an empty gameplay view for worldgen benchmarks.
     ///
     /// Runtime lifecycle code must use ticket-driven insertion. Benchmark holders

--- a/steel-core/src/chunk/chunk_map/mod.rs
+++ b/steel-core/src/chunk/chunk_map/mod.rs
@@ -32,7 +32,7 @@ use crate::block_entity::{BlockEntityLifecycleExt as _, ClearedBlockEntities, Sh
 use crate::chunk::chunk_holder::{
     ChunkHolder, ChunkSaveDependency, PostProcessGenerationError, TickingReadiness,
 };
-pub(crate) use crate::chunk::chunk_scheduler::ChunkMapSchedulingTimings;
+pub use crate::chunk::chunk_scheduler::ChunkMapSchedulingTimings;
 use crate::chunk::chunk_scheduler::{
     ChunkMapPreparationTimings, ChunkSchedulingBoundaryStep, ChunkSchedulingCoordinator,
     ChunkTicketOperation, ChunkTicketRevision, PreparedChunkSchedulingEpoch,
@@ -952,13 +952,20 @@ impl ChunkMap {
         timings
     }
 
-    /// Ticks block entities in tickable full chunks.
     /// Commits a ready scheduling epoch and forks the next background epoch.
     ///
     /// This must run at a gameplay lifecycle boundary or during startup before
     /// gameplay begins. It never waits for a running epoch; the previously
     /// committed chunk state remains authoritative until that epoch is ready at
     /// a later boundary.
+    ///
+    /// # Calling constraint
+    ///
+    /// Must only be called from the thread driving this world, between game
+    /// ticks (or during startup, before gameplay begins) — never concurrently
+    /// with [`Self::tick_game`]. Calling it mid-tick or from another thread
+    /// can commit a scheduling epoch while `tick_game` is iterating the chunk
+    /// snapshot from before that commit.
     #[instrument(level = "trace", skip(self), name = "advance_chunk_scheduling")]
     pub fn advance_scheduling(self: &Arc<Self>) -> ChunkMapSchedulingTimings {
         match self.scheduling.take_boundary_step() {

--- a/steel-core/src/chunk/chunk_scheduler.rs
+++ b/steel-core/src/chunk/chunk_scheduler.rs
@@ -13,7 +13,7 @@ use crate::chunk::gameplay_chunk_lookup_cache::GameplayChunkLookupCacheStats;
 
 /// Timing information for one background epoch and its boundary commit.
 #[derive(Debug, Default)]
-pub(crate) struct ChunkMapSchedulingTimings {
+pub struct ChunkMapSchedulingTimings {
     /// Time spent applying queued ticket operations and propagating their levels.
     pub(crate) ticket_updates: Duration,
     /// Time spent finalizing block-entity unloads before the boundary commit.

--- a/steel-core/src/chunk/chunk_scheduler.rs
+++ b/steel-core/src/chunk/chunk_scheduler.rs
@@ -15,37 +15,37 @@ use crate::chunk::gameplay_chunk_lookup_cache::GameplayChunkLookupCacheStats;
 #[derive(Debug, Default)]
 pub struct ChunkMapSchedulingTimings {
     /// Time spent applying queued ticket operations and propagating their levels.
-    pub(crate) ticket_updates: Duration,
+    pub ticket_updates: Duration,
     /// Time spent finalizing block-entity unloads before the boundary commit.
-    pub(crate) block_entity_unloads: Duration,
+    pub block_entity_unloads: Duration,
     /// Time spent revoking ticking readiness before holder lifecycle changes.
-    pub(crate) readiness_demotions: Duration,
+    pub readiness_demotions: Duration,
     /// Time spent committing holder lifecycle changes at the game-tick boundary.
-    pub(crate) lifecycle_commit: Duration,
+    pub lifecycle_commit: Duration,
     /// Time spent reconciling Full neighborhoods and applying ticking readiness.
-    pub(crate) readiness_reconcile: Duration,
+    pub readiness_reconcile: Duration,
     /// Subset of `readiness_reconcile` spent running generation post-processing.
-    pub(crate) post_process_generation: Duration,
+    pub post_process_generation: Duration,
     /// Number of chunks whose generation post-processing completed.
-    pub(crate) post_process_chunk_count: usize,
+    pub post_process_chunk_count: usize,
     /// Number of packed generation post-processing positions attempted.
-    pub(crate) post_process_position_count: usize,
+    pub post_process_position_count: usize,
     /// Number of readiness candidates considered during reconciliation.
-    pub(crate) readiness_candidate_count: usize,
+    pub readiness_candidate_count: usize,
     /// Time spent rebuilding the published ticking-chunk snapshot.
-    pub(crate) ticking_snapshot_rebuild: Duration,
+    pub ticking_snapshot_rebuild: Duration,
     /// Number of block-ticking chunks in a snapshot rebuilt during this epoch.
-    pub(crate) rebuilt_ticking_chunk_count: usize,
+    pub rebuilt_ticking_chunk_count: usize,
     /// Scoped holder-cache activity during readiness reconciliation.
-    pub(crate) lookup_cache: GameplayChunkLookupCacheStats,
+    pub lookup_cache: GameplayChunkLookupCacheStats,
     /// Time spent creating or updating chunk-generation tasks.
-    pub(crate) schedule_generation: Duration,
+    pub schedule_generation: Duration,
     /// Number of holders scheduled for generation.
-    pub(crate) scheduled_count: usize,
+    pub scheduled_count: usize,
     /// Time spent refilling generation worker slots.
-    pub(crate) run_generation: Duration,
+    pub run_generation: Duration,
     /// Time spent processing physical chunk unloads.
-    pub(crate) process_unloads: Duration,
+    pub process_unloads: Duration,
 }
 
 /// Timing information produced by the background half of a scheduling epoch.


### PR DESCRIPTION
For flint, we need to load the chunks synchronous the previous version is not anymore possible.
First I created a function which exposes via a feature the adance_scheduling (see comment).
But now the method was changed from `pub (crate)` to `pub`.