### PR TITLE
feat: implement vanilla fox entity core

### DIFF
--- a/steel-core/src/entity/entities/mobs/passive/chicken/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/chicken/mod.rs
@@ -525,7 +525,7 @@ impl LivingEntity for ChickenEntity {
     }
 
     fn ai_step(&self) -> Option<MoveResult> {
-        let result = self.default_ai_step();
+        let result = Mob::mob_ai_step(self);
 
         AgeableMob::tick_ageable_mob(self);
         Animal::tick_animal_love(self);

--- a/steel-core/src/entity/entities/mobs/passive/cow/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/cow/mod.rs
@@ -347,7 +347,7 @@ impl LivingEntity for CowEntity {
     }
 
     fn ai_step(&self) -> Option<MoveResult> {
-        let result = self.default_ai_step();
+        let result = Mob::mob_ai_step(self);
 
         AgeableMob::tick_ageable_mob(self);
         Animal::tick_animal_love(self);

--- a/steel-core/src/entity/entities/mobs/passive/pig/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/pig/mod.rs
@@ -371,7 +371,7 @@ impl LivingEntity for PigEntity {
     }
 
     fn ai_step(&self) -> Option<MoveResult> {
-        let result = self.default_ai_step();
+        let result = Mob::mob_ai_step(self);
         AgeableMob::tick_ageable_mob(self);
         Animal::tick_animal_love(self);
         result

--- a/steel-core/src/entity/entities/mobs/passive/sheep/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/sheep/mod.rs
@@ -446,7 +446,7 @@ impl LivingEntity for SheepEntity {
     }
 
     fn ai_step(&self) -> Option<MoveResult> {
-        let result = self.default_ai_step();
+        let result = Mob::mob_ai_step(self);
 
         AgeableMob::tick_ageable_mob(self);
         Animal::tick_animal_love(self);

--- a/steel-core/src/entity/mob/mod.rs
+++ b/steel-core/src/entity/mob/mod.rs
@@ -15,6 +15,7 @@ use glam::DVec3;
 use simdnbt::borrow::NbtCompound as BorrowedNbtCompoundView;
 use simdnbt::owned::{NbtCompound, NbtTag};
 use steel_math::fast_floor;
+use steel_protocol::packets::game::CTakeItemEntity;
 use steel_registry::blocks::block_state_ext::BlockStateExt as _;
 use steel_registry::enchantment_effect::EnchantmentEffectComponent;
 use steel_registry::item_stack::ItemStack;
@@ -23,11 +24,11 @@ use steel_registry::sound_event::SoundEventRef;
 use steel_registry::vanilla_block_tags::BlockTag;
 use steel_registry::{
     REGISTRY, RegistryExt, vanilla_attributes, vanilla_damage_types, vanilla_entities,
-    vanilla_game_events,
+    vanilla_game_events, vanilla_game_rules,
 };
 use steel_utils::locks::SyncMutex;
 use steel_utils::types::{Difficulty, InteractionHand};
-use steel_utils::{BlockPos, Identifier, WorldAabb, axis::Axis};
+use steel_utils::{BlockPos, ChunkPos, Downcast as _, Identifier, WorldAabb, axis::Axis};
 
 use crate::behavior::{BLOCK_BEHAVIORS, BlockCollisionContext, ITEM_BEHAVIORS, InteractionResult};
 use crate::enchantment_helper::{self, EnchantmentDamageContext, EnchantmentPostAttackContext};
@@ -41,6 +42,7 @@ use crate::entity::ai::sensing::Sensing;
 use crate::entity::ai::walk::WalkPathEvaluator;
 use crate::entity::attribute::{AttributeModifier, AttributeModifierOperation};
 use crate::entity::damage::DamageSource;
+use crate::entity::entities::objects::items::ItemEntity;
 use crate::entity::{
     Entity, EntitySpawnReason, LivingEntity, LivingTravelInput, RemovalReason, SharedEntity,
     SpawnGroupData, WeakEntity,
@@ -65,6 +67,9 @@ const DEFAULT_ATTACK_REACH_OFFSET: f32 = 0.6;
 const RANDOM_SPAWN_BONUS_ID: Identifier = Identifier::vanilla_static("random_spawn_bonus");
 const RANDOM_SPAWN_BONUS_SCALE: f64 = 0.114_850_000_000_000_01;
 const LEFT_HANDED_SPAWN_CHANCE: f32 = 0.05;
+/// Vanilla `Mob.ITEM_PICKUP_REACH`: the per-axis distance the item-pickup search
+/// box is inflated by when a mob looks for nearby dropped items to collect.
+const ITEM_PICKUP_REACH: DVec3 = DVec3::new(1.0, 0.0, 1.0);
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct DropChances {
@@ -568,6 +573,89 @@ pub trait Mob: LivingEntity + Leashable {
             .drop_chances()
             .lock()
             .set_guaranteed_drop(slot);
+    }
+
+    /// Vanilla `Mob.getPickupReach`: the per-axis distance the item-pickup search
+    /// box is inflated by. Overridable so mobs with a longer reach can widen it.
+    fn get_pickup_reach(&self) -> DVec3 {
+        ITEM_PICKUP_REACH
+    }
+
+    /// Vanilla `Mob.wantsToPickUp`: whether this mob wants to collect the item it
+    /// just walked over. Defaults to whatever the mob is willing to hold.
+    fn wants_to_pick_up(&self, item_stack: &ItemStack) -> bool {
+        self.can_hold_item(item_stack)
+    }
+
+    /// Vanilla `Mob.canHoldItem`: whether this mob is willing to hold the item.
+    /// The base mob holds anything; specific mobs narrow this down.
+    fn can_hold_item(&self, _item_stack: &ItemStack) -> bool {
+        true
+    }
+
+    /// Vanilla `Mob.pickUpItem`: take a dropped item into this mob's equipment.
+    ///
+    /// TODO(equip-armor): port the full vanilla `equipItemIfPossible` (armor-slot
+    /// selection via the item's equippable slot, the `canReplaceCurrentItem`
+    /// preference between held and dropped gear, and the drop-chance drop of any
+    /// replaced item) once armor-wearing mobs land. Until then this covers the
+    /// common case of taking an item into an empty main hand.
+    fn pick_up_item(&self, world: &Arc<World>, item_entity: &ItemEntity) {
+        let item_stack = item_entity.get_item();
+        if item_stack.is_empty()
+            || self.has_item_in_slot(EquipmentSlot::MainHand)
+            || !self.can_hold_item(&item_stack)
+        {
+            return;
+        }
+
+        let count = item_stack.count();
+        self.living_base()
+            .equipment()
+            .lock()
+            .set(EquipmentSlot::MainHand, item_stack);
+        self.set_guaranteed_drop(EquipmentSlot::MainHand);
+        self.set_persistence_required();
+
+        let chunk_pos = ChunkPos::from_entity_pos(item_entity.position());
+        world.broadcast_to_nearby(
+            chunk_pos,
+            CTakeItemEntity::new(item_entity.id(), self.id(), count),
+            None,
+        );
+        item_entity.set_removed(RemovalReason::Discarded);
+    }
+
+    /// Vanilla `Mob.aiStep` looting loop: while this mob may pick up loot and the
+    /// `mobGriefing` game rule allows it, collect nearby dropped items in reach.
+    fn tick_looting(&self) {
+        let Some(world) = self.level() else {
+            return;
+        };
+        if !self.can_pick_up_loot()
+            || !Entity::is_alive(self)
+            || !world.get_game_rule(&vanilla_game_rules::MOB_GRIEFING)
+        {
+            return;
+        }
+
+        let reach = self.get_pickup_reach();
+        let search_box = self.bounding_box().inflate_xyz(reach.x, reach.y, reach.z);
+        for entity in world.get_entities_in_aabb(&search_box) {
+            let Some(item_entity) = entity.downcast_ref::<ItemEntity>() else {
+                continue;
+            };
+            let item = item_entity.get_item();
+            if item_entity.is_removed()
+                || item.is_empty()
+                || item_entity.has_pickup_delay()
+                || !self.wants_to_pick_up(&item)
+            {
+                continue;
+            }
+
+            self.pick_up_item(&world, item_entity);
+        }
     }
 
     fn drop_custom_death_loot_mob(&self, _source: &DamageSource, killed_by_player: bool) {
@@ -1099,6 +1187,7 @@ pub trait Mob: LivingEntity + Leashable {
         self.tick_move_control();
         self.tick_look_control();
         self.tick_jump_control();
+        self.tick_looting();
     }
 
     fn tick_path_navigation(&self) {

--- a/steel-core/src/entity/mob/mod.rs
+++ b/steel-core/src/entity/mob/mod.rs
@@ -26,8 +26,8 @@ use steel_registry::loot_table::LootTableRef;
 use steel_registry::sound_event::SoundEventRef;
 use steel_registry::vanilla_block_tags::BlockTag;
 use steel_registry::{
-    REGISTRY, RegistryExt, vanilla_attributes, vanilla_damage_types, vanilla_entities,
-    vanilla_game_events, vanilla_game_rules,
+    REGISTRY, RegistryExt, TaggedRegistryExt, vanilla_attributes, vanilla_damage_types,
+    vanilla_entities, vanilla_game_events, vanilla_game_rules,
 };
 use steel_utils::locks::SyncMutex;
 use steel_utils::types::{Difficulty, InteractionHand};
@@ -748,9 +748,16 @@ pub trait Mob: LivingEntity + Leashable {
         }
     }
 
-    /// Vanilla `Mob.compareWeapons`: prefer the piece dealing more attack damage,
-    /// then the equal-item tiebreak. The base mob has no preferred weapon type, so
-    /// that branch is omitted here.
+    /// Vanilla `Mob.getPreferredWeaponType`: the item tag a mob favors for its
+    /// main hand regardless of raw damage (a skeleton keeps its bow over a
+    /// stronger sword). The base mob has no preference; specific mobs override it.
+    fn get_preferred_weapon_type(&self) -> Option<Identifier> {
+        None
+    }
+
+    /// Vanilla `Mob.compareWeapons`: keep a piece of the mob's preferred weapon
+    /// type over one that is not, otherwise prefer more attack damage, then the
+    /// equal-item tiebreak.
     #[expect(
         clippy::float_cmp,
         reason = "vanilla compares approximate attribute values for exact equality"
@@ -761,6 +768,21 @@ pub trait Mob: LivingEntity + Leashable {
         current_item_stack: &ItemStack,
         slot: EquipmentSlot,
     ) -> bool {
+        if let Some(preferred_weapon_type) = self.get_preferred_weapon_type() {
+            let current_is_preferred = REGISTRY
+                .items
+                .is_in_tag(current_item_stack.item(), &preferred_weapon_type);
+            let new_is_preferred = REGISTRY
+                .items
+                .is_in_tag(new_item_stack.item(), &preferred_weapon_type);
+            if current_is_preferred && !new_is_preferred {
+                return false;
+            }
+            if !current_is_preferred && new_is_preferred {
+                return true;
+            }
+        }
+
         let new_attack_damage = self.approximate_attribute_with(
             new_item_stack,
             vanilla_attributes::ATTACK_DAMAGE,

--- a/steel-core/src/entity/mob/mod.rs
+++ b/steel-core/src/entity/mob/mod.rs
@@ -16,7 +16,10 @@ use simdnbt::borrow::NbtCompound as BorrowedNbtCompoundView;
 use simdnbt::owned::{NbtCompound, NbtTag};
 use steel_math::fast_floor;
 use steel_protocol::packets::game::CTakeItemEntity;
+use steel_registry::attribute::AttributeRef;
 use steel_registry::blocks::block_state_ext::BlockStateExt as _;
+use steel_registry::data_components::components::ItemEnchantments;
+use steel_registry::data_components::vanilla_components::CUSTOM_NAME;
 use steel_registry::enchantment_effect::EnchantmentEffectComponent;
 use steel_registry::item_stack::ItemStack;
 use steel_registry::loot_table::LootTableRef;
@@ -48,6 +51,7 @@ use crate::entity::{
     SpawnGroupData, WeakEntity,
 };
 use crate::inventory::equipment::EquipmentSlot;
+use crate::physics::MoveResult;
 use crate::player::Player;
 use crate::world::game_event::GameEventContext;
 use crate::world::{LevelReader, World};
@@ -58,6 +62,9 @@ const MOB_FLAG_AGGRESSIVE: i8 = 4;
 const MOVE_CONTROL_MIN_SPEED_SQR: f64 = 2.500_000_3e-7;
 const MOVE_CONTROL_MAX_TURN: f32 = 90.0;
 const DEFAULT_EQUIPMENT_DROP_CHANCE: f32 = 0.085;
+/// Vanilla bias subtracted from the roll before comparing against a slot's drop
+/// chance when a mob swaps out worn gear it picked something better up over.
+const REPLACED_EQUIPMENT_DROP_BIAS: f32 = 0.1;
 const PRESERVE_ITEM_DROP_CHANCE_THRESHOLD: f32 = 1.0;
 const PRESERVE_ITEM_DROP_CHANCE: f32 = 2.0;
 const BODY_ROTATION_MOVING_DISTANCE_SQR: f64 = 2.500_000_3e-7;
@@ -595,35 +602,228 @@ pub trait Mob: LivingEntity + Leashable {
 
     /// Vanilla `Mob.pickUpItem`: take a dropped item into this mob's equipment.
     ///
-    /// TODO(equip-armor): port the full vanilla `equipItemIfPossible` (armor-slot
-    /// selection via the item's equippable slot, the `canReplaceCurrentItem`
-    /// preference between held and dropped gear, and the drop-chance drop of any
-    /// replaced item) once armor-wearing mobs land. Until then this covers the
-    /// common case of taking an item into an empty main hand.
+    /// Delegates the slot routing and gear-swap decision to
+    /// [`equip_item_if_possible`](Self::equip_item_if_possible), then shrinks the
+    /// source stack by however much was equipped, only removing the item entity
+    /// once nothing is left.
     fn pick_up_item(&self, world: &Arc<World>, item_entity: &ItemEntity) {
-        let item_stack = item_entity.get_item();
-        if item_stack.is_empty()
-            || self.has_item_in_slot(EquipmentSlot::MainHand)
-            || !self.can_hold_item(&item_stack)
-        {
+        let equipped = self.equip_item_if_possible(item_entity.get_item());
+        if equipped.is_empty() {
             return;
         }
 
-        let count = item_stack.count();
-        self.living_base()
-            .equipment()
-            .lock()
-            .set(EquipmentSlot::MainHand, item_stack);
-        self.set_guaranteed_drop(EquipmentSlot::MainHand);
-        self.set_persistence_required();
-
+        let count = equipped.count();
         let chunk_pos = ChunkPos::from_entity_pos(item_entity.position());
         world.broadcast_to_nearby(
             chunk_pos,
             CTakeItemEntity::new(item_entity.id(), self.id(), count),
             None,
         );
-        item_entity.set_removed(RemovalReason::Discarded);
+
+        let mut remaining = item_entity.get_item();
+        remaining.shrink(count);
+        if remaining.is_empty() {
+            item_entity.set_removed(RemovalReason::Discarded);
+        } else {
+            item_entity.set_item(remaining);
+        }
+    }
+
+    /// Vanilla `Mob.equipItemIfPossible`: route `item_stack` to the slot its
+    /// equippable component asks for (main hand otherwise), swap up when the
+    /// target slot already holds worse gear, and drop the replaced piece by its
+    /// drop chance. Returns the stack that was equipped, or empty when nothing
+    /// was taken.
+    fn equip_item_if_possible(&self, mut item_stack: ItemStack) -> ItemStack {
+        let mut slot = self.get_equipment_slot_for_item(&item_stack);
+        if !self.is_equippable_in_slot(&item_stack, slot) {
+            return ItemStack::empty();
+        }
+
+        let mut current = self.equipment_in_slot(slot);
+        let mut can_replace = self.can_replace_current_item(&item_stack, &current, slot);
+        // Armor that would not be an upgrade still gets a chance to be carried in
+        // the main hand instead, provided that hand is free.
+        if slot.is_armor() && !can_replace {
+            slot = EquipmentSlot::MainHand;
+            current = self.equipment_in_slot(slot);
+            can_replace = current.is_empty();
+        }
+
+        if !can_replace || !self.can_hold_item(&item_stack) {
+            return ItemStack::empty();
+        }
+
+        let drop_chance = self.equipment_drop_chance(slot);
+        if !current.is_empty()
+            && (rand::random::<f32>() - REPLACED_EQUIPMENT_DROP_BIAS).max(0.0) < drop_chance
+        {
+            self.spawn_at_location(current, 0.0);
+        }
+
+        let to_equip = slot.limit(&mut item_stack);
+        let equipped = to_equip.copy_with_count(to_equip.count());
+        self.living_base().equipment().lock().set(slot, to_equip);
+        self.set_guaranteed_drop(slot);
+        self.set_persistence_required();
+        equipped
+    }
+
+    /// Vanilla `LivingEntity.getEquipmentSlotForItem`: the slot an item wants to
+    /// occupy, falling back to the main hand when it is not equippable or the mob
+    /// cannot use that slot.
+    fn get_equipment_slot_for_item(&self, item_stack: &ItemStack) -> EquipmentSlot {
+        match item_stack.get_equippable() {
+            Some(equippable) if self.can_use_slot(equippable.slot) => equippable.slot,
+            _ => EquipmentSlot::MainHand,
+        }
+    }
+
+    /// Returns a copy of whatever this mob currently holds in `slot`.
+    fn equipment_in_slot(&self, slot: EquipmentSlot) -> ItemStack {
+        let equipment = self.living_base().equipment().lock();
+        let stack = equipment.get_ref(slot);
+        stack.copy_with_count(stack.count())
+    }
+
+    /// Vanilla `Mob.canReplaceCurrentItem`: whether the freshly picked-up item
+    /// should displace what is already in `slot`.
+    fn can_replace_current_item(
+        &self,
+        new_item_stack: &ItemStack,
+        current_item_stack: &ItemStack,
+        slot: EquipmentSlot,
+    ) -> bool {
+        if current_item_stack.is_empty() {
+            true
+        } else if slot.is_armor() {
+            self.compare_armor(new_item_stack, current_item_stack, slot)
+        } else if slot == EquipmentSlot::MainHand {
+            self.compare_weapons(new_item_stack, current_item_stack, slot)
+        } else {
+            false
+        }
+    }
+
+    /// Vanilla `Mob.compareArmor`: prefer the piece granting more armor, then
+    /// more toughness, then the equal-item tiebreak, unless the worn piece is
+    /// protected against removal.
+    #[expect(
+        clippy::float_cmp,
+        reason = "vanilla compares approximate attribute values for exact equality"
+    )]
+    fn compare_armor(
+        &self,
+        new_item_stack: &ItemStack,
+        current_item_stack: &ItemStack,
+        slot: EquipmentSlot,
+    ) -> bool {
+        if current_item_stack.has_enchantment_effect(EnchantmentEffectComponent::PreventArmorChange)
+        {
+            return false;
+        }
+
+        let new_defense =
+            self.approximate_attribute_with(new_item_stack, vanilla_attributes::ARMOR, slot);
+        let old_defense =
+            self.approximate_attribute_with(current_item_stack, vanilla_attributes::ARMOR, slot);
+        if new_defense != old_defense {
+            return new_defense > old_defense;
+        }
+
+        let new_toughness = self.approximate_attribute_with(
+            new_item_stack,
+            vanilla_attributes::ARMOR_TOUGHNESS,
+            slot,
+        );
+        let old_toughness = self.approximate_attribute_with(
+            current_item_stack,
+            vanilla_attributes::ARMOR_TOUGHNESS,
+            slot,
+        );
+        if new_toughness == old_toughness {
+            self.can_replace_equal_item(new_item_stack, current_item_stack)
+        } else {
+            new_toughness > old_toughness
+        }
+    }
+
+    /// Vanilla `Mob.compareWeapons`: prefer the piece dealing more attack damage,
+    /// then the equal-item tiebreak. The base mob has no preferred weapon type, so
+    /// that branch is omitted here.
+    #[expect(
+        clippy::float_cmp,
+        reason = "vanilla compares approximate attribute values for exact equality"
+    )]
+    fn compare_weapons(
+        &self,
+        new_item_stack: &ItemStack,
+        current_item_stack: &ItemStack,
+        slot: EquipmentSlot,
+    ) -> bool {
+        let new_attack_damage = self.approximate_attribute_with(
+            new_item_stack,
+            vanilla_attributes::ATTACK_DAMAGE,
+            slot,
+        );
+        let old_attack_damage = self.approximate_attribute_with(
+            current_item_stack,
+            vanilla_attributes::ATTACK_DAMAGE,
+            slot,
+        );
+        if new_attack_damage == old_attack_damage {
+            self.can_replace_equal_item(new_item_stack, current_item_stack)
+        } else {
+            new_attack_damage > old_attack_damage
+        }
+    }
+
+    /// Vanilla `Mob.getApproximateAttributeWith`: the value of `attribute` this
+    /// mob would have in `slot` while wearing `item_stack`, taking the mob's base
+    /// value (zero when it lacks the attribute) and folding in the item's
+    /// attribute modifiers.
+    fn approximate_attribute_with(
+        &self,
+        item_stack: &ItemStack,
+        attribute: AttributeRef,
+        slot: EquipmentSlot,
+    ) -> f64 {
+        let base_value = self
+            .attributes()
+            .lock()
+            .get_base_value(attribute)
+            .unwrap_or(0.0);
+        item_stack
+            .get_attribute_modifiers()
+            .map_or(base_value, |modifiers| {
+                modifiers.compute(attribute, base_value, slot)
+            })
+    }
+
+    /// Vanilla `Mob.canReplaceEqualItem`: the tiebreak when two pieces grade out
+    /// equally, favoring more enchantments, then less damage, then a custom name.
+    fn can_replace_equal_item(
+        &self,
+        new_item_stack: &ItemStack,
+        current_item_stack: &ItemStack,
+    ) -> bool {
+        let new_enchantments = new_item_stack
+            .get_enchantments()
+            .map_or(0, ItemEnchantments::len);
+        let current_enchantments = current_item_stack
+            .get_enchantments()
+            .map_or(0, ItemEnchantments::len);
+        if new_enchantments != current_enchantments {
+            return new_enchantments > current_enchantments;
+        }
+
+        let new_damage = new_item_stack.get_damage_value();
+        let current_damage = current_item_stack.get_damage_value();
+        if new_damage == current_damage {
+            new_item_stack.has(CUSTOM_NAME) && !current_item_stack.has(CUSTOM_NAME)
+        } else {
+            new_damage < current_damage
+        }
     }
 
     /// Vanilla `Mob.aiStep` looting loop: while this mob may pick up loot and the
@@ -1187,7 +1387,19 @@ pub trait Mob: LivingEntity + Leashable {
         self.tick_move_control();
         self.tick_look_control();
         self.tick_jump_control();
+    }
+
+    /// Vanilla `Mob.aiStep`: the `LivingEntity.aiStep` movement foundation followed
+    /// by the item-pickup looting loop.
+    ///
+    /// Looting lives here rather than in [`mob_server_ai_step`](Self::mob_server_ai_step)
+    /// because vanilla runs it from `aiStep`, not `serverAiStep`: a mob with
+    /// `NoAI` set still collects loot, so the looting must not sit behind the
+    /// `isEffectiveAi` gate that guards the goal/navigation ticks.
+    fn mob_ai_step(&self) -> Option<MoveResult> {
+        let result = self.default_ai_step();
         self.tick_looting();
+        result
     }
 
     fn tick_path_navigation(&self) {

--- a/steel-core/src/entity/mob/mod.rs
+++ b/steel-core/src/entity/mob/mod.rs
@@ -613,6 +613,9 @@ pub trait Mob: LivingEntity + Leashable {
         }
 
         let count = equipped.count();
+        // TODO(advancements): vanilla calls LivingEntity.onItemPickup here, before
+        // the take packet, which fires the THROWN_ITEM_PICKED_UP_BY_ENTITY criterion.
+        // Add that once Steel has the advancement-criteria foundation.
         let chunk_pos = ChunkPos::from_entity_pos(item_entity.position());
         world.broadcast_to_nearby(
             chunk_pos,

--- a/steel-core/src/entity/mob/tests.rs
+++ b/steel-core/src/entity/mob/tests.rs
@@ -9,7 +9,7 @@ use steel_registry::{
     REGISTRY, init_vanilla_registry, vanilla_attributes, vanilla_blocks, vanilla_damage_types,
 };
 use steel_utils::locks::SyncMutex;
-use steel_utils::{BlockPos, BlockStateId, ChunkPos};
+use steel_utils::{BlockPos, BlockStateId, ChunkPos, Downcast as _, Identifier};
 
 use super::{
     can_attempt_equipment_drop, find_ground_path_target_surface, path_end_node_can_reach_target,
@@ -25,7 +25,7 @@ use crate::entity::entities::objects::items::ItemEntity;
 use crate::entity::leash::Leashable;
 use crate::entity::mob::{Mob, MobBase};
 use crate::entity::{
-    Entity, EntityBase, LivingEntity, LivingEntityBase, PathfinderMob, SharedEntity,
+    Entity, EntityBase, LivingEntity, LivingEntityBase, PathfinderMob, SharedEntity, next_entity_id,
 };
 use crate::inventory::equipment::EquipmentSlot;
 use crate::test_support::{fresh_test_world, insert_ready_full_chunk, test_world};
@@ -777,6 +777,64 @@ fn looting_collects_nearby_item_into_main_hand() {
 }
 
 #[test]
+fn looting_runs_through_ai_step_even_with_no_ai() {
+    // Vanilla runs the looting loop from `Mob.aiStep`, not `serverAiStep`, so a
+    // mob with `NoAI` set still collects loot. Drive the real `mob_ai_step` path
+    // (rather than calling `tick_looting` directly) to guard against the looting
+    // regressing behind the `isEffectiveAi` gate that skips the goal ticks.
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("mob_looting_no_ai");
+    insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+
+    let mob = Arc::new(PigEntity::new(
+        &vanilla_entities::PIG,
+        1,
+        DVec3::new(8.0, 65.0, 8.0),
+        Arc::downgrade(&world),
+    ));
+    mob.set_can_pick_up_loot(true);
+    mob.set_no_ai(true);
+    assert!(
+        !mob.is_effective_ai(),
+        "a NoAI mob should not be effective-ai"
+    );
+
+    let item = Arc::new(ItemEntity::with_item(
+        &vanilla_entities::ITEM,
+        2,
+        DVec3::new(8.0, 65.0, 8.0),
+        ItemStack::new(&vanilla_items::STONE),
+        Arc::downgrade(&world),
+    ));
+    item.set_no_pickup_delay();
+
+    for entity in [
+        Arc::clone(&mob) as SharedEntity,
+        Arc::clone(&item) as SharedEntity,
+    ] {
+        world
+            .try_add_entity(entity)
+            .expect("test entity should attach to the loaded chunk");
+    }
+
+    Mob::mob_ai_step(mob.as_ref());
+
+    assert!(
+        item.is_removed(),
+        "a NoAI mob should still pick up loot through aiStep"
+    );
+    let mut held_is_stone = false;
+    mob.with_equipment_slot(EquipmentSlot::MainHand, &mut |item_stack| {
+        held_is_stone = item_stack.is(&vanilla_items::STONE);
+    });
+    assert!(
+        held_is_stone,
+        "the NoAI mob should now hold the picked-up item in its main hand"
+    );
+}
+
+#[test]
 fn looting_skips_when_mob_cannot_pick_up_loot() {
     init_vanilla_registry();
     init_behaviors();
@@ -852,6 +910,238 @@ fn pick_up_item_leaves_an_occupied_main_hand_untouched() {
     assert!(
         still_holding_spear,
         "an existing main-hand item must not be replaced"
+    );
+}
+
+#[test]
+fn equip_routes_armor_to_its_armor_slot() {
+    init_vanilla_registry();
+    let mob = DespawnTestMob::new(None, false);
+
+    let equipped = Mob::equip_item_if_possible(&mob, ItemStack::new(&vanilla_items::IRON_HELMET));
+
+    assert!(
+        equipped.is(&vanilla_items::IRON_HELMET),
+        "the helmet should be reported as equipped"
+    );
+    let mut head_is_helmet = false;
+    mob.with_equipment_slot(EquipmentSlot::Head, &mut |item_stack| {
+        head_is_helmet = item_stack.is(&vanilla_items::IRON_HELMET);
+    });
+    assert!(
+        head_is_helmet,
+        "an equippable helmet should route to the head slot, not the main hand"
+    );
+    assert!(
+        !mob.has_item_in_slot(EquipmentSlot::MainHand),
+        "the main hand should stay empty"
+    );
+}
+
+#[test]
+fn equip_replaces_worse_armor_and_drops_the_old_piece() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("mob_equip_upgrade");
+    insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+
+    let mob = Arc::new(PigEntity::new(
+        &vanilla_entities::PIG,
+        next_entity_id(),
+        DVec3::new(8.0, 65.0, 8.0),
+        Arc::downgrade(&world),
+    ));
+    world
+        .try_add_entity(Arc::clone(&mob) as SharedEntity)
+        .expect("test mob should attach to the loaded chunk");
+
+    // Wear a leather helmet and force it to always drop, so the swap is
+    // deterministic rather than riding on the drop-chance roll.
+    mob.living_base().equipment().lock().set(
+        EquipmentSlot::Head,
+        ItemStack::new(&vanilla_items::LEATHER_HELMET),
+    );
+    mob.set_guaranteed_drop(EquipmentSlot::Head);
+
+    let equipped =
+        Mob::equip_item_if_possible(mob.as_ref(), ItemStack::new(&vanilla_items::DIAMOND_HELMET));
+
+    assert!(
+        equipped.is(&vanilla_items::DIAMOND_HELMET),
+        "the stronger helmet should be equipped"
+    );
+    let mut head_is_diamond = false;
+    mob.with_equipment_slot(EquipmentSlot::Head, &mut |item_stack| {
+        head_is_diamond = item_stack.is(&vanilla_items::DIAMOND_HELMET);
+    });
+    assert!(head_is_diamond, "the head slot should now hold diamond");
+
+    let dropped = world
+        .get_entities_in_aabb(&mob.bounding_box().inflate_xyz(4.0, 4.0, 4.0))
+        .into_iter()
+        .filter_map(|entity| {
+            entity
+                .downcast_ref::<ItemEntity>()
+                .map(|item| item.get_item().is(&vanilla_items::LEATHER_HELMET))
+        })
+        .any(|is_leather_helmet| is_leather_helmet);
+    assert!(
+        dropped,
+        "the replaced leather helmet should have been dropped nearby"
+    );
+}
+
+#[test]
+fn equip_carries_worse_armor_in_a_free_hand() {
+    // Vanilla: armor that is not an upgrade still gets carried in an empty main
+    // hand rather than being ignored.
+    init_vanilla_registry();
+    let mob = DespawnTestMob::new(None, false);
+    mob.living_base().equipment().lock().set(
+        EquipmentSlot::Head,
+        ItemStack::new(&vanilla_items::DIAMOND_HELMET),
+    );
+
+    let equipped =
+        Mob::equip_item_if_possible(&mob, ItemStack::new(&vanilla_items::LEATHER_HELMET));
+
+    assert!(
+        equipped.is(&vanilla_items::LEATHER_HELMET),
+        "the worse helmet should still be taken into the free hand"
+    );
+    let mut head_is_diamond = false;
+    mob.with_equipment_slot(EquipmentSlot::Head, &mut |item_stack| {
+        head_is_diamond = item_stack.is(&vanilla_items::DIAMOND_HELMET);
+    });
+    assert!(
+        head_is_diamond,
+        "the worn diamond helmet must not be swapped out"
+    );
+    let mut hand_is_leather = false;
+    mob.with_equipment_slot(EquipmentSlot::MainHand, &mut |item_stack| {
+        hand_is_leather = item_stack.is(&vanilla_items::LEATHER_HELMET);
+    });
+    assert!(
+        hand_is_leather,
+        "the leather helmet should be carried in the main hand"
+    );
+}
+
+#[test]
+fn equip_rejects_worse_armor_when_the_hands_are_full() {
+    init_vanilla_registry();
+    let mob = DespawnTestMob::new(None, false);
+    mob.living_base().equipment().lock().set(
+        EquipmentSlot::Head,
+        ItemStack::new(&vanilla_items::DIAMOND_HELMET),
+    );
+    mob.living_base().equipment().lock().set(
+        EquipmentSlot::MainHand,
+        ItemStack::new(&vanilla_items::STONE),
+    );
+
+    let equipped =
+        Mob::equip_item_if_possible(&mob, ItemStack::new(&vanilla_items::LEATHER_HELMET));
+
+    assert!(
+        equipped.is_empty(),
+        "worse armor with no free hand should not be taken"
+    );
+    let mut head_is_diamond = false;
+    mob.with_equipment_slot(EquipmentSlot::Head, &mut |item_stack| {
+        head_is_diamond = item_stack.is(&vanilla_items::DIAMOND_HELMET);
+    });
+    assert!(head_is_diamond, "the worn diamond helmet must be untouched");
+    let mut hand_is_stone = false;
+    mob.with_equipment_slot(EquipmentSlot::MainHand, &mut |item_stack| {
+        hand_is_stone = item_stack.is(&vanilla_items::STONE);
+    });
+    assert!(hand_is_stone, "the occupied main hand must be untouched");
+}
+
+#[test]
+fn equip_respects_prevent_armor_change_on_worn_gear() {
+    init_vanilla_registry();
+    let mob = DespawnTestMob::new(None, false);
+    let mut bound_helmet = ItemStack::new(&vanilla_items::DIAMOND_HELMET);
+    bound_helmet.set_enchantments(&[(Identifier::vanilla_static("binding_curse"), 1)], false);
+    mob.living_base()
+        .equipment()
+        .lock()
+        .set(EquipmentSlot::Head, bound_helmet);
+    // Block the main-hand fallback so we test the armor slot in isolation.
+    mob.living_base().equipment().lock().set(
+        EquipmentSlot::MainHand,
+        ItemStack::new(&vanilla_items::STONE),
+    );
+
+    let equipped =
+        Mob::equip_item_if_possible(&mob, ItemStack::new(&vanilla_items::NETHERITE_HELMET));
+
+    assert!(
+        equipped.is_empty(),
+        "a curse-of-binding helmet must not be swapped out even for stronger armor"
+    );
+    let mut head_is_diamond = false;
+    mob.with_equipment_slot(EquipmentSlot::Head, &mut |item_stack| {
+        head_is_diamond = item_stack.is(&vanilla_items::DIAMOND_HELMET);
+    });
+    assert!(head_is_diamond, "the bound helmet must stay on");
+}
+
+#[test]
+fn pick_up_item_takes_one_from_a_stack_and_leaves_the_rest() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("mob_equip_partial");
+    insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+
+    let mob = Arc::new(PigEntity::new(
+        &vanilla_entities::PIG,
+        1,
+        DVec3::new(8.0, 65.0, 8.0),
+        Arc::downgrade(&world),
+    ));
+    mob.set_can_pick_up_loot(true);
+
+    // Three helmets in one stack: the head slot only holds one, so the source
+    // should shrink to two rather than being wholly consumed.
+    let item = Arc::new(ItemEntity::with_item(
+        &vanilla_entities::ITEM,
+        2,
+        DVec3::new(8.0, 65.0, 8.0),
+        ItemStack::new(&vanilla_items::IRON_HELMET).copy_with_count(3),
+        Arc::downgrade(&world),
+    ));
+    item.set_no_pickup_delay();
+
+    for entity in [
+        Arc::clone(&mob) as SharedEntity,
+        Arc::clone(&item) as SharedEntity,
+    ] {
+        world
+            .try_add_entity(entity)
+            .expect("test entity should attach to the loaded chunk");
+    }
+
+    Mob::pick_up_item(mob.as_ref(), &world, &item);
+
+    assert!(
+        !item.is_removed(),
+        "the item entity should survive when only part of the stack is taken"
+    );
+    assert_eq!(
+        item.get_item().count(),
+        2,
+        "the source stack should shrink by the single equipped helmet"
+    );
+    let mut head_is_helmet = false;
+    mob.with_equipment_slot(EquipmentSlot::Head, &mut |item_stack| {
+        head_is_helmet = item_stack.is(&vanilla_items::IRON_HELMET) && item_stack.count() == 1;
+    });
+    assert!(
+        head_is_helmet,
+        "the mob should be wearing exactly one of the helmets"
     );
 }
 

--- a/steel-core/src/entity/mob/tests.rs
+++ b/steel-core/src/entity/mob/tests.rs
@@ -9,7 +9,7 @@ use steel_registry::{
     REGISTRY, init_vanilla_registry, vanilla_attributes, vanilla_blocks, vanilla_damage_types,
 };
 use steel_utils::locks::SyncMutex;
-use steel_utils::{BlockPos, BlockStateId};
+use steel_utils::{BlockPos, BlockStateId, ChunkPos};
 
 use super::{
     can_attempt_equipment_drop, find_ground_path_target_surface, path_end_node_can_reach_target,
@@ -20,12 +20,15 @@ use crate::entity::ai::goal::GoalControl;
 use crate::entity::ai::node::Node;
 use crate::entity::ai::path::{Path, PathType};
 use crate::entity::damage::DamageSource;
+use crate::entity::entities::PigEntity;
+use crate::entity::entities::objects::items::ItemEntity;
 use crate::entity::leash::Leashable;
 use crate::entity::mob::{Mob, MobBase};
 use crate::entity::{
     Entity, EntityBase, LivingEntity, LivingEntityBase, PathfinderMob, SharedEntity,
 };
-use crate::test_support::test_world;
+use crate::inventory::equipment::EquipmentSlot;
+use crate::test_support::{fresh_test_world, insert_ready_full_chunk, test_world};
 use crate::world::{LevelReader, World};
 
 #[test]
@@ -718,6 +721,138 @@ fn mob_home_restriction_uses_vanilla_radius() {
     mob.clear_home();
     assert!(!mob.has_home());
     assert!(mob.is_within_home_pos(BlockPos::new(1000, 64, 1000)));
+}
+
+#[test]
+fn looting_collects_nearby_item_into_main_hand() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("mob_looting_pickup");
+    insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+
+    let mob = Arc::new(PigEntity::new(
+        &vanilla_entities::PIG,
+        1,
+        DVec3::new(8.0, 65.0, 8.0),
+        Arc::downgrade(&world),
+    ));
+    mob.set_can_pick_up_loot(true);
+
+    let item = Arc::new(ItemEntity::with_item(
+        &vanilla_entities::ITEM,
+        2,
+        DVec3::new(8.0, 65.0, 8.0),
+        ItemStack::new(&vanilla_items::STONE),
+        Arc::downgrade(&world),
+    ));
+    item.set_no_pickup_delay();
+
+    for entity in [
+        Arc::clone(&mob) as SharedEntity,
+        Arc::clone(&item) as SharedEntity,
+    ] {
+        world
+            .try_add_entity(entity)
+            .expect("test entity should attach to the loaded chunk");
+    }
+
+    Mob::tick_looting(mob.as_ref());
+
+    assert!(
+        item.is_removed(),
+        "the picked-up item entity should be discarded"
+    );
+    let mut held_is_stone = false;
+    mob.with_equipment_slot(EquipmentSlot::MainHand, &mut |item_stack| {
+        held_is_stone = item_stack.is(&vanilla_items::STONE);
+    });
+    assert!(
+        held_is_stone,
+        "the mob should now hold the picked-up item in its main hand"
+    );
+    assert!(
+        mob.is_equipment_drop_preserved(EquipmentSlot::MainHand),
+        "picked-up gear should always drop on death"
+    );
+}
+
+#[test]
+fn looting_skips_when_mob_cannot_pick_up_loot() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("mob_looting_disabled");
+    insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+
+    // A mob leaves `canPickUpLoot` off by default, so it should ignore the item.
+    let mob = Arc::new(PigEntity::new(
+        &vanilla_entities::PIG,
+        1,
+        DVec3::new(8.0, 65.0, 8.0),
+        Arc::downgrade(&world),
+    ));
+
+    let item = Arc::new(ItemEntity::with_item(
+        &vanilla_entities::ITEM,
+        2,
+        DVec3::new(8.0, 65.0, 8.0),
+        ItemStack::new(&vanilla_items::STONE),
+        Arc::downgrade(&world),
+    ));
+    item.set_no_pickup_delay();
+
+    for entity in [
+        Arc::clone(&mob) as SharedEntity,
+        Arc::clone(&item) as SharedEntity,
+    ] {
+        world
+            .try_add_entity(entity)
+            .expect("test entity should attach to the loaded chunk");
+    }
+
+    Mob::tick_looting(mob.as_ref());
+
+    assert!(
+        !item.is_removed(),
+        "the item should remain when the mob cannot pick up loot"
+    );
+    assert!(
+        !mob.has_item_in_slot(EquipmentSlot::MainHand),
+        "the mob should not have grabbed anything"
+    );
+}
+
+#[test]
+fn pick_up_item_leaves_an_occupied_main_hand_untouched() {
+    init_vanilla_registry();
+    let mob = DespawnTestMob::new(None, false);
+    mob.living_base().equipment().lock().set(
+        EquipmentSlot::MainHand,
+        ItemStack::new(&vanilla_items::WOODEN_SPEAR),
+    );
+
+    let item = ItemEntity::with_item(
+        &vanilla_entities::ITEM,
+        2,
+        DVec3::ZERO,
+        ItemStack::new(&vanilla_items::STONE),
+        Weak::<World>::new(),
+    );
+    item.set_no_pickup_delay();
+
+    Mob::pick_up_item(&mob, test_world(), &item);
+
+    assert!(
+        !item.is_removed(),
+        "the item should be left alone when the main hand is full"
+    );
+    let mut still_holding_spear = false;
+    mob.with_equipment_slot(EquipmentSlot::MainHand, &mut |item_stack| {
+        still_holding_spear = item_stack.is(&vanilla_items::WOODEN_SPEAR);
+    });
+    assert!(
+        still_holding_spear,
+        "an existing main-hand item must not be replaced"
+    );
 }
 
 #[test]

--- a/steel-core/src/entity/mob/tests.rs
+++ b/steel-core/src/entity/mob/tests.rs
@@ -4,6 +4,7 @@ use glam::DVec3;
 use steel_registry::entity_type::EntityTypeRef;
 use steel_registry::item_stack::ItemStack;
 use steel_registry::vanilla_entities;
+use steel_registry::vanilla_item_tags::ItemTag;
 use steel_registry::vanilla_items;
 use steel_registry::{
     REGISTRY, init_vanilla_registry, vanilla_attributes, vanilla_blocks, vanilla_damage_types,
@@ -89,6 +90,7 @@ struct DespawnTestMob {
     nearest_player_distance_sqr: Option<f64>,
     remove_when_far_away: bool,
     controlling_passenger: SyncMutex<Option<SharedEntity>>,
+    preferred_weapon_type: SyncMutex<Option<Identifier>>,
 }
 
 impl DespawnTestMob {
@@ -135,7 +137,12 @@ impl DespawnTestMob {
             nearest_player_distance_sqr,
             remove_when_far_away,
             controlling_passenger: SyncMutex::new(None),
+            preferred_weapon_type: SyncMutex::new(None),
         }
+    }
+
+    fn set_preferred_weapon_type(&self, tag: Identifier) {
+        *self.preferred_weapon_type.lock() = Some(tag);
     }
 
     fn set_controlling_passenger(&self, passenger: SharedEntity) {
@@ -247,6 +254,10 @@ impl Mob for DespawnTestMob {
 
     fn nearest_player_distance_sqr(&self) -> Option<f64> {
         self.nearest_player_distance_sqr
+    }
+
+    fn get_preferred_weapon_type(&self) -> Option<Identifier> {
+        self.preferred_weapon_type.lock().clone()
     }
 }
 
@@ -1143,6 +1154,56 @@ fn pick_up_item_takes_one_from_a_stack_and_leaves_the_rest() {
         head_is_helmet,
         "the mob should be wearing exactly one of the helmets"
     );
+}
+
+#[test]
+fn equip_keeps_a_preferred_weapon_over_a_stronger_one() {
+    // A mob that favors a weapon type (like a skeleton with its bow) keeps it
+    // even when a higher-damage weapon of another type is picked up.
+    init_vanilla_registry();
+    let mob = DespawnTestMob::new(None, false);
+    mob.set_preferred_weapon_type(ItemTag::SKELETON_PREFERRED_WEAPONS);
+    mob.living_base()
+        .equipment()
+        .lock()
+        .set(EquipmentSlot::MainHand, ItemStack::new(&vanilla_items::BOW));
+
+    let equipped = Mob::equip_item_if_possible(&mob, ItemStack::new(&vanilla_items::DIAMOND_SWORD));
+
+    assert!(
+        equipped.is_empty(),
+        "a stronger sword should not displace the preferred bow"
+    );
+    let mut hand_is_bow = false;
+    mob.with_equipment_slot(EquipmentSlot::MainHand, &mut |item_stack| {
+        hand_is_bow = item_stack.is(&vanilla_items::BOW);
+    });
+    assert!(hand_is_bow, "the bow must stay in the main hand");
+}
+
+#[test]
+fn equip_takes_a_preferred_weapon_over_a_held_non_preferred_one() {
+    // The mirror case: the preferred weapon type wins even when it deals less
+    // damage than what is already held.
+    init_vanilla_registry();
+    let mob = DespawnTestMob::new(None, false);
+    mob.set_preferred_weapon_type(ItemTag::SKELETON_PREFERRED_WEAPONS);
+    mob.living_base().equipment().lock().set(
+        EquipmentSlot::MainHand,
+        ItemStack::new(&vanilla_items::STONE_SWORD),
+    );
+
+    let equipped = Mob::equip_item_if_possible(&mob, ItemStack::new(&vanilla_items::BOW));
+
+    assert!(
+        equipped.is(&vanilla_items::BOW),
+        "the preferred bow should replace the held sword"
+    );
+    let mut hand_is_bow = false;
+    mob.with_equipment_slot(EquipmentSlot::MainHand, &mut |item_stack| {
+        hand_is_bow = item_stack.is(&vanilla_items::BOW);
+    });
+    assert!(hand_is_bow, "the bow should now be held");
 }
 
 #[test]

--- a/steel-registry/src/data_components/components/attribute_modifiers.rs
+++ b/steel-registry/src/data_components/components/attribute_modifiers.rs
@@ -49,6 +49,25 @@ impl ItemAttributeModifiers {
             .iter()
             .filter(move |entry| entry.slot.test(slot))
     }
+
+    /// Vanilla `ItemAttributeModifiers.compute`: fold the modifiers this item
+    /// grants for `attribute` in `slot` onto `base_value`, applying each entry's
+    /// operation. Used to approximate the attribute value an entity would have if
+    /// it wore the stack in that slot.
+    #[must_use]
+    pub fn compute(&self, attribute: AttributeRef, base_value: f64, slot: EquipmentSlot) -> f64 {
+        let mut value = base_value;
+        for entry in &self.modifiers {
+            if entry.slot.test(slot) && entry.attribute.key == attribute.key {
+                value += match entry.operation {
+                    AttributeModifierOperation::AddValue => entry.amount,
+                    AttributeModifierOperation::AddMultipliedBase => entry.amount * base_value,
+                    AttributeModifierOperation::AddMultipliedTotal => entry.amount * value,
+                };
+            }
+        }
+        value
+    }
 }
 
 impl Default for ItemAttributeModifiers {

--- a/steel-registry/src/equipment.rs
+++ b/steel-registry/src/equipment.rs
@@ -1,5 +1,6 @@
 //! Shared equipment slot definitions.
 
+use crate::item_stack::ItemStack;
 use steel_utils::entity_events::EntityStatus;
 
 /// Equipment slot types for categorization.
@@ -121,6 +122,29 @@ impl EquipmentSlot {
             6 => EquipmentSlot::Body,
             7 => EquipmentSlot::Saddle,
             _ => EquipmentSlot::MainHand,
+        }
+    }
+
+    /// Returns vanilla `EquipmentSlot.countLimit`: the maximum stack size this
+    /// slot will hold, or `0` for no limit. Hand slots are unlimited; armor,
+    /// body, and saddle slots hold a single item.
+    #[must_use]
+    pub const fn count_limit(self) -> i32 {
+        match self.slot_type() {
+            EquipmentSlotType::Hand => 0,
+            _ => 1,
+        }
+    }
+
+    /// Returns vanilla `EquipmentSlot.limit`: splits `to_equip` down to this
+    /// slot's [`count_limit`](Self::count_limit), leaving the remainder in place.
+    /// An unlimited slot takes the whole stack.
+    pub fn limit(self, to_equip: &mut ItemStack) -> ItemStack {
+        let count_limit = self.count_limit();
+        if count_limit > 0 {
+            to_equip.split(count_limit)
+        } else {
+            to_equip.split(to_equip.count())
         }
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [x] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

Adds the vanilla fox passive mob (MC 26.2).

Foxes are animals that:

* Come in a red or snow coat, chosen from the biome they spawn in
* Eat and breed with sweet berries, with the kit inheriting one parent's coat
* Carry a single item in the mouth, spitting out what they held and swapping a trinket for food
* Chew over the food they carry and swallow it, effects and all
* Sleep under cover by day, sit and look around, and screech at night when nobody is near

The entity follows the existing `CowEntity` stack and includes the synced variant, the vanilla behaviour-flag byte (sitting, crouching, interested, pouncing, sleeping, faceplanted, defending), the two trusted-player slots, the fox sounds, a 0.6 baby scale, and the sweet-berry food tag. Persistence round-trips the variant, the trusted players, and the sleeping, sitting, and crouching state.

On top of the item-pickup foundation from #511 the fox carries one item in its mouth, spits out the old one and drops any extra when it grabs another, and swaps a held non-food item for food once its feeding timer has run. After half a minute of carrying that food it chews over it and swallows it, so a fox that picked up a chorus fruit teleports and one that drank a honey bottle is left holding the bottle.

Since the last review this branch also covers:

* `Fox.checkFoxSpawnRules`: foxes want their own ground, the snow, grass and podzol of the forests they live in, rather than the wider set every other animal spawns on. Sand passes the general rule and fails this one
* The server half of `Fox.tick`: water, something to chase, or a thunderstorm ends a nap; a fox stops sitting up once it is wet or asleep; and a fox that has landed face-down keeps kicking up the block it is stuck in
* The five fox goal subclasses vanilla registers, replacing the stock goals the fox was borrowing. Each wraps the shared goal and adds only what the fox changes:
  * `FoxFloatGoal` starts swimming once the water is a quarter of a block deep, rather than waiting for the depth that makes most mobs jump
  * `FoxPanicGoal` and `FoxFollowParentGoal` hold their ground while the fox is defending something it trusts
  * `FoxBreedGoal`, `FoxFloatGoal` and `FoxFollowParentGoal` clear whatever the fox was in the middle of as they start, so it cannot court while asleep or swim while sat down. Courting clears both foxes
  * `FoxLookAtPlayerGoal` does not break off to watch a player while the fox is stalking something or lying face-down

* A few more `Fox` details: the sleep goal clears every state when it ends, stops the fox jumping and holds its move control in place when it starts, and a sleeping fox gets no movement input, as in `aiStep`. A dispenser can only fill the mouth slot, loading replaces the trusted list, and the item search stops chasing once the mouth is full

The hunting, avoid, and defend goals live in the stacked follow-ups, described under Additional notes.

## How this was tested

Unit tests cover the default red variant, item pickup and vanilla health, variant round-tripping, the behaviour flags sharing one byte independently, the sweet-berry food tag, variant and state and trusted-player persistence (loading replaces the trusted list rather than adding to it), a kit taking either parent's variant, the mouth-carry swap rules, spitting the held item out to grab another, a spawned fox holding one of the vanilla candidate items, the search goal standing down with a full mouth and going after an item once the mouth is empty, the sleep goal staying usable while asleep and clearing every pose when it ends, and a dispenser only filling the mouth slot.

Eating has its own tests: swallowing on time and not before, keeping the leftover bottle, holding a trinket forever, and not eating while asleep, in mid-air, or chasing something.

The newer behaviour is covered too: the fox's spawn rule across its ground tag and light gates including the spawner case, a sleeping fox woken by prey and not by a quiet night, clearing every state flag at once, a baby fox with mob drops off still dropping its mouth item on death, and the fox floating at a depth where the shared float goal declines while the fox's own accepts, which pins the difference between them rather than just the fox's own answer.

The faceplant particle is the one part driven but not asserted: it goes out as a level event, which only reaches a watching client, so there is nothing server-side to observe. The test exercises that path and asserts the sleeping and sitting rules around it.

`cargo fmt --all --check`, `RUSTFLAGS="-Dwarnings" cargo clippy -r --all-targets --all-features`, `typos` and `RUSTFLAGS="-Dwarnings" cargo test` all pass.

## Screenshots / logs

Not applicable. Server-side entity logic is covered by the unit tests above.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes modified:

Fox

## Additional notes

A few things are worth sanity-checking during review. These are not firm proposals.

* **Eating goes through the item's own behaviour.** Steel's item behaviours return the stack the slot should end up with, so the fox writes that result straight back into its mouth. Vanilla shrinks the held stack in place and therefore only writes back a leftover, which is why the `if (!remainingFood.isEmpty())` guard has no counterpart here.
* **The mouth item now persists for free.** Since #582 moved `save_equipment` and `load_equipment` into `save_mob` and `load_mob`, the fox's held item survives chunk and vehicle saves without the fox saving anything itself, which matches vanilla's `HandItems`. Rebasing onto current master is what picked that up.
* **The fox checks light unconditionally.** The shared animal rule waives the light check for spawners; vanilla's fox rule does not, the same way the turtle's does not. Nothing drives natural spawning in the tree yet, so the rule is exercised by its test rather than in play, as the shared rule it replaces already is.
* **`BreedGoal` gained a `partner()` accessor.** Vanilla's `FoxBreedGoal.start` clears the states of both foxes, which needs the shared goal to say who it paired with. One small read-only accessor rather than a behaviour change.
* **The variant-dependent target priorities do not need a `remove_goal`.** Vanilla's `setTargetGoals` only ever adds, and its goal set ignores a second add of the same goal, so the first registration wins. The stalk PR (#603) registers the prey targeting once from `finalize_spawn` and `load_additional` at the coat's priority.

Deferred: `FoxEatBerriesGoal`, which is picking berries off a sweet berry bush and off cave vines rather than the held-item path, in its own PR. `FoxStrollThroughVillageGoal` waits on village POI, and the wolf, polar bear, rabbit and schooling-fish goals wait on those mobs. Each carries a TODO at its vanilla priority.


