### PR TITLE
feat: implement vanilla chest block behavior

### DIFF
--- a/steel-core/src/behavior/blocks/container/chest_block.rs
+++ b/steel-core/src/behavior/blocks/container/chest_block.rs
@@ -1,0 +1,651 @@
+//! Chest block behavior (`ChestBlock`).
+
+use std::sync::{Arc, Weak};
+
+use glam::DVec3;
+use steel_macros::block_behavior;
+use steel_protocol::packets::game::SoundSource;
+use steel_registry::blocks::BlockRef;
+use steel_registry::blocks::block_state_ext::BlockStateExt;
+use steel_registry::blocks::properties::{
+    BlockStateProperties, BoolProperty, ChestType, Direction, EnumProperty,
+};
+use steel_registry::fluid::FluidState;
+use steel_registry::sound_event::SoundEventRef;
+use steel_registry::vanilla_block_entity_types;
+use steel_registry::vanilla_custom_stats;
+use steel_utils::{BlockPos, BlockStateId, Downcast as _, translations};
+
+use crate::behavior::block::PickupResult;
+use crate::behavior::block::{
+    pickup_waterlogged_block, place_simple_waterlogged_liquid, schedule_water_tick_if_waterlogged,
+};
+use crate::behavior::{
+    BLOCK_BEHAVIORS, BlockBehavior, BlockEntityCreation, BlockHitResult, BlockPlaceContext,
+    InteractionResult, InventoryAccess,
+};
+use crate::block_entity::BLOCK_ENTITIES;
+use crate::block_entity::SharedBlockEntity;
+use crate::block_entity::entities::ChestBlockEntity;
+use crate::entity::ai::path::PathComputationType;
+use crate::inventory::lock::{ContainerLockGuard, ContainerRef};
+use crate::inventory::menu::kinds::{chest as chest_menu, double_chest};
+use crate::player::Player;
+use crate::world::{LevelAccessor, LevelReader, ScheduledTickAccess, World};
+use text_components::TextComponent;
+
+/// Behavior for vanilla chest blocks.
+#[block_behavior]
+pub struct ChestBlock {
+    block: BlockRef,
+    #[json_arg(sound_events, json = "open_sound")]
+    open_sound: SoundEventRef,
+    #[json_arg(sound_events, json = "close_sound")]
+    close_sound: SoundEventRef,
+}
+
+const HORIZONTAL_FACING: &EnumProperty<Direction> = &BlockStateProperties::HORIZONTAL_FACING;
+const CHEST_TYPE: &EnumProperty<ChestType> = &BlockStateProperties::CHEST_TYPE;
+const WATERLOGGED: &BoolProperty = &BlockStateProperties::WATERLOGGED;
+
+const OPEN_SOUND_VOLUME: f32 = 0.5;
+const OPEN_SOUND_PITCH_BASE: f32 = 0.9;
+const OPEN_SOUND_PITCH_VARIANCE: f32 = 0.1;
+
+enum CombinedChests {
+    None,
+    Single(SharedBlockEntity),
+    Double {
+        first: SharedBlockEntity,
+        second: SharedBlockEntity,
+    },
+}
+
+impl ChestBlock {
+    /// Creates a new chest block behavior.
+    #[must_use]
+    pub const fn new(
+        block: BlockRef,
+        open_sound: SoundEventRef,
+        close_sound: SoundEventRef,
+    ) -> Self {
+        Self {
+            block,
+            open_sound,
+            close_sound,
+        }
+    }
+
+    /// Vanilla `ChestBlock.getConnectedDirection`.
+    #[must_use]
+    pub fn get_connected_direction(state: BlockStateId) -> Direction {
+        let facing = state.get_value(HORIZONTAL_FACING);
+        if state.get_value(CHEST_TYPE) == ChestType::Left {
+            facing.rotate_y_clockwise()
+        } else {
+            facing.rotate_y_counter_clockwise()
+        }
+    }
+
+    fn chest_can_connect_to(&self, state: BlockStateId) -> bool {
+        state.get_block() == self.block
+    }
+
+    fn candidate_partner_facing(
+        &self,
+        world: &dyn LevelReader,
+        pos: BlockPos,
+        neighbour_direction: Direction,
+    ) -> Option<Direction> {
+        let state = world.get_block_state(pos.relative(neighbour_direction));
+        (self.chest_can_connect_to(state) && state.get_value(CHEST_TYPE) == ChestType::Single)
+            .then(|| state.get_value(HORIZONTAL_FACING))
+    }
+
+    fn chest_type_for_placement(
+        &self,
+        world: &dyn LevelReader,
+        pos: BlockPos,
+        facing: Direction,
+    ) -> ChestType {
+        if Some(facing) == self.candidate_partner_facing(world, pos, facing.rotate_y_clockwise()) {
+            ChestType::Left
+        } else if Some(facing)
+            == self.candidate_partner_facing(world, pos, facing.rotate_y_counter_clockwise())
+        {
+            ChestType::Right
+        } else {
+            ChestType::Single
+        }
+    }
+
+    fn is_chest_blocked_at(world: &dyn LevelReader, pos: BlockPos) -> bool {
+        // Vanilla also rejects a sitting cat on top of the chest. Steel has no Cat
+        // entity yet, so only the redstone-conductor occupancy check is live.
+        let above = pos.above();
+        let above_state = world.get_block_state(above);
+        BLOCK_BEHAVIORS
+            .get_behavior(above_state.get_block())
+            .is_redstone_conductor(above_state, world, above)
+    }
+
+    fn combine(
+        &self,
+        state: BlockStateId,
+        world: &dyn LevelReader,
+        pos: BlockPos,
+        ignore_being_blocked: bool,
+    ) -> CombinedChests {
+        let blocked =
+            |check_pos| !ignore_being_blocked && Self::is_chest_blocked_at(world, check_pos);
+        let Some(block_entity) = chest_entity_at(world, pos) else {
+            return CombinedChests::None;
+        };
+        if blocked(pos) {
+            return CombinedChests::None;
+        }
+
+        let chest_type = state.get_value(CHEST_TYPE);
+        if chest_type == ChestType::Single {
+            return CombinedChests::Single(block_entity);
+        }
+
+        let neighbor_pos = pos.relative(Self::get_connected_direction(state));
+        let neighbor_state = world.get_block_state(neighbor_pos);
+        if !self.chest_can_connect_to(neighbor_state) {
+            return CombinedChests::Single(block_entity);
+        }
+
+        let neighbor_type = neighbor_state.get_value(CHEST_TYPE);
+        if neighbor_type == ChestType::Single
+            || neighbor_type == chest_type
+            || neighbor_state.get_value(HORIZONTAL_FACING) != state.get_value(HORIZONTAL_FACING)
+        {
+            return CombinedChests::Single(block_entity);
+        }
+        if blocked(neighbor_pos) {
+            return CombinedChests::None;
+        }
+
+        let Some(neighbor) = chest_entity_at(world, neighbor_pos) else {
+            return CombinedChests::Single(block_entity);
+        };
+
+        let is_first = chest_type == ChestType::Right;
+        if is_first {
+            CombinedChests::Double {
+                first: block_entity,
+                second: neighbor,
+            }
+        } else {
+            CombinedChests::Double {
+                first: neighbor,
+                second: block_entity,
+            }
+        }
+    }
+
+    fn play_opened_sound(&self, world: &World, pos: BlockPos, state: BlockStateId) {
+        if state.get_value(CHEST_TYPE) == ChestType::Left {
+            return;
+        }
+
+        let mut sound_pos = DVec3::new(
+            f64::from(pos.x()) + 0.5,
+            f64::from(pos.y()) + 0.5,
+            f64::from(pos.z()) + 0.5,
+        );
+        if state.get_value(CHEST_TYPE) == ChestType::Right {
+            let connected = Self::get_connected_direction(state);
+            let (dx, _, dz) = connected.offset();
+            sound_pos.x += f64::from(dx) * 0.5;
+            sound_pos.z += f64::from(dz) * 0.5;
+        }
+
+        let pitch = rand::random::<f32>() * OPEN_SOUND_PITCH_VARIANCE + OPEN_SOUND_PITCH_BASE;
+        world.play_sound_at(
+            self.open_sound,
+            SoundSource::Blocks,
+            sound_pos,
+            OPEN_SOUND_VOLUME,
+            pitch,
+            None,
+        );
+        let _ = self.close_sound;
+    }
+}
+
+fn chest_entity_at(world: &dyn LevelReader, pos: BlockPos) -> Option<SharedBlockEntity> {
+    let entity = world.get_block_entity(pos)?;
+    entity.downcast_ref::<ChestBlockEntity>()?;
+    Some(entity)
+}
+
+fn as_chest(entity: &SharedBlockEntity) -> Option<&ChestBlockEntity> {
+    entity.downcast_ref::<ChestBlockEntity>()
+}
+
+impl BlockBehavior for ChestBlock {
+    fn get_state_for_placement(&self, context: &BlockPlaceContext<'_>) -> Option<BlockStateId> {
+        let mut chest_type = ChestType::Single;
+        let mut facing = context.horizontal_direction().opposite();
+        let secondary_use = context.is_secondary_use_active();
+        let clicked_face = context.clicked_face();
+
+        if clicked_face.get_axis().is_horizontal() && secondary_use {
+            let neighbour_facing = self.candidate_partner_facing(
+                context.world,
+                context.place_pos(),
+                clicked_face.opposite(),
+            );
+            if let Some(neighbour_facing) = neighbour_facing
+                && neighbour_facing.get_axis() != clicked_face.get_axis()
+            {
+                facing = neighbour_facing;
+                chest_type = if facing.rotate_y_counter_clockwise() == clicked_face.opposite() {
+                    ChestType::Right
+                } else {
+                    ChestType::Left
+                };
+            }
+        }
+
+        if chest_type == ChestType::Single && !secondary_use {
+            chest_type = self.chest_type_for_placement(context.world, context.place_pos(), facing);
+        }
+
+        Some(
+            self.block
+                .default_state()
+                .set_value(HORIZONTAL_FACING, facing)
+                .set_value(CHEST_TYPE, chest_type)
+                .set_value(WATERLOGGED, context.is_water_source()),
+        )
+    }
+
+    fn update_shape(
+        &self,
+        state: BlockStateId,
+        world: &dyn ScheduledTickAccess,
+        pos: BlockPos,
+        direction: Direction,
+        _neighbor_pos: BlockPos,
+        neighbor_state: BlockStateId,
+    ) -> BlockStateId {
+        schedule_water_tick_if_waterlogged(state, world, pos);
+
+        if self.chest_can_connect_to(neighbor_state) && direction.get_axis().is_horizontal() {
+            let neighbour_type = neighbor_state.get_value(CHEST_TYPE);
+            if state.get_value(CHEST_TYPE) == ChestType::Single
+                && neighbour_type != ChestType::Single
+                && state.get_value(HORIZONTAL_FACING) == neighbor_state.get_value(HORIZONTAL_FACING)
+                && Self::get_connected_direction(neighbor_state) == direction.opposite()
+            {
+                return state.set_value(CHEST_TYPE, neighbour_type.opposite());
+            }
+        } else if Self::get_connected_direction(state) == direction {
+            return state.set_value(CHEST_TYPE, ChestType::Single);
+        }
+
+        state
+    }
+
+    fn use_without_item(
+        &self,
+        state: BlockStateId,
+        world: &Arc<World>,
+        pos: BlockPos,
+        player: &Player,
+        _hit_result: &BlockHitResult,
+        _inv: &mut InventoryAccess,
+    ) -> InteractionResult {
+        match self.combine(state, world.as_ref(), pos, false) {
+            CombinedChests::None => {}
+            CombinedChests::Single(entity) => {
+                let Some(chest) = as_chest(&entity) else {
+                    return InteractionResult::Success;
+                };
+                if !chest.can_open(player) {
+                    return InteractionResult::Success;
+                }
+                chest.unpack_loot_table(Some(player));
+                let Some(container_ref) = entity.container_ref() else {
+                    return InteractionResult::Success;
+                };
+                self.play_opened_sound(world, pos, state);
+                let inventory = player.inventory.clone();
+                player.open_menu(
+                    TextComponent::translated(translations::CONTAINER_CHEST.msg()),
+                    move |context| chest_menu(inventory, context.container_id, container_ref, 3),
+                );
+                player.award_custom_stat(&vanilla_custom_stats::OPEN_CHEST);
+                // TODO: Anger nearby piglins (PiglinAi.angerNearbyPiglins).
+                // TODO: ContainerOpenersCounter for close sounds, lid block events, and recheckOpen.
+            }
+            CombinedChests::Double { first, second } => {
+                let Some(first_chest) = as_chest(&first) else {
+                    return InteractionResult::Success;
+                };
+                let Some(second_chest) = as_chest(&second) else {
+                    return InteractionResult::Success;
+                };
+                if !first_chest.can_open(player) || !second_chest.can_open(player) {
+                    return InteractionResult::Success;
+                }
+                first_chest.unpack_loot_table(Some(player));
+                second_chest.unpack_loot_table(Some(player));
+                let Some(first_ref) = first.container_ref() else {
+                    return InteractionResult::Success;
+                };
+                let Some(second_ref) = second.container_ref() else {
+                    return InteractionResult::Success;
+                };
+                self.play_opened_sound(world, first.get_block_pos(), first.get_block_state());
+                let inventory = player.inventory.clone();
+                player.open_menu(
+                    TextComponent::translated(translations::CONTAINER_CHEST_DOUBLE.msg()),
+                    move |context| {
+                        double_chest(inventory, context.container_id, first_ref, second_ref)
+                    },
+                );
+                player.award_custom_stat(&vanilla_custom_stats::OPEN_CHEST);
+                // TODO: Anger nearby piglins (PiglinAi.angerNearbyPiglins).
+                // TODO: ContainerOpenersCounter for close sounds, lid block events, and recheckOpen.
+            }
+        }
+
+        InteractionResult::Success
+    }
+
+    fn new_block_entity(
+        &self,
+        level: Weak<World>,
+        pos: BlockPos,
+        state: BlockStateId,
+    ) -> BlockEntityCreation {
+        BlockEntityCreation::from_registered_factory(BLOCK_ENTITIES.create(
+            &vanilla_block_entity_types::CHEST,
+            level,
+            pos,
+            state,
+        ))
+    }
+
+    fn has_analog_output_signal(&self, _state: BlockStateId) -> bool {
+        true
+    }
+
+    fn get_analog_output_signal(
+        &self,
+        state: BlockStateId,
+        world: &dyn LevelReader,
+        pos: BlockPos,
+        _direction: Direction,
+    ) -> i32 {
+        match self.combine(state, world, pos, false) {
+            CombinedChests::None => 0,
+            CombinedChests::Single(entity) => {
+                if let Some(chest) = as_chest(&entity) {
+                    chest.unpack_loot_table(None);
+                }
+                analog_signal(&[&entity])
+            }
+            CombinedChests::Double { first, second } => {
+                if let Some(chest) = as_chest(&first) {
+                    chest.unpack_loot_table(None);
+                }
+                if let Some(chest) = as_chest(&second) {
+                    chest.unpack_loot_table(None);
+                }
+                analog_signal(&[&first, &second])
+            }
+        }
+    }
+
+    fn affect_neighbors_after_removal(
+        &self,
+        state: BlockStateId,
+        world: &Arc<World>,
+        pos: BlockPos,
+        _moved_by_piston: bool,
+    ) {
+        world.update_neighbor_for_output_signal(pos, state.get_block());
+    }
+
+    fn is_pathfindable(
+        &self,
+        _state: BlockStateId,
+        _computation_type: PathComputationType,
+    ) -> bool {
+        false
+    }
+
+    fn pickup_block(
+        &self,
+        world: &Arc<World>,
+        pos: BlockPos,
+        state: BlockStateId,
+        player: Option<&Player>,
+    ) -> Option<PickupResult> {
+        pickup_waterlogged_block(self, world, pos, state, player)
+    }
+
+    fn place_liquid(
+        &self,
+        level: &dyn LevelAccessor,
+        pos: BlockPos,
+        state: BlockStateId,
+        fluid_state: FluidState,
+    ) -> bool {
+        place_simple_waterlogged_liquid(level, pos, state, fluid_state)
+    }
+}
+
+fn analog_signal(entities: &[&SharedBlockEntity]) -> i32 {
+    let refs: Vec<ContainerRef> = entities
+        .iter()
+        .filter_map(|entity| entity.container_ref())
+        .collect();
+    if refs.is_empty() {
+        return 0;
+    }
+    let guard = ContainerLockGuard::lock_all(&refs);
+    analog_signal_from_locked(&guard, &refs)
+}
+
+fn analog_signal_from_locked(guard: &ContainerLockGuard, refs: &[ContainerRef]) -> i32 {
+    let mut size = 0usize;
+    let mut total_percent = 0.0f32;
+    for container_ref in refs {
+        let Some(container) = guard.get(container_ref.container_id()) else {
+            continue;
+        };
+        size += container.get_container_size();
+        for slot in 0..container.get_container_size() {
+            let item = container.get_item(slot);
+            if !item.is_empty() {
+                let max_stack = container.get_max_stack_size_for_item(item);
+                total_percent += item.count() as f32 / max_stack as f32;
+            }
+        }
+    }
+    if size == 0 {
+        return 0;
+    }
+    total_percent /= size as f32;
+    (total_percent * 14.0).floor() as i32 + i32::from(total_percent > 0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use glam::DVec3;
+    use steel_registry::init_vanilla_registry;
+    use steel_registry::item_stack::ItemStack;
+    use steel_registry::sound_events;
+    use steel_registry::vanilla_blocks;
+    use steel_registry::vanilla_items;
+    use steel_utils::types::{InteractionHand, UpdateFlags};
+
+    use super::*;
+    use crate::behavior::{PlacementOrientation, PlacementSource, init_behaviors};
+    use crate::bootstrap::init_globals_once;
+    use crate::entity::ai::path::PathComputationType;
+    use crate::test_support::{fresh_test_world, insert_ready_full_chunk, test_world};
+    use steel_utils::ChunkPos;
+
+    fn chest_behavior() -> ChestBlock {
+        ChestBlock::new(
+            &vanilla_blocks::CHEST,
+            &sound_events::BLOCK_CHEST_OPEN,
+            &sound_events::BLOCK_CHEST_CLOSE,
+        )
+    }
+
+    fn place_context<'a>(
+        world: &'a Arc<World>,
+        pos: BlockPos,
+        facing: Direction,
+        secondary_use: bool,
+        stack: &'a mut ItemStack,
+    ) -> BlockPlaceContext<'a> {
+        let (x, y, z) = pos.get_center();
+        let hit_result = BlockHitResult {
+            location: DVec3::new(x, y - 0.5, z),
+            direction: Direction::Up,
+            block_pos: pos.below(),
+            miss: false,
+            inside: false,
+            world_border_hit: false,
+        };
+        let source = PlacementSource::direct(
+            None,
+            InteractionHand::MainHand,
+            stack,
+            PlacementOrientation::Directional { direction: facing },
+            secondary_use,
+        );
+        BlockPlaceContext::new(world, source, &hit_result)
+    }
+
+    #[test]
+    fn connected_direction_matches_vanilla_left_and_right() {
+        init_vanilla_registry();
+        let north_left = vanilla_blocks::CHEST
+            .default_state()
+            .set_value(HORIZONTAL_FACING, Direction::North)
+            .set_value(CHEST_TYPE, ChestType::Left);
+        let north_right = vanilla_blocks::CHEST
+            .default_state()
+            .set_value(HORIZONTAL_FACING, Direction::North)
+            .set_value(CHEST_TYPE, ChestType::Right);
+
+        assert_eq!(
+            ChestBlock::get_connected_direction(north_left),
+            Direction::East
+        );
+        assert_eq!(
+            ChestBlock::get_connected_direction(north_right),
+            Direction::West
+        );
+    }
+
+    #[test]
+    fn placement_faces_the_player_and_stays_single_without_a_partner() {
+        init_globals_once();
+        let world = fresh_test_world("chest_single_placement");
+        insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+        let behavior = chest_behavior();
+        let pos = BlockPos::new(1, 64, 1);
+        assert!(world.set_block(
+            pos.below(),
+            vanilla_blocks::STONE.default_state(),
+            UpdateFlags::UPDATE_ALL,
+        ));
+        let mut stack = ItemStack::new(&vanilla_items::CHEST);
+        let context = place_context(&world, pos, Direction::South, false, &mut stack);
+        let placed = behavior
+            .get_state_for_placement(&context)
+            .expect("chest always has a placement state");
+
+        assert_eq!(placed.get_value(HORIZONTAL_FACING), Direction::North);
+        assert_eq!(placed.get_value(CHEST_TYPE), ChestType::Single);
+        assert!(!placed.get_value(WATERLOGGED));
+    }
+
+    #[test]
+    fn placement_connects_to_an_adjacent_single_chest() {
+        init_globals_once();
+        let world = fresh_test_world("chest_double_placement");
+        insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+        let behavior = chest_behavior();
+        let partner = BlockPos::new(1, 64, 1);
+        let pos = BlockPos::new(2, 64, 1);
+        assert!(world.set_block(
+            pos.below(),
+            vanilla_blocks::STONE.default_state(),
+            UpdateFlags::UPDATE_ALL,
+        ));
+        assert!(
+            world.set_block(
+                partner,
+                vanilla_blocks::CHEST
+                    .default_state()
+                    .set_value(HORIZONTAL_FACING, Direction::North)
+                    .set_value(CHEST_TYPE, ChestType::Single),
+                UpdateFlags::UPDATE_ALL,
+            )
+        );
+
+        let mut stack = ItemStack::new(&vanilla_items::CHEST);
+        let context = place_context(&world, pos, Direction::South, false, &mut stack);
+        let placed = behavior
+            .get_state_for_placement(&context)
+            .expect("chest always has a placement state");
+
+        assert_eq!(placed.get_value(HORIZONTAL_FACING), Direction::North);
+        assert_eq!(placed.get_value(CHEST_TYPE), ChestType::Right);
+    }
+
+    #[test]
+    fn update_shape_forms_and_breaks_double_chests() {
+        init_vanilla_registry();
+        init_behaviors();
+        let behavior = chest_behavior();
+        let single = vanilla_blocks::CHEST
+            .default_state()
+            .set_value(HORIZONTAL_FACING, Direction::North)
+            .set_value(CHEST_TYPE, ChestType::Single);
+        let right = single.set_value(CHEST_TYPE, ChestType::Right);
+        let world = test_world();
+
+        let connected = behavior.update_shape(
+            single,
+            world,
+            BlockPos::new(1, 64, 1),
+            Direction::East,
+            BlockPos::new(2, 64, 1),
+            right,
+        );
+        assert_eq!(connected.get_value(CHEST_TYPE), ChestType::Left);
+
+        let disconnected = behavior.update_shape(
+            connected,
+            world,
+            BlockPos::new(1, 64, 1),
+            Direction::East,
+            BlockPos::new(2, 64, 1),
+            vanilla_blocks::AIR.default_state(),
+        );
+        assert_eq!(disconnected.get_value(CHEST_TYPE), ChestType::Single);
+    }
+
+    #[test]
+    fn is_pathfindable_returns_false_for_all_types() {
+        init_vanilla_registry();
+        let block = chest_behavior();
+        let state = vanilla_blocks::CHEST.default_state();
+        assert!(!block.is_pathfindable(state, PathComputationType::Land));
+        assert!(!block.is_pathfindable(state, PathComputationType::Water));
+        assert!(!block.is_pathfindable(state, PathComputationType::Air));
+    }
+}

--- a/steel-core/src/behavior/blocks/container/mod.rs
+++ b/steel-core/src/behavior/blocks/container/mod.rs
@@ -1,11 +1,13 @@
 mod anvil_block;
 mod barrel_block;
 mod beehive_block;
+mod chest_block;
 mod chiseled_bookshelf_block;
 mod crafting_table_block;
 
 pub use anvil_block::AnvilBlock;
 pub use barrel_block::BarrelBlock;
 pub use beehive_block::BeehiveBlock;
+pub use chest_block::ChestBlock;
 pub use chiseled_bookshelf_block::ChiseledBookShelfBlock;
 pub use crafting_table_block::CraftingTableBlock;

--- a/steel-core/src/behavior/blocks/mod.rs
+++ b/steel-core/src/behavior/blocks/mod.rs
@@ -28,7 +28,7 @@ pub use building::{
 };
 pub use colored::StainedGlassPaneBlock;
 pub use container::{
-    AnvilBlock, BarrelBlock, BeehiveBlock, ChiseledBookShelfBlock, CraftingTableBlock,
+    AnvilBlock, BarrelBlock, BeehiveBlock, ChestBlock, ChiseledBookShelfBlock, CraftingTableBlock,
 };
 pub use decoration::{
     BannerBlock, CakeBlock, CandleBlock, CandleCakeBlock, CeilingHangingSignBlock, ChainBlock,

--- a/steel-core/src/block_entity/entities/chest.rs
+++ b/steel-core/src/block_entity/entities/chest.rs
@@ -1,0 +1,323 @@
+//! Chest block entity (`ChestBlockEntity`).
+
+use std::{
+    mem,
+    str::FromStr,
+    sync::{Arc, Weak},
+};
+
+use rand::{Rng, SeedableRng as _, rngs::StdRng};
+use simdnbt::ToNbtTag;
+use simdnbt::borrow::{BaseNbtCompound as BorrowedNbtCompound, NbtCompound as NbtCompoundView};
+use simdnbt::owned::{NbtCompound, NbtList, NbtTag};
+use steel_registry::item_stack::ItemStack;
+use steel_registry::loot_table::{LootContext, LootTableRef};
+use steel_registry::vanilla_block_entity_types;
+use steel_registry::{REGISTRY, RegistryExt};
+use steel_utils::Identifier;
+use steel_utils::{BlockPos, BlockStateId, DowncastType, DowncastTypeKey, locks::SyncMutex};
+
+use crate::block_entity::{BlockEntity, BlockEntityBase};
+use crate::entity::entity_loot_ref;
+use crate::entity::{Entity, LivingEntity};
+use crate::inventory::container::{Container, fill_container};
+use crate::inventory::lock::{ContainerRef, SharedContainer};
+use crate::player::Player;
+use crate::world::World;
+
+/// Number of slots in a single chest (3 rows of 9).
+pub const CHEST_SLOTS: usize = 27;
+
+/// Chest block entity.
+pub struct ChestBlockEntity {
+    base: Arc<BlockEntityBase>,
+    container: Arc<SyncMutex<ChestContainer>>,
+    container_ref: ContainerRef,
+}
+
+struct ChestContainer {
+    items: Vec<ItemStack>,
+    loot_table: Option<Identifier>,
+    loot_table_seed: i64,
+}
+
+// SAFETY: This key is owned by Steel and uniquely identifies `ChestBlockEntity`.
+unsafe impl DowncastType for ChestBlockEntity {
+    const TYPE_KEY: DowncastTypeKey = DowncastTypeKey::new("steel:block_entity/chest");
+}
+
+// SAFETY: This key is owned by Steel and uniquely identifies the independently
+// lockable inventory data used by a chest block entity.
+unsafe impl DowncastType for ChestContainer {
+    const TYPE_KEY: DowncastTypeKey = DowncastTypeKey::new("steel:container/chest");
+}
+
+impl ChestBlockEntity {
+    /// Creates a new chest block entity.
+    #[must_use]
+    pub fn new(level: Weak<World>, pos: BlockPos, state: BlockStateId) -> Self {
+        let base = Arc::new(BlockEntityBase::new(
+            &vanilla_block_entity_types::CHEST,
+            level,
+            pos,
+            state,
+        ));
+        let container = Arc::new(SyncMutex::new(ChestContainer {
+            items: vec![ItemStack::empty(); CHEST_SLOTS],
+            loot_table: None,
+            loot_table_seed: 0,
+        }));
+        let shared_container: SharedContainer = container.clone();
+        Self {
+            container_ref: ContainerRef::owned_by_block_entity(shared_container, Arc::clone(&base)),
+            base,
+            container,
+        }
+    }
+
+    /// Vanilla `RandomizableContainer.canOpen`.
+    #[must_use]
+    pub fn can_open(&self, player: &Player) -> bool {
+        let has_loot = self.container.lock().loot_table.is_some();
+        !(has_loot && player.is_spectator())
+    }
+
+    /// Vanilla `RandomizableContainer.unpackLootTable`.
+    pub fn unpack_loot_table(&self, player: Option<&Player>) {
+        let (loot_table_key, seed) = {
+            let mut container = self.container.lock();
+            match container.loot_table.take() {
+                Some(key) => (key, mem::take(&mut container.loot_table_seed)),
+                None => return,
+            }
+        };
+
+        if self.get_level().is_none() {
+            let mut container = self.container.lock();
+            container.loot_table = Some(loot_table_key);
+            container.loot_table_seed = seed;
+            return;
+        }
+
+        let loot_table = REGISTRY.loot_tables.by_key(&loot_table_key);
+        let origin = self.get_block_pos();
+        let origin = (
+            f64::from(origin.x()) + 0.5,
+            f64::from(origin.y()) + 0.5,
+            f64::from(origin.z()) + 0.5,
+        );
+
+        if seed == 0 {
+            let mut rng = rand::rng();
+            self.fill_from_loot(loot_table, player, origin, &mut rng);
+        } else {
+            let mut rng = StdRng::seed_from_u64(seed as u64);
+            self.fill_from_loot(loot_table, player, origin, &mut rng);
+        }
+        self.set_changed();
+    }
+
+    fn fill_from_loot<R: Rng>(
+        &self,
+        loot_table: Option<LootTableRef>,
+        player: Option<&Player>,
+        origin: (f64, f64, f64),
+        rng: &mut R,
+    ) {
+        let items = match loot_table {
+            Some(table) => {
+                let mut ctx = LootContext::new(rng).with_origin(origin.0, origin.1, origin.2);
+                if let Some(player) = player {
+                    ctx = ctx
+                        .with_luck(player.get_luck())
+                        .with_this_entity(entity_loot_ref(player));
+                }
+                table.get_random_items(&mut ctx)
+            }
+            None => Vec::new(),
+        };
+
+        let mut container = self.container.lock();
+        fill_container(&mut *container, items, rng);
+    }
+}
+
+impl BlockEntity for ChestBlockEntity {
+    fn base(&self) -> &BlockEntityBase {
+        &self.base
+    }
+
+    fn pre_remove_side_effects(&self, pos: BlockPos, _state: BlockStateId) {
+        self.unpack_loot_table(None);
+        let items = {
+            let mut container = self.container.lock();
+            mem::replace(&mut container.items, vec![ItemStack::empty(); CHEST_SLOTS])
+        };
+        let Some(world) = self.get_level() else {
+            return;
+        };
+        for item in items {
+            world.drop_item_stack(pos, item);
+        }
+    }
+
+    fn load_additional(&self, nbt: &BorrowedNbtCompound<'_>) {
+        let nbt_view: NbtCompoundView<'_, '_> = nbt.into();
+        let mut container = self.container.lock();
+        container.items.fill(ItemStack::empty());
+        container.loot_table = nbt_view
+            .string("LootTable")
+            .and_then(|value| Identifier::from_str(&value.to_string()).ok());
+        container.loot_table_seed = nbt_view.long("LootTableSeed").unwrap_or(0);
+
+        if container.loot_table.is_some() {
+            return;
+        }
+
+        if let Some(items_list) = nbt_view.list("Items")
+            && let Some(compounds) = items_list.compounds()
+        {
+            for compound in compounds {
+                if let Some(slot) = compound.byte("Slot") {
+                    let slot = slot as usize;
+                    if slot < CHEST_SLOTS
+                        && let Some(item) = ItemStack::from_borrowed_compound(&compound)
+                    {
+                        container.items[slot] = item;
+                    }
+                }
+            }
+        }
+    }
+
+    fn save_additional(&self, nbt: &mut NbtCompound) {
+        let container = self.container.lock();
+        if let Some(loot_table) = &container.loot_table {
+            nbt.insert("LootTable", loot_table.to_string());
+            if container.loot_table_seed != 0 {
+                nbt.insert("LootTableSeed", container.loot_table_seed);
+            }
+            return;
+        }
+
+        let mut items: Vec<NbtCompound> = Vec::new();
+        for (slot, item) in container.items.iter().enumerate() {
+            if !item.is_empty()
+                && let NbtTag::Compound(mut item_nbt) = item.clone().to_nbt_tag()
+            {
+                item_nbt.insert("Slot", slot as i8);
+                items.push(item_nbt);
+            }
+        }
+        nbt.insert("Items", NbtList::Compound(items));
+    }
+
+    fn get_update_tag(&self) -> Option<NbtCompound> {
+        None
+    }
+
+    fn container_ref(&self) -> Option<ContainerRef> {
+        Some(self.container_ref.clone())
+    }
+}
+
+impl Container for ChestContainer {
+    fn items(&self) -> &[ItemStack] {
+        &self.items
+    }
+
+    fn items_mut(&mut self) -> &mut [ItemStack] {
+        &mut self.items
+    }
+
+    fn get_container_size(&self) -> usize {
+        CHEST_SLOTS
+    }
+
+    fn set_item(&mut self, slot: usize, mut stack: ItemStack) {
+        if slot < CHEST_SLOTS {
+            let max_stack_size = self.get_max_stack_size_for_item(&stack);
+            if !stack.is_empty() && stack.count() > max_stack_size {
+                stack.set_count(max_stack_size);
+            }
+            self.items[slot] = stack;
+        }
+    }
+
+    fn set_changed(&mut self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use simdnbt::borrow::read_compound;
+    use steel_registry::{init_vanilla_registry, vanilla_blocks, vanilla_items};
+
+    use super::*;
+
+    fn test_chest() -> ChestBlockEntity {
+        init_vanilla_registry();
+        ChestBlockEntity::new(
+            Weak::new(),
+            BlockPos::new(1, 2, 3),
+            vanilla_blocks::CHEST.default_state(),
+        )
+    }
+
+    #[test]
+    fn loot_table_nbt_round_trips_and_skips_items() {
+        let chest = test_chest();
+        {
+            let mut container = chest.container.lock();
+            container.loot_table = Some(Identifier::vanilla_static("chests/simple_dungeon"));
+            container.loot_table_seed = 42;
+            container.items[0] = ItemStack::new(&vanilla_items::STONE);
+        }
+
+        let mut saved = NbtCompound::new();
+        chest.save_additional(&mut saved);
+        assert_eq!(
+            saved.string("LootTable").map(ToString::to_string),
+            Some("minecraft:chests/simple_dungeon".to_owned())
+        );
+        assert_eq!(saved.long("LootTableSeed"), Some(42));
+        assert!(saved.list("Items").is_none());
+
+        let loaded = test_chest();
+        let mut bytes = Vec::new();
+        saved.write(&mut bytes);
+        let borrowed =
+            read_compound(&mut Cursor::new(&bytes)).expect("saved chest nbt should reborrow");
+        loaded.load_additional(&borrowed);
+        let container = loaded.container.lock();
+        assert_eq!(
+            container.loot_table.as_ref().map(ToString::to_string),
+            Some("minecraft:chests/simple_dungeon".to_owned())
+        );
+        assert_eq!(container.loot_table_seed, 42);
+        assert!(container.items.iter().all(ItemStack::is_empty));
+    }
+
+    #[test]
+    fn item_nbt_round_trips_when_loot_table_is_absent() {
+        let chest = test_chest();
+        chest
+            .container
+            .lock()
+            .set_item(3, ItemStack::with_count(&vanilla_items::STONE, 4));
+
+        let mut saved = NbtCompound::new();
+        chest.save_additional(&mut saved);
+
+        let loaded = test_chest();
+        let mut bytes = Vec::new();
+        saved.write(&mut bytes);
+        let borrowed =
+            read_compound(&mut Cursor::new(&bytes)).expect("saved chest nbt should reborrow");
+        loaded.load_additional(&borrowed);
+        let item = loaded.container.lock().get_item(3).clone();
+        assert!(item.is(&vanilla_items::STONE));
+        assert_eq!(item.count(), 4);
+    }
+}

--- a/steel-core/src/block_entity/entities/mod.rs
+++ b/steel-core/src/block_entity/entities/mod.rs
@@ -3,6 +3,7 @@
 mod barrel;
 mod beehive;
 mod brushable;
+mod chest;
 mod chiseled_bookshelf;
 mod comparator;
 mod daylight_detector;
@@ -19,6 +20,7 @@ pub use beehive::{
     BEEHIVE_MAX_OCCUPANTS, BEEHIVE_MIN_OCCUPATION_TICKS_NECTARLESS, BeehiveBlockEntity,
 };
 pub use brushable::BrushableBlockEntity;
+pub use chest::{CHEST_SLOTS, ChestBlockEntity};
 pub use chiseled_bookshelf::{CHISELED_BOOKSHELF_SLOTS, ChiseledBookShelfBlockEntity};
 pub use comparator::ComparatorBlockEntity;
 pub use daylight_detector::DaylightDetectorBlockEntity;

--- a/steel-core/src/block_entity/registry.rs
+++ b/steel-core/src/block_entity/registry.rs
@@ -16,10 +16,10 @@ use steel_utils::{BlockPos, BlockStateId};
 
 use super::SharedBlockEntity;
 use super::entities::{
-    BarrelBlockEntity, BeehiveBlockEntity, BrushableBlockEntity, ChiseledBookShelfBlockEntity,
-    ComparatorBlockEntity, DaylightDetectorBlockEntity, EndGatewayBlockEntity,
-    EndPortalBlockEntity, JukeboxBlockEntity, PistonMovingBlockEntity, PotentSulfurBlockEntity,
-    RawBlockEntity, SignBlockEntity,
+    BarrelBlockEntity, BeehiveBlockEntity, BrushableBlockEntity, ChestBlockEntity,
+    ChiseledBookShelfBlockEntity, ComparatorBlockEntity, DaylightDetectorBlockEntity,
+    EndGatewayBlockEntity, EndPortalBlockEntity, JukeboxBlockEntity, PistonMovingBlockEntity,
+    PotentSulfurBlockEntity, RawBlockEntity, SignBlockEntity,
 };
 use crate::world::World;
 
@@ -221,6 +221,10 @@ pub fn init_block_entities() {
         // Register barrel block entity factory
         registry.register(&vanilla_block_entity_types::BARREL, |level, pos, state| {
             Arc::new(BarrelBlockEntity::new(level, pos, state))
+        });
+
+        registry.register(&vanilla_block_entity_types::CHEST, |level, pos, state| {
+            Arc::new(ChestBlockEntity::new(level, pos, state))
         });
 
         registry.register(

--- a/steel-core/src/inventory/container/loot.rs
+++ b/steel-core/src/inventory/container/loot.rs
@@ -1,0 +1,141 @@
+//! Vanilla `LootTable.fill` placement into a container.
+
+use std::mem;
+
+use rand::{Rng, RngExt};
+use steel_registry::item_stack::ItemStack;
+
+use crate::inventory::container::Container;
+
+/// Places generated loot into empty container slots.
+///
+/// Mirrors vanilla `LootTable.fill` after `getRandomItems`: empty slots are
+/// shuffled, stacks with count greater than 1 may be split to occupy extra
+/// slots, then items are written from the end of the shuffled slot list.
+pub fn fill_container<R: Rng>(container: &mut dyn Container, items: Vec<ItemStack>, rng: &mut R) {
+    let mut items = items;
+    let mut available_slots = available_slots(container, rng);
+    shuffle_and_split_items(&mut items, available_slots.len(), rng);
+
+    for item in items {
+        let Some(slot) = available_slots.pop() else {
+            log::warn!("Tried to over-fill a container");
+            return;
+        };
+        container.set_item(slot, item);
+    }
+}
+
+fn available_slots<R: Rng>(container: &dyn Container, rng: &mut R) -> Vec<usize> {
+    let mut slots: Vec<usize> = (0..container.get_container_size())
+        .filter(|&slot| container.get_item(slot).is_empty())
+        .collect();
+    shuffle_indices(&mut slots, rng);
+    slots
+}
+
+fn shuffle_and_split_items<R: Rng>(
+    items: &mut Vec<ItemStack>,
+    available_slots: usize,
+    rng: &mut R,
+) {
+    let mut splittable = Vec::new();
+    items.retain_mut(|item| {
+        if item.is_empty() {
+            false
+        } else if item.count() > 1 {
+            splittable.push(mem::take(item));
+            false
+        } else {
+            true
+        }
+    });
+
+    while available_slots > items.len() + splittable.len() && !splittable.is_empty() {
+        let index = next_int_inclusive(rng, 0, splittable.len() as i32 - 1) as usize;
+        let mut stack = splittable.swap_remove(index);
+        let remove = next_int_inclusive(rng, 1, stack.count() / 2);
+        let copy = stack.split(remove);
+        if stack.count() > 1 && rng.random_bool(0.5) {
+            splittable.push(stack);
+        } else {
+            items.push(stack);
+        }
+        if copy.count() > 1 && rng.random_bool(0.5) {
+            splittable.push(copy);
+        } else {
+            items.push(copy);
+        }
+    }
+
+    items.append(&mut splittable);
+    shuffle(items, rng);
+}
+
+fn shuffle_indices<R: Rng>(values: &mut [usize], rng: &mut R) {
+    shuffle(values, rng);
+}
+
+fn shuffle<T, R: Rng>(values: &mut [T], rng: &mut R) {
+    for i in (1..values.len()).rev() {
+        let j = rng.random_range(0..=i);
+        values.swap(i, j);
+    }
+}
+
+/// Vanilla `Mth.nextInt(random, min, max)`: inclusive, returns `min` when `min >= max`.
+fn next_int_inclusive<R: Rng>(rng: &mut R, min: i32, max: i32) -> i32 {
+    if min >= max {
+        min
+    } else {
+        rng.random_range(min..=max)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng as _;
+    use rand::rngs::StdRng;
+    use steel_registry::{init_vanilla_registry, vanilla_items};
+
+    use super::*;
+    use crate::inventory::container::SimpleContainer;
+
+    #[test]
+    fn fill_places_generated_stacks_into_empty_slots() {
+        init_vanilla_registry();
+        let mut container = SimpleContainer::new(3);
+        container.set_item(1, ItemStack::new(&vanilla_items::DIRT));
+        let mut rng = StdRng::seed_from_u64(1);
+        fill_container(
+            &mut container,
+            vec![ItemStack::new(&vanilla_items::STONE)],
+            &mut rng,
+        );
+
+        let filled = (0..3)
+            .filter(|&slot| container.get_item(slot).is(&vanilla_items::STONE))
+            .count();
+        assert_eq!(filled, 1);
+        assert!(container.get_item(1).is(&vanilla_items::DIRT));
+    }
+
+    #[test]
+    fn fill_splits_oversized_stacks_into_extra_empty_slots() {
+        init_vanilla_registry();
+        let mut container = SimpleContainer::new(4);
+        let mut rng = StdRng::seed_from_u64(7);
+        fill_container(
+            &mut container,
+            vec![ItemStack::with_count(&vanilla_items::STONE, 8)],
+            &mut rng,
+        );
+
+        let occupied = (0..4)
+            .filter(|&slot| !container.get_item(slot).is_empty())
+            .count();
+        let total: i32 = (0..4).map(|slot| container.get_item(slot).count()).sum();
+        assert!(occupied > 1, "vanilla split uses extra empty slots");
+        assert_eq!(total, 8);
+    }
+}

--- a/steel-core/src/inventory/container/mod.rs
+++ b/steel-core/src/inventory/container/mod.rs
@@ -4,10 +4,12 @@
 //! including player inventories, chests, barrels, furnaces, etc.
 
 mod crafting;
+mod loot;
 mod result;
 mod simple;
 
 pub use crafting::CraftingContainer;
+pub use loot::fill_container;
 pub use result::ResultContainer;
 pub use simple::SimpleContainer;
 

--- a/steel-core/src/inventory/menu/kinds/chest_menu.rs
+++ b/steel-core/src/inventory/menu/kinds/chest_menu.rs
@@ -35,7 +35,43 @@ pub fn chest(
     builder.route(chest, player.all(), FillDirection::Backward);
     builder.route(player.all(), chest, FillDirection::Forward);
 
-    builder.build(ChestKind { container })
+    builder.build(ChestKind {
+        containers: ChestContainers::Single(container),
+    })
+}
+
+/// Builds a double-chest menu: two 27-slot containers as six rows.
+///
+/// Slot order matches vanilla `CompoundContainer(first, second)`: `first` is
+/// the `ChestType::RIGHT` half.
+#[must_use]
+pub fn double_chest(
+    inventory: Shared<PlayerInventory>,
+    container_id: u8,
+    first: impl Into<ContainerRef>,
+    second: impl Into<ContainerRef>,
+) -> Menu {
+    let first = first.into();
+    let second = second.into();
+    let mut builder = MenuBuilder::new(menu_type_for_rows(6), container_id);
+    let first_section = builder.section(&first, 27);
+    let second_section = builder.section(&second, 27);
+    let player = builder.player_inventory(&inventory);
+
+    builder.route(
+        [first_section, second_section],
+        player.all(),
+        FillDirection::Backward,
+    );
+    builder.route(
+        player.all(),
+        [first_section, second_section],
+        FillDirection::Forward,
+    );
+
+    builder.build(ChestKind {
+        containers: ChestContainers::Double { first, second },
+    })
 }
 
 /// Menu type for a chest of `rows` rows.
@@ -55,10 +91,17 @@ pub fn menu_type_for_rows(rows: usize) -> MenuTypeRef {
     }
 }
 
-/// Per-menu chest state: just the backing container for the validity check.
+enum ChestContainers {
+    Single(ContainerRef),
+    Double {
+        first: ContainerRef,
+        second: ContainerRef,
+    },
+}
+
+/// Per-menu chest state: the backing container(s) for the validity check.
 pub struct ChestKind {
-    /// The backing container.
-    container: ContainerRef,
+    containers: ChestContainers,
 }
 
 // SAFETY: This Steel-owned key uniquely identifies the concrete menu kind
@@ -71,7 +114,12 @@ unsafe impl steel_utils::DowncastType for ChestKind {
 impl MenuKind for ChestKind {
     /// Returns true if the backing container is still valid for the player.
     fn still_valid(&self, _behavior: &MenuBehavior, player: &Player) -> bool {
-        self.container.still_valid(player)
+        match &self.containers {
+            ChestContainers::Single(container) => container.still_valid(player),
+            ChestContainers::Double { first, second } => {
+                first.still_valid(player) && second.still_valid(player)
+            }
+        }
     }
 }
 
@@ -90,5 +138,16 @@ mod tests {
         let menu = chest(inventory, 1, container, 1);
 
         assert_eq!(menu.behavior().slot_count(), 9 + 36);
+    }
+
+    #[test]
+    fn double_chest_exposes_fifty_four_container_slots() {
+        let inventory = PlayerInventory::new().into_shared();
+        let first = SimpleContainer::new(27).into_shared();
+        let second = SimpleContainer::new(27).into_shared();
+
+        let menu = double_chest(inventory, 1, first, second);
+
+        assert_eq!(menu.behavior().slot_count(), 54 + 36);
     }
 }

--- a/steel-core/src/inventory/menu/kinds/mod.rs
+++ b/steel-core/src/inventory/menu/kinds/mod.rs
@@ -8,6 +8,6 @@ mod inventory_menu;
 
 pub use anvil_menu::{AnvilKind, anvil};
 pub use basic_menu::BasicKind;
-pub use chest_menu::{ChestKind, chest};
+pub use chest_menu::{ChestKind, chest, double_chest};
 pub use crafting_menu::{CraftingKind, crafting};
 pub use inventory_menu::{INVENTORY_MENU_CONTAINER_ID, InventoryKind, inventory_menu};

--- a/steel-registry/src/blocks/properties.rs
+++ b/steel-registry/src/blocks/properties.rs
@@ -547,6 +547,18 @@ pub enum ChestType {
     Right,
 }
 
+impl ChestType {
+    /// Vanilla `ChestType.getOpposite`.
+    #[must_use]
+    pub const fn opposite(self) -> Self {
+        match self {
+            Self::Single => Self::Single,
+            Self::Left => Self::Right,
+            Self::Right => Self::Left,
+        }
+    }
+}
+
 impl PropertyEnum for ChestType {
     fn as_str(&self) -> &str {
         match self {


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [x] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

Implements vanilla `ChestBlock` and `ChestBlockEntity` for Minecraft 26.2:

- Placement faces the player, waterlogs, and forms a double chest with a neighboring single chest
- `updateShape` connects and splits double chests
- Opening uses a 3-row menu, or a 6-row menu in vanilla `CompoundContainer` order (`RIGHT` then `LEFT`)
- Worldgen `LootTable` / `LootTableSeed` unpack on open, comparator read, and break
- Comparator signal is the combined 27- or 54-slot fill level
- A redstone conductor above blocks opening
- Awards `Stats.OPEN_CHEST` and plays the open sound

## How this was tested

Minecraft 26.2

- `cargo test -p steel-core --lib chest`
- `cargo test -p steel-core --lib inventory::container::loot`
- `cargo clippy -p steel-core --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`

In-game: placed single and double chests, opened them, and opened a generated dungeon chest.

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

Follow-ups that need other foundations: piglin anger, `ContainerOpenersCounter` (close sound / lid), sitting cats, lock/custom name.

This PR does **not** include trapped chests, ender chests, or copper chests.