### PR TITLE
feat: implement area effect cloud entity

### DIFF
--- a/steel-core/src/entity/base/mod.rs
+++ b/steel-core/src/entity/base/mod.rs
@@ -511,6 +511,11 @@ impl EntityBase {
         self.state.lock().tick_count
     }
 
+    /// Sets vanilla `Entity.tickCount`.
+    pub fn set_tick_count(&self, tick_count: i32) {
+        self.state.lock().tick_count = tick_count;
+    }
+
     /// Gets the entity's current bounding box.
     #[inline]
     pub fn bounding_box(&self) -> WorldAabb {

--- a/steel-core/src/entity/entities/mod.rs
+++ b/steel-core/src/entity/entities/mod.rs
@@ -6,6 +6,7 @@ mod raw;
 
 pub use mobs::hostile::EndermiteEntity;
 pub use mobs::passive::{ChickenEntity, CowEntity, PigEntity, SheepEntity};
+pub use objects::AreaEffectCloudEntity;
 pub use objects::display_ui::{BlockDisplayEntity, ItemFrameEntity, LeashFenceKnotEntity};
 pub use objects::explosives::EndCrystalEntity;
 pub use objects::items::{ExperienceOrbEntity, FallingBlockEntity, ItemEntity};

--- a/steel-core/src/entity/entities/objects/area_effect_cloud.rs
+++ b/steel-core/src/entity/entities/objects/area_effect_cloud.rs
@@ -1,0 +1,807 @@
+//! Area effect cloud entity (`AreaEffectCloud`).
+//!
+//! The server owns wait/duration, radius growth, potion application, and
+//! reapplication tracking. Cloud particles are created by the client from
+//! synchronized radius, waiting, and particle data.
+
+use std::sync::Weak;
+
+use glam::DVec3;
+use rustc_hash::FxHashMap;
+use simdnbt::ToNbtTag;
+use simdnbt::borrow::NbtCompound as BorrowedNbtCompoundView;
+use simdnbt::owned::{NbtCompound, NbtTag};
+use steel_macros::entity_behavior;
+use steel_registry::data_components::PotionContents;
+use steel_registry::data_components::vanilla_components::{POTION_CONTENTS, POTION_DURATION_SCALE};
+use steel_registry::entity_data::EntityPose;
+use steel_registry::entity_type::{EntityDimensions, EntityTypeRef};
+use steel_registry::item_stack::ItemStack;
+use steel_registry::mob_effect_instance::MobEffectInstance as RegistryMobEffectInstance;
+use steel_registry::particle_type::{ColorParticleOption, ParticleData};
+use steel_registry::vanilla_entity_data::AreaEffectCloudEntityData;
+use steel_registry::vanilla_particle_types;
+use steel_utils::ArgbColor;
+use steel_utils::locks::SyncMutex;
+use steel_utils::{DowncastType, DowncastTypeKey, UuidExt};
+use uuid::Uuid;
+
+use crate::entity::{
+    Entity, EntityBase, EntityBaseLoad, EntitySyncedData, LivingEntity, MobEffectInstance,
+    RemovalReason, SharedEntity,
+};
+use crate::world::World;
+
+const TIME_BETWEEN_APPLICATIONS: i32 = 5;
+const MAX_RADIUS: f32 = 32.0;
+const MINIMAL_RADIUS: f32 = 0.5;
+const DEFAULT_RADIUS: f32 = 3.0;
+const HEIGHT: f32 = 0.5;
+const INFINITE_DURATION: i32 = -1;
+const DEFAULT_WAIT_TIME: i32 = 20;
+const DEFAULT_REAPPLICATION_DELAY: i32 = 20;
+const DEFAULT_DURATION_ON_USE: i32 = 0;
+const DEFAULT_RADIUS_ON_USE: f32 = 0.0;
+const DEFAULT_RADIUS_PER_TICK: f32 = 0.0;
+const DEFAULT_POTION_DURATION_SCALE: f32 = 1.0;
+const INSTANTANEOUS_EFFECT_SCALE: f64 = 0.5;
+
+struct AreaEffectCloudState {
+    potion_contents: PotionContents,
+    potion_duration_scale: f32,
+    custom_particle: Option<ParticleData>,
+    victims: FxHashMap<i32, i32>,
+    duration: i32,
+    wait_time: i32,
+    reapplication_delay: i32,
+    duration_on_use: i32,
+    radius_on_use: f32,
+    radius_per_tick: f32,
+    owner: Option<Uuid>,
+}
+
+impl AreaEffectCloudState {
+    fn new() -> Self {
+        Self {
+            potion_contents: PotionContents::empty(),
+            potion_duration_scale: DEFAULT_POTION_DURATION_SCALE,
+            custom_particle: None,
+            victims: FxHashMap::default(),
+            duration: INFINITE_DURATION,
+            wait_time: DEFAULT_WAIT_TIME,
+            reapplication_delay: DEFAULT_REAPPLICATION_DELAY,
+            duration_on_use: DEFAULT_DURATION_ON_USE,
+            radius_on_use: DEFAULT_RADIUS_ON_USE,
+            radius_per_tick: DEFAULT_RADIUS_PER_TICK,
+            owner: None,
+        }
+    }
+}
+
+/// Vanilla area-effect cloud entity.
+#[entity_behavior(class = "AreaEffectCloud")]
+pub struct AreaEffectCloudEntity {
+    base: EntityBase,
+    entity_type: EntityTypeRef,
+    entity_data: SyncMutex<AreaEffectCloudEntityData>,
+    state: SyncMutex<AreaEffectCloudState>,
+}
+
+// SAFETY: This key is owned by Steel and uniquely identifies `AreaEffectCloudEntity`.
+unsafe impl DowncastType for AreaEffectCloudEntity {
+    const TYPE_KEY: DowncastTypeKey = DowncastTypeKey::new("steel:entity/area_effect_cloud");
+}
+
+impl AreaEffectCloudEntity {
+    /// Creates a new area-effect cloud for the entity factory.
+    #[must_use]
+    pub fn new(entity_type: EntityTypeRef, id: i32, position: DVec3, world: Weak<World>) -> Self {
+        let cloud = Self {
+            base: EntityBase::new(id, position, entity_type.dimensions, world),
+            entity_type,
+            entity_data: SyncMutex::new(AreaEffectCloudEntityData::new()),
+            state: SyncMutex::new(AreaEffectCloudState::new()),
+        };
+        cloud.set_no_physics(true);
+        cloud
+    }
+
+    /// Creates an area-effect cloud from saved base data.
+    #[must_use]
+    pub fn from_saved(entity_type: EntityTypeRef, load: EntityBaseLoad) -> Self {
+        let cloud = Self {
+            base: EntityBase::from_load(load, entity_type.dimensions),
+            entity_type,
+            entity_data: SyncMutex::new(AreaEffectCloudEntityData::new()),
+            state: SyncMutex::new(AreaEffectCloudState::new()),
+        };
+        cloud.set_no_physics(true);
+        cloud
+    }
+
+    /// Vanilla lingering-potion duration (`AreaEffectCloud.DEFAULT_LINGERING_DURATION`).
+    pub const DEFAULT_LINGERING_DURATION: i32 = 600;
+
+    /// Returns the synchronized cloud radius.
+    #[must_use]
+    pub fn radius(&self) -> f32 {
+        *self.entity_data.lock().radius.get()
+    }
+
+    /// Sets the synchronized cloud radius, matching vanilla `setRadius`.
+    pub fn set_radius(&self, radius: f32) {
+        self.entity_data
+            .lock()
+            .radius
+            .set(radius.clamp(0.0, MAX_RADIUS));
+        self.refresh_dimensions();
+    }
+
+    /// Returns whether the cloud is in its wait period.
+    #[must_use]
+    pub fn is_waiting(&self) -> bool {
+        *self.entity_data.lock().waiting.get()
+    }
+
+    /// Sets whether the cloud is waiting before applying effects.
+    pub fn set_waiting(&self, waiting: bool) {
+        self.entity_data.lock().waiting.set(waiting);
+    }
+
+    /// Returns the synchronized particle options.
+    #[must_use]
+    pub fn particle(&self) -> ParticleData {
+        self.entity_data.lock().particle.get().clone()
+    }
+
+    /// Returns the current potion contents.
+    #[must_use]
+    pub fn potion_contents(&self) -> PotionContents {
+        self.state.lock().potion_contents.clone()
+    }
+
+    /// Sets potion contents and refreshes the synchronized particle.
+    pub fn set_potion_contents(&self, contents: PotionContents) {
+        self.state.lock().potion_contents = contents;
+        self.update_particle();
+    }
+
+    /// Sets an optional custom particle, matching vanilla `setCustomParticle`.
+    pub fn set_custom_particle(&self, particle: Option<ParticleData>) {
+        self.state.lock().custom_particle = particle;
+        self.update_particle();
+    }
+
+    /// Adds a custom effect, matching vanilla `addEffect`.
+    pub fn add_effect(&self, effect: RegistryMobEffectInstance) {
+        let contents = self.state.lock().potion_contents.with_effect_added(effect);
+        self.set_potion_contents(contents);
+    }
+
+    /// Returns the potion duration scale.
+    #[must_use]
+    pub fn potion_duration_scale(&self) -> f32 {
+        self.state.lock().potion_duration_scale
+    }
+
+    /// Sets the potion duration scale.
+    pub fn set_potion_duration_scale(&self, scale: f32) {
+        self.state.lock().potion_duration_scale = scale;
+    }
+
+    /// Returns remaining duration in ticks, or `-1` for infinite.
+    #[must_use]
+    pub fn duration(&self) -> i32 {
+        self.state.lock().duration
+    }
+
+    /// Sets remaining duration in ticks, or `-1` for infinite.
+    pub fn set_duration(&self, duration: i32) {
+        self.state.lock().duration = duration;
+    }
+
+    /// Returns wait time before the cloud starts applying effects.
+    #[must_use]
+    pub fn wait_time(&self) -> i32 {
+        self.state.lock().wait_time
+    }
+
+    /// Sets wait time before the cloud starts applying effects.
+    pub fn set_wait_time(&self, wait_time: i32) {
+        self.state.lock().wait_time = wait_time;
+    }
+
+    /// Returns radius change applied when an entity is affected.
+    #[must_use]
+    pub fn radius_on_use(&self) -> f32 {
+        self.state.lock().radius_on_use
+    }
+
+    /// Sets radius change applied when an entity is affected.
+    pub fn set_radius_on_use(&self, radius_on_use: f32) {
+        self.state.lock().radius_on_use = radius_on_use;
+    }
+
+    /// Returns radius change applied each tick after waiting.
+    #[must_use]
+    pub fn radius_per_tick(&self) -> f32 {
+        self.state.lock().radius_per_tick
+    }
+
+    /// Sets radius change applied each tick after waiting.
+    pub fn set_radius_per_tick(&self, radius_per_tick: f32) {
+        self.state.lock().radius_per_tick = radius_per_tick;
+    }
+
+    /// Returns duration change applied when an entity is affected.
+    #[must_use]
+    pub fn duration_on_use(&self) -> i32 {
+        self.state.lock().duration_on_use
+    }
+
+    /// Sets duration change applied when an entity is affected.
+    pub fn set_duration_on_use(&self, duration_on_use: i32) {
+        self.state.lock().duration_on_use = duration_on_use;
+    }
+
+    /// Sets the living owner UUID, matching vanilla `setOwner`.
+    pub fn set_owner(&self, owner: Option<&dyn LivingEntity>) {
+        self.state.lock().owner = owner.map(Entity::uuid);
+    }
+
+    /// Sets the owner UUID directly.
+    pub fn set_owner_uuid(&self, owner: Option<Uuid>) {
+        self.state.lock().owner = owner;
+    }
+
+    /// Returns the owner UUID.
+    #[must_use]
+    pub fn owner_uuid(&self) -> Option<Uuid> {
+        self.state.lock().owner
+    }
+
+    /// Applies potion contents and duration scale from an item stack.
+    pub fn apply_components_from_item_stack(&self, stack: &ItemStack) {
+        if let Some(contents) = stack.get(POTION_CONTENTS).cloned() {
+            self.set_potion_contents(contents);
+        }
+        if let Some(&scale) = stack.get(POTION_DURATION_SCALE) {
+            self.set_potion_duration_scale(scale);
+        }
+    }
+
+    fn owner(&self) -> Option<SharedEntity> {
+        let uuid = self.state.lock().owner?;
+        let world = self.level()?;
+        let owner = world.get_entity_by_uuid(&uuid)?;
+        owner.as_living_entity()?;
+        Some(owner)
+    }
+
+    fn update_particle(&self) {
+        let state = self.state.lock();
+        let particle = if let Some(custom_particle) = &state.custom_particle {
+            custom_particle.clone()
+        } else {
+            ParticleData::new(
+                &vanilla_particle_types::ENTITY_EFFECT,
+                ColorParticleOption::new(ArgbColor::new(opaque_argb(
+                    state.potion_contents.color(),
+                ))),
+            )
+        };
+        drop(state);
+        self.entity_data.lock().particle.set(particle);
+    }
+
+    fn discard(&self) {
+        self.set_removed(RemovalReason::Discarded);
+    }
+
+    fn server_tick(&self) {
+        let Some(radius) = self.tick_lifetime() else {
+            return;
+        };
+        self.apply_effects_pulse(radius);
+    }
+
+    fn tick_lifetime(&self) -> Option<f32> {
+        let tick_count = self.tick_count();
+        let (duration, wait_time, radius_per_tick) = {
+            let state = self.state.lock();
+            (state.duration, state.wait_time, state.radius_per_tick)
+        };
+
+        if duration != INFINITE_DURATION && tick_count - wait_time >= duration {
+            self.discard();
+            return None;
+        }
+
+        let should_wait = tick_count < wait_time;
+        if self.is_waiting() != should_wait {
+            self.set_waiting(should_wait);
+        }
+        if should_wait {
+            return None;
+        }
+
+        let mut radius = self.radius();
+        if radius_per_tick != 0.0 {
+            radius += radius_per_tick;
+            if radius < MINIMAL_RADIUS {
+                self.discard();
+                return None;
+            }
+            self.set_radius(radius);
+        }
+
+        (tick_count % TIME_BETWEEN_APPLICATIONS == 0).then_some(radius)
+    }
+
+    fn apply_effects_pulse(&self, mut radius: f32) {
+        let tick_count = self.tick_count();
+        let (effects, reapplication_delay, radius_on_use, duration_on_use, has_effects) = {
+            let mut state = self.state.lock();
+            state.victims.retain(|_, expire_at| tick_count < *expire_at);
+            let has_effects = state.potion_contents.has_effects();
+            if !has_effects {
+                state.victims.clear();
+            }
+            (
+                state
+                    .potion_contents
+                    .effects_with_duration_scale(state.potion_duration_scale),
+                state.reapplication_delay,
+                state.radius_on_use,
+                state.duration_on_use,
+                has_effects,
+            )
+        };
+        if !has_effects {
+            return;
+        }
+
+        let Some(world) = self.level() else {
+            return;
+        };
+
+        let cloud_pos = self.position();
+        let entities = world.get_entities_in_aabb_matching(&self.bounding_box(), |entity| {
+            entity.as_living_entity().is_some()
+        });
+        for entity in entities {
+            let Some(living) = entity.as_living_entity() else {
+                continue;
+            };
+            if self.state.lock().victims.contains_key(&entity.id()) {
+                continue;
+            }
+            if !living.is_affected_by_potions() {
+                continue;
+            }
+            let living_effects = effects
+                .iter()
+                .map(MobEffectInstance::from_potion_contents)
+                .collect::<Vec<_>>();
+            if living_effects
+                .iter()
+                .all(|effect| !living.can_be_affected(effect))
+            {
+                continue;
+            }
+
+            let dx = living.position().x - cloud_pos.x;
+            let dz = living.position().z - cloud_pos.z;
+            if dx * dx + dz * dz > f64::from(radius * radius) {
+                continue;
+            }
+
+            self.state
+                .lock()
+                .victims
+                .insert(entity.id(), tick_count + reapplication_delay);
+
+            let owner = self.owner();
+            let owner_ref = owner.as_deref();
+            for (codec_effect, living_effect) in effects.iter().zip(living_effects) {
+                if codec_effect.effect().is_instantaneous() {
+                    living.apply_instantaneous_effect(
+                        &world,
+                        Some(self),
+                        owner_ref,
+                        codec_effect.effect(),
+                        codec_effect.amplifier(),
+                        INSTANTANEOUS_EFFECT_SCALE,
+                    );
+                } else {
+                    living.add_mob_effect(living_effect);
+                }
+            }
+
+            if radius_on_use != 0.0 {
+                radius += radius_on_use;
+                if radius < MINIMAL_RADIUS {
+                    self.discard();
+                    return;
+                }
+                self.set_radius(radius);
+            }
+
+            if duration_on_use != 0 {
+                let new_duration = {
+                    let mut state = self.state.lock();
+                    if state.duration == INFINITE_DURATION {
+                        continue;
+                    }
+                    state.duration += duration_on_use;
+                    state.duration
+                };
+                if new_duration <= 0 {
+                    self.discard();
+                    return;
+                }
+            }
+        }
+    }
+}
+
+const fn opaque_argb(color: i32) -> i32 {
+    (color as u32 | 0xFF00_0000) as i32
+}
+
+impl Entity for AreaEffectCloudEntity {
+    fn base(&self) -> &EntityBase {
+        &self.base
+    }
+
+    fn entity_type(&self) -> EntityTypeRef {
+        self.entity_type
+    }
+
+    fn tick(&self) {
+        self.default_tick();
+        self.server_tick();
+    }
+
+    fn dimensions_for_pose(&self, _pose: EntityPose) -> EntityDimensions {
+        EntityDimensions::scalable(self.radius() * 2.0, HEIGHT)
+    }
+
+    fn synced_data(&self) -> Option<&dyn EntitySyncedData> {
+        Some(&self.entity_data)
+    }
+
+    fn save_additional(&self, nbt: &mut NbtCompound) {
+        nbt.insert("Age", self.tick_count());
+        let state = self.state.lock();
+        nbt.insert("Duration", state.duration);
+        nbt.insert("WaitTime", state.wait_time);
+        nbt.insert("ReapplicationDelay", state.reapplication_delay);
+        nbt.insert("DurationOnUse", state.duration_on_use);
+        nbt.insert("RadiusOnUse", state.radius_on_use);
+        nbt.insert("RadiusPerTick", state.radius_per_tick);
+        nbt.insert("Radius", self.radius());
+        if let Some(custom_particle) = &state.custom_particle {
+            nbt.insert("custom_particle", custom_particle.to_nbt_tag_ref());
+        }
+        if let Some(owner) = state.owner {
+            nbt.insert("Owner", NbtTag::IntArray(owner.to_int_array().to_vec()));
+        }
+        if state.potion_contents != PotionContents::empty() {
+            nbt.insert(
+                "potion_contents",
+                state.potion_contents.clone().to_nbt_tag(),
+            );
+        }
+        if state.potion_duration_scale != DEFAULT_POTION_DURATION_SCALE {
+            nbt.insert("potion_duration_scale", state.potion_duration_scale);
+        }
+    }
+
+    fn load_additional(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
+        self.base.set_tick_count(nbt.int("Age").unwrap_or(0));
+        {
+            let mut state = self.state.lock();
+            state.duration = nbt.int("Duration").unwrap_or(INFINITE_DURATION);
+            state.wait_time = nbt.int("WaitTime").unwrap_or(DEFAULT_WAIT_TIME);
+            state.reapplication_delay = nbt
+                .int("ReapplicationDelay")
+                .unwrap_or(DEFAULT_REAPPLICATION_DELAY);
+            state.duration_on_use = nbt.int("DurationOnUse").unwrap_or(DEFAULT_DURATION_ON_USE);
+            state.radius_on_use = nbt.float("RadiusOnUse").unwrap_or(DEFAULT_RADIUS_ON_USE);
+            state.radius_per_tick = nbt
+                .float("RadiusPerTick")
+                .unwrap_or(DEFAULT_RADIUS_PER_TICK);
+            if let Some(owner) = nbt
+                .int_array("Owner")
+                .and_then(|arr| Uuid::from_int_array(&arr))
+            {
+                state.owner = Some(owner);
+            }
+        }
+
+        if let Some(particle) = nbt.compound("custom_particle").and_then(|compound| {
+            ParticleData::from_owned_nbt(&NbtTag::Compound(compound.to_owned()))
+        }) {
+            self.set_custom_particle(Some(particle));
+        }
+
+        let contents = nbt
+            .compound("potion_contents")
+            .and_then(|compound| {
+                PotionContents::from_owned_nbt(&NbtTag::Compound(compound.to_owned()))
+            })
+            .or_else(|| {
+                nbt.string("potion_contents").and_then(|value| {
+                    PotionContents::from_owned_nbt(&NbtTag::String(value.to_string().into()))
+                })
+            })
+            .unwrap_or_else(PotionContents::empty);
+        self.set_potion_contents(contents);
+
+        if let Some(scale) = nbt.float("potion_duration_scale") {
+            self.set_potion_duration_scale(scale);
+        }
+
+        self.set_radius(nbt.float("Radius").unwrap_or(DEFAULT_RADIUS));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::sync::{Arc, Weak};
+
+    use simdnbt::borrow::read_compound as read_borrowed_compound;
+    use steel_registry::RegistryReference;
+    use steel_registry::init_vanilla_registry;
+    use steel_registry::vanilla_entities;
+    use steel_registry::vanilla_mob_effects;
+    use steel_registry::vanilla_potions;
+    use steel_utils::{ChunkPos, Downcast};
+
+    use crate::entity::entities::PigEntity;
+    use crate::entity::{ENTITIES, init_entities, next_entity_id};
+    use crate::test_support::{fresh_test_world, insert_ready_full_chunk};
+
+    use super::*;
+
+    fn new_cloud() -> AreaEffectCloudEntity {
+        init_vanilla_registry();
+        AreaEffectCloudEntity::new(
+            &vanilla_entities::AREA_EFFECT_CLOUD,
+            1,
+            DVec3::ZERO,
+            Weak::new(),
+        )
+    }
+
+    #[test]
+    fn factory_creates_area_effect_cloud() {
+        init_vanilla_registry();
+        init_entities();
+        let Some(entity) = ENTITIES.create(
+            &vanilla_entities::AREA_EFFECT_CLOUD,
+            1,
+            DVec3::new(1.0, 2.0, 3.0),
+            Weak::new(),
+        ) else {
+            panic!("area effect cloud factory should be registered");
+        };
+        assert!(entity.downcast_ref::<AreaEffectCloudEntity>().is_some());
+        assert!(entity.no_physics());
+    }
+
+    #[test]
+    fn defaults_match_vanilla() {
+        let cloud = new_cloud();
+        assert_eq!(cloud.radius().to_bits(), DEFAULT_RADIUS.to_bits());
+        assert!(!cloud.is_waiting());
+        assert_eq!(cloud.duration(), INFINITE_DURATION);
+        assert_eq!(cloud.wait_time(), DEFAULT_WAIT_TIME);
+        assert_eq!(
+            cloud.potion_duration_scale().to_bits(),
+            DEFAULT_POTION_DURATION_SCALE.to_bits()
+        );
+        assert!(cloud.no_physics());
+        assert_eq!(
+            cloud.particle().particle_type().key,
+            vanilla_particle_types::ENTITY_EFFECT.key
+        );
+    }
+
+    #[test]
+    fn radius_clamps_and_refreshes_dimensions() {
+        let cloud = new_cloud();
+        cloud.set_radius(40.0);
+        assert_eq!(cloud.radius().to_bits(), MAX_RADIUS.to_bits());
+        assert_eq!(
+            cloud
+                .dimensions_for_pose(EntityPose::Standing)
+                .width
+                .to_bits(),
+            (MAX_RADIUS * 2.0).to_bits()
+        );
+
+        cloud.set_radius(-1.0);
+        assert_eq!(cloud.radius().to_bits(), 0.0_f32.to_bits());
+    }
+
+    #[test]
+    fn wait_then_duration_discards_the_cloud() {
+        let cloud = new_cloud();
+        cloud.set_wait_time(2);
+        cloud.set_duration(3);
+
+        for _ in 0..4 {
+            cloud.advance_tick_count();
+            cloud.tick();
+        }
+        assert!(!cloud.is_removed());
+
+        cloud.advance_tick_count();
+        cloud.tick();
+        assert!(cloud.is_removed());
+    }
+
+    #[test]
+    fn shrinking_below_minimal_radius_discards() {
+        let cloud = new_cloud();
+        cloud.set_wait_time(0);
+        cloud.set_radius(0.6);
+        cloud.set_radius_per_tick(-0.2);
+
+        cloud.advance_tick_count();
+        cloud.tick();
+        assert!(cloud.is_removed());
+    }
+
+    #[test]
+    fn state_persists_with_vanilla_keys() {
+        let cloud = new_cloud();
+        cloud.base.set_tick_count(17);
+        cloud.set_duration(600);
+        cloud.set_wait_time(10);
+        cloud.set_radius_on_use(-0.5);
+        cloud.set_radius_per_tick(-0.005);
+        cloud.set_duration_on_use(-1);
+        cloud.set_radius(2.5);
+        cloud.set_potion_duration_scale(0.25);
+        cloud.set_owner_uuid(Some(Uuid::from_u128(42)));
+        cloud.set_potion_contents(PotionContents::new(
+            Some(RegistryReference::new(&vanilla_potions::POISON)),
+            None,
+            Vec::new(),
+            None,
+        ));
+        cloud.set_custom_particle(Some(ParticleData::simple(&vanilla_particle_types::FLAME)));
+
+        let mut nbt = NbtCompound::new();
+        cloud.save_additional(&mut nbt);
+        assert_eq!(nbt.int("Age"), Some(17));
+        assert_eq!(nbt.int("Duration"), Some(600));
+        assert_eq!(nbt.int("WaitTime"), Some(10));
+        assert_eq!(nbt.float("RadiusOnUse"), Some(-0.5));
+        assert_eq!(nbt.float("potion_duration_scale"), Some(0.25));
+
+        let mut bytes = Vec::new();
+        nbt.write(&mut bytes);
+        let borrowed = read_borrowed_compound(&mut Cursor::new(&bytes))
+            .unwrap_or_else(|error| panic!("test NBT should reborrow: {error}"));
+        let loaded = AreaEffectCloudEntity::new(
+            &vanilla_entities::AREA_EFFECT_CLOUD,
+            2,
+            DVec3::ZERO,
+            Weak::new(),
+        );
+        loaded.load_additional((&borrowed).into());
+
+        assert_eq!(loaded.tick_count(), 17);
+        assert_eq!(loaded.duration(), 600);
+        assert_eq!(loaded.wait_time(), 10);
+        assert_eq!(loaded.radius().to_bits(), 2.5_f32.to_bits());
+        assert_eq!(loaded.potion_duration_scale().to_bits(), 0.25_f32.to_bits());
+        assert_eq!(loaded.owner_uuid(), Some(Uuid::from_u128(42)));
+        assert!(loaded.potion_contents().is(&vanilla_potions::POISON));
+        assert_eq!(
+            loaded.particle().particle_type().key,
+            vanilla_particle_types::FLAME.key
+        );
+    }
+
+    #[test]
+    fn applies_scaled_effects_inside_horizontal_radius() {
+        init_vanilla_registry();
+        let world = fresh_test_world("area_effect_cloud_poison");
+        insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+
+        let pig = Arc::new(PigEntity::new(
+            &vanilla_entities::PIG,
+            next_entity_id(),
+            DVec3::new(8.0, 64.0, 8.0),
+            Arc::downgrade(&world),
+        ));
+        world
+            .try_add_entity(Arc::clone(&pig) as SharedEntity)
+            .expect("pig should attach");
+
+        let cloud = Arc::new(AreaEffectCloudEntity::new(
+            &vanilla_entities::AREA_EFFECT_CLOUD,
+            next_entity_id(),
+            DVec3::new(8.0, 64.0, 8.0),
+            Arc::downgrade(&world),
+        ));
+        cloud.set_wait_time(0);
+        cloud.set_potion_contents(PotionContents::new(
+            Some(RegistryReference::new(&vanilla_potions::POISON)),
+            None,
+            Vec::new(),
+            None,
+        ));
+        world
+            .try_add_entity(Arc::clone(&cloud) as SharedEntity)
+            .expect("cloud should attach");
+
+        for _ in 0..5 {
+            cloud.advance_tick_count();
+            cloud.tick();
+        }
+
+        assert!(pig.has_mob_effect(vanilla_mob_effects::POISON));
+        let poison = pig
+            .mob_effect(vanilla_mob_effects::POISON)
+            .expect("poison should be applied");
+        assert_eq!(poison.duration(), 900);
+    }
+
+    #[test]
+    fn applies_instantaneous_damage_at_vanilla_cloud_scale() {
+        init_vanilla_registry();
+        let world = fresh_test_world("area_effect_cloud_harm");
+        insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+
+        let pig = Arc::new(PigEntity::new(
+            &vanilla_entities::PIG,
+            next_entity_id(),
+            DVec3::new(8.0, 64.0, 8.0),
+            Arc::downgrade(&world),
+        ));
+        world
+            .try_add_entity(Arc::clone(&pig) as SharedEntity)
+            .expect("pig should attach");
+
+        let cloud = Arc::new(AreaEffectCloudEntity::new(
+            &vanilla_entities::AREA_EFFECT_CLOUD,
+            next_entity_id(),
+            DVec3::new(8.0, 64.0, 8.0),
+            Arc::downgrade(&world),
+        ));
+        cloud.set_wait_time(0);
+        cloud.set_potion_contents(PotionContents::new(
+            Some(RegistryReference::new(&vanilla_potions::HARMING)),
+            None,
+            Vec::new(),
+            None,
+        ));
+        world
+            .try_add_entity(Arc::clone(&cloud) as SharedEntity)
+            .expect("cloud should attach");
+
+        for _ in 0..5 {
+            cloud.advance_tick_count();
+            cloud.tick();
+        }
+
+        assert_eq!(pig.get_health().to_bits(), 7.0_f32.to_bits());
+    }
+
+    #[test]
+    fn empty_potion_contents_are_not_saved() {
+        let cloud = new_cloud();
+        let mut nbt = NbtCompound::new();
+        cloud.save_additional(&mut nbt);
+        assert!(nbt.get("potion_contents").is_none());
+        assert!(nbt.get("potion_duration_scale").is_none());
+        assert_eq!(nbt.int("Duration"), Some(INFINITE_DURATION));
+    }
+}

--- a/steel-core/src/entity/entities/objects/mod.rs
+++ b/steel-core/src/entity/entities/objects/mod.rs
@@ -1,7 +1,10 @@
 //! Non-living entity implementations grouped by behavior.
 
+mod area_effect_cloud;
 pub mod display_ui;
 pub mod explosives;
 pub mod items;
 pub mod projectiles;
 pub mod vehicles;
+
+pub use area_effect_cloud::AreaEffectCloudEntity;

--- a/steel-core/src/entity/living_base/mod.rs
+++ b/steel-core/src/entity/living_base/mod.rs
@@ -18,6 +18,10 @@ use steel_registry::entity_type::EntityTypeRef;
 use steel_registry::item_stack::ItemStack;
 use steel_registry::items::ItemRef;
 use steel_registry::mob_effect::MobEffectRef;
+use steel_registry::mob_effect_instance::{
+    MobEffectInstance as PotionMobEffectInstance,
+    MobEffectInstanceDetails as PotionMobEffectInstanceDetails,
+};
 use steel_registry::vanilla_attributes;
 use steel_registry::vanilla_entity_data::VanillaLivingEntityData;
 use steel_registry::{vanilla_damage_types, vanilla_mob_effects};
@@ -100,6 +104,50 @@ impl MobEffectInstance {
     pub const fn with_show_icon(mut self, show_icon: bool) -> Self {
         self.show_icon = show_icon;
         self
+    }
+
+    /// Creates runtime effect state from a potion-contents codec instance.
+    #[must_use]
+    pub fn from_potion_contents(effect: &PotionMobEffectInstance) -> Self {
+        Self::from_potion_contents_details(
+            effect.effect(),
+            effect.duration(),
+            effect.amplifier(),
+            effect.ambient(),
+            effect.show_particles(),
+            effect.show_icon(),
+            effect.hidden_effect(),
+        )
+    }
+
+    fn from_potion_contents_details(
+        effect: MobEffectRef,
+        duration: i32,
+        amplifier: i32,
+        ambient: bool,
+        visible: bool,
+        show_icon: bool,
+        hidden_effect: Option<&PotionMobEffectInstanceDetails>,
+    ) -> Self {
+        Self {
+            effect,
+            duration,
+            amplifier: clamp_effect_amplifier(amplifier),
+            ambient,
+            visible,
+            show_icon,
+            hidden_effect: hidden_effect.map(|hidden| {
+                Box::new(Self::from_potion_contents_details(
+                    effect,
+                    hidden.duration(),
+                    hidden.amplifier(),
+                    hidden.ambient(),
+                    hidden.show_particles(),
+                    hidden.show_icon(),
+                    hidden.hidden_effect(),
+                ))
+            }),
+        }
     }
 
     /// Returns the mob effect.
@@ -891,6 +939,11 @@ impl LivingEntityBase {
         self.state.lock().rotation.y_body_rot = y_body_rot;
     }
 
+    /// Sets vanilla `yBodyRotO`.
+    pub fn set_y_body_rot_o(&self, y_body_rot_o: f32) {
+        self.state.lock().rotation.y_body_rot_o = y_body_rot_o;
+    }
+
     /// Returns vanilla `yHeadRot`.
     #[must_use]
     pub fn y_head_rot(&self) -> f32 {
@@ -900,6 +953,11 @@ impl LivingEntityBase {
     /// Sets vanilla `yHeadRot`.
     pub fn set_y_head_rot(&self, y_head_rot: f32) {
         self.state.lock().rotation.y_head_rot = y_head_rot;
+    }
+
+    /// Sets vanilla `yHeadRotO`.
+    pub fn set_y_head_rot_o(&self, y_head_rot_o: f32) {
+        self.state.lock().rotation.y_head_rot_o = y_head_rot_o;
     }
 
     /// Copies current living head/body rotations to their old-rotation fields.

--- a/steel-core/src/entity/living_entity.rs
+++ b/steel-core/src/entity/living_entity.rs
@@ -431,6 +431,15 @@ pub trait LivingEntity: Entity {
         !self.is_invulnerable() && self.can_be_seen_by_anyone()
     }
 
+    /// Returns vanilla `LivingEntity.attackable()`.
+    ///
+    /// This is the mob-targeting gate (wither, vindicator). It is not
+    /// [`Entity::attackable`], which mirrors `Entity.isAttackable` and is what
+    /// player punches use.
+    fn is_living_attackable(&self) -> bool {
+        true
+    }
+
     /// Returns vanilla `LivingEntity.canAttack()`.
     fn can_attack(&self, target: &dyn LivingEntity) -> bool {
         if target.entity_type() == &vanilla_entities::PLAYER
@@ -1166,6 +1175,61 @@ pub trait LivingEntity: Entity {
         !self.is_dead_or_dying()
     }
 
+    /// Vanilla `LivingEntity.isInvertedHealAndHarm`.
+    fn is_inverted_heal_and_harm(&self) -> bool {
+        REGISTRY.entity_types.is_in_tag(
+            self.entity_type(),
+            &EntityTypeTag::INVERTED_HEALING_AND_HARM,
+        )
+    }
+
+    /// Vanilla `MobEffect.applyInstantaneousEffect`.
+    fn apply_instantaneous_effect(
+        &self,
+        world: &World,
+        source: Option<&dyn Entity>,
+        owner: Option<&dyn Entity>,
+        effect: MobEffectRef,
+        amplifier: i32,
+        scale: f64,
+    ) {
+        if effect == vanilla_mob_effects::INSTANT_HEALTH
+            || effect == vanilla_mob_effects::INSTANT_DAMAGE
+        {
+            let is_harm = effect == vanilla_mob_effects::INSTANT_DAMAGE;
+            if is_harm == self.is_inverted_heal_and_harm() {
+                let amount = (scale * f64::from(4_i32.wrapping_shl(amplifier as u32)) + 0.5) as i32;
+                self.heal(amount as f32);
+            } else {
+                let amount = (scale * f64::from(6_i32.wrapping_shl(amplifier as u32)) + 0.5) as i32;
+                let damage_source = match source {
+                    None => DamageSource::environment(&vanilla_damage_types::MAGIC),
+                    Some(source) => {
+                        let mut damage_source =
+                            DamageSource::environment(&vanilla_damage_types::INDIRECT_MAGIC)
+                                .with_direct_entity(source.id());
+                        if let Some(owner) = owner {
+                            damage_source = damage_source.with_causing_entity(owner.id());
+                        }
+                        damage_source
+                    }
+                };
+                self.hurt(world, &damage_source, amount as f32);
+            }
+            return;
+        }
+
+        if effect == vanilla_mob_effects::SATURATION {
+            if let Some(player) = self.as_player() {
+                player.food_data.lock().eat(amplifier + 1, 1.0);
+            }
+            return;
+        }
+
+        let _ =
+            MobEffectInstance::with_duration(effect, 1, amplifier).apply_effect_tick(world, self);
+    }
+
     /// Returns vanilla base `LivingEntity.canBeAffected` eligibility.
     fn default_can_be_affected(&self, effect: &MobEffectInstance) -> bool {
         if REGISTRY
@@ -1502,6 +1566,20 @@ pub trait LivingEntity: Entity {
         true
     }
 
+    /// Returns vanilla `LivingEntity.getEquipmentSlotForItem`.
+    fn equipment_slot_for_item(&self, item_stack: &ItemStack) -> EquipmentSlot {
+        item_stack
+            .get_equippable()
+            .filter(|equippable| self.can_use_slot(equippable.slot))
+            .map_or(EquipmentSlot::MainHand, |equippable| equippable.slot)
+    }
+
+    /// Runs vanilla `LivingEntity.tickHeadTurn`.
+    ///
+    /// Armor stands replace this with yaw-locked body rotation. Mob body
+    /// control continues to run from [`Self::tick_living_state`].
+    fn tick_head_turn(&self) {}
+
     /// Returns the effective vanilla dispenser slot gate for living entities and mobs.
     fn can_dispenser_equip_into_slot(&self, _slot: EquipmentSlot) -> bool {
         self.as_mob().is_none_or(Mob::can_pick_up_loot)
@@ -1793,6 +1871,7 @@ pub trait LivingEntity: Entity {
 
     /// Ticks living-entity counters after movement.
     fn tick_living_state(&self) {
+        self.tick_head_turn();
         if let Some(mob) = self.as_mob() {
             mob.tick_body_rotation_control();
         }

--- a/steel-registry/src/data_components/components/potion_contents.rs
+++ b/steel-registry/src/data_components/components/potion_contents.rs
@@ -75,6 +75,69 @@ impl PotionContents {
         self.potion.is_some_and(|p| p.value().key == potion.key) && self.custom_effects.is_empty()
     }
 
+    /// Vanilla `PotionContents.EMPTY` water-bottle fallback color.
+    pub const BASE_POTION_COLOR: i32 = -13_083_194;
+
+    /// Vanilla `PotionContents.hasEffects`.
+    #[must_use]
+    pub fn has_effects(&self) -> bool {
+        !self.custom_effects.is_empty()
+            || self
+                .potion
+                .is_some_and(|potion| !potion.value().effects.is_empty())
+    }
+
+    /// Vanilla `PotionContents.withEffectAdded`.
+    #[must_use]
+    pub fn with_effect_added(&self, effect: MobEffectInstance) -> Self {
+        let mut custom_effects = self.custom_effects.clone();
+        custom_effects.push(effect);
+        Self {
+            custom_effects,
+            ..self.clone()
+        }
+    }
+
+    /// Vanilla `PotionContents.getAllEffects`.
+    #[must_use]
+    pub fn all_effects(&self) -> Vec<MobEffectInstance> {
+        let mut effects = Vec::new();
+        if let Some(potion) = self.potion {
+            for effect in potion.value().effects {
+                effects.push(MobEffectInstance::simple(
+                    effect.effect,
+                    effect.duration,
+                    effect.amplifier,
+                ));
+            }
+        }
+        effects.extend(self.custom_effects.iter().cloned());
+        effects
+    }
+
+    /// Vanilla `PotionContents.forEachEffect` with duration scaling.
+    #[must_use]
+    pub fn effects_with_duration_scale(&self, duration_scale: f32) -> Vec<MobEffectInstance> {
+        self.all_effects()
+            .into_iter()
+            .map(|effect| effect.with_scaled_duration(duration_scale))
+            .collect()
+    }
+
+    /// Vanilla `PotionContents.getColor`.
+    #[must_use]
+    pub fn color(&self) -> i32 {
+        self.color_or(Self::BASE_POTION_COLOR)
+    }
+
+    /// Vanilla `PotionContents.getColorOr`.
+    #[must_use]
+    pub fn color_or(&self, default: i32) -> i32 {
+        self.custom_color
+            .or_else(|| blended_effect_color(self.all_effects()))
+            .unwrap_or(default)
+    }
+
     fn to_nbt_tag_ref(&self) -> NbtTag {
         let mut compound = NbtCompound::new();
         if let Some(potion) = self.potion {
@@ -103,7 +166,9 @@ impl PotionContents {
         NbtTag::Compound(compound)
     }
 
-    fn from_owned_nbt(tag: &NbtTag) -> Option<Self> {
+    /// Decodes vanilla `PotionContents.CODEC` NBT.
+    #[must_use]
+    pub fn from_owned_nbt(tag: &NbtTag) -> Option<Self> {
         if tag.string().is_some() {
             return registry_reference_from_owned_nbt(tag)
                 .map(|potion| Self::new(Some(potion), None, Vec::new(), None));
@@ -269,6 +334,33 @@ fn read_network_string(data: &mut Cursor<&[u8]>) -> Result<String> {
     Ok(value)
 }
 
+fn blended_effect_color(effects: Vec<MobEffectInstance>) -> Option<i32> {
+    let mut red = 0i32;
+    let mut green = 0i32;
+    let mut blue = 0i32;
+    let mut total_weight = 0i32;
+    for effect in effects {
+        if !effect.show_particles() {
+            continue;
+        }
+        let color = effect.effect().color;
+        let amplifier = effect.amplifier() + 1;
+        red += amplifier * i32::from(color.red());
+        green += amplifier * i32::from(color.green());
+        blue += amplifier * i32::from(color.blue());
+        total_weight += amplifier;
+    }
+    if total_weight == 0 {
+        return None;
+    }
+    Some(
+        (0xFF00_0000u32 as i32)
+            | ((red / total_weight) << 16)
+            | ((green / total_weight) << 8)
+            | (blue / total_weight),
+    )
+}
+
 fn push_hash_entry<T: HashComponent + ?Sized>(entries: &mut Vec<HashEntry>, key: &str, value: &T) {
     let mut key_hasher = ComponentHasher::new();
     key_hasher.put_string(key);
@@ -356,5 +448,27 @@ mod tests {
                 Some(PotionContents::empty())
             );
         }
+    }
+
+    #[test]
+    fn empty_contents_have_no_effects_and_base_color() {
+        init_vanilla_registry();
+        let empty = PotionContents::empty();
+        assert!(!empty.has_effects());
+        assert_eq!(empty.color(), PotionContents::BASE_POTION_COLOR);
+    }
+
+    #[test]
+    fn with_effect_added_and_duration_scale_match_vanilla() {
+        init_vanilla_registry();
+        let contents = PotionContents::empty().with_effect_added(crate::MobEffectInstance::simple(
+            vanilla_mob_effects::SPEED,
+            200,
+            0,
+        ));
+        assert!(contents.has_effects());
+        let scaled = contents.effects_with_duration_scale(0.25);
+        assert_eq!(scaled.len(), 1);
+        assert_eq!(scaled[0].duration(), 50);
     }
 }

--- a/steel-registry/src/entity_type.rs
+++ b/steel-registry/src/entity_type.rs
@@ -215,6 +215,14 @@ impl EntityDimensions {
         }
     }
 
+    /// Vanilla `EntityDimensions.scalable(width, height)`.
+    ///
+    /// Eye height is `height * 0.85`, matching vanilla `defaultEyeHeight`.
+    #[must_use]
+    pub const fn scalable(width: f32, height: f32) -> Self {
+        Self::new(width, height, height * 0.85)
+    }
+
     /// Scale dimensions by a factor (for baby entities, etc.)
     #[must_use]
     pub fn scale(&self, factor: f32) -> Self {
@@ -366,6 +374,14 @@ mod tests {
             diff.length_squared() < 1.0e-12,
             "expected {left:?} to equal {right:?}"
         );
+    }
+
+    #[test]
+    fn scalable_dimensions_use_vanilla_default_eye_height() {
+        let dimensions = EntityDimensions::scalable(6.0, 0.5);
+        assert_eq!(dimensions.width.to_bits(), 6.0_f32.to_bits());
+        assert_eq!(dimensions.height.to_bits(), 0.5_f32.to_bits());
+        assert_eq!(dimensions.eye_height.to_bits(), 0.425_f32.to_bits());
     }
 
     #[test]

--- a/steel-registry/src/mob_effect/instance.rs
+++ b/steel-registry/src/mob_effect/instance.rs
@@ -101,6 +101,22 @@ impl MobEffectInstance {
         self.hidden_effect.as_deref()
     }
 
+    /// Returns whether this instance uses vanilla's infinite-duration sentinel.
+    #[must_use]
+    pub const fn is_infinite_duration(&self) -> bool {
+        self.duration == -1
+    }
+
+    /// Vanilla `MobEffectInstance.withScaledDuration`.
+    #[must_use]
+    pub fn with_scaled_duration(&self, scale: f32) -> Self {
+        let mut copy = self.clone();
+        if !copy.is_infinite_duration() && copy.duration != 0 {
+            copy.duration = ((copy.duration as f32) * scale).floor().max(1.0) as i32;
+        }
+        copy
+    }
+
     fn details(&self) -> MobEffectInstanceDetails {
         MobEffectInstanceDetails {
             amplifier: self.amplifier,
@@ -168,6 +184,36 @@ impl MobEffectInstanceDetails {
             show_icon,
             hidden_effect: hidden_effect.map(Box::new),
         }
+    }
+
+    #[must_use]
+    pub const fn amplifier(&self) -> i32 {
+        self.amplifier
+    }
+
+    #[must_use]
+    pub const fn duration(&self) -> i32 {
+        self.duration
+    }
+
+    #[must_use]
+    pub const fn ambient(&self) -> bool {
+        self.ambient
+    }
+
+    #[must_use]
+    pub const fn show_particles(&self) -> bool {
+        self.show_particles
+    }
+
+    #[must_use]
+    pub const fn show_icon(&self) -> bool {
+        self.show_icon
+    }
+
+    #[must_use]
+    pub fn hidden_effect(&self) -> Option<&Self> {
+        self.hidden_effect.as_deref()
     }
 
     fn to_nbt_compound(&self) -> NbtCompound {

--- a/steel-registry/src/mob_effect/mod.rs
+++ b/steel-registry/src/mob_effect/mod.rs
@@ -79,6 +79,14 @@ pub struct MobEffect {
 }
 
 impl MobEffect {
+    /// Vanilla `MobEffect.isInstantaneous`.
+    #[must_use]
+    pub fn is_instantaneous(&self) -> bool {
+        std::ptr::eq(self, crate::vanilla_mob_effects::INSTANT_HEALTH)
+            || std::ptr::eq(self, crate::vanilla_mob_effects::INSTANT_DAMAGE)
+            || std::ptr::eq(self, crate::vanilla_mob_effects::SATURATION)
+    }
+
     /// Creates the particle options synchronized for one effect instance.
     #[must_use]
     pub fn create_particle_options(&self, ambient: bool) -> ParticleData {
@@ -156,6 +164,15 @@ crate::impl_registry!(
 mod tests {
     use crate::particle_type::{ColorParticleOption, SimpleParticleOptions};
     use crate::{vanilla_mob_effects, vanilla_particle_types};
+
+    #[test]
+    fn instantaneous_effects_match_vanilla_subclasses() {
+        assert!(vanilla_mob_effects::INSTANT_HEALTH.is_instantaneous());
+        assert!(vanilla_mob_effects::INSTANT_DAMAGE.is_instantaneous());
+        assert!(vanilla_mob_effects::SATURATION.is_instantaneous());
+        assert!(!vanilla_mob_effects::SPEED.is_instantaneous());
+        assert!(!vanilla_mob_effects::POISON.is_instantaneous());
+    }
 
     #[test]
     fn generated_effect_particles_match_vanilla_factories() {

--- a/steel-registry/src/particle_type.rs
+++ b/steel-registry/src/particle_type.rs
@@ -1,9 +1,13 @@
 use std::fmt::{self, Debug, Formatter};
 use std::io::{Cursor, Error, Result, Write};
+use std::str::FromStr;
 
 use glam::DVec3;
 use rustc_hash::FxHashMap;
+use simdnbt::owned::{NbtCompound, NbtTag};
+use simdnbt::{FromNbtTag, ToNbtTag};
 use steel_utils::codec::VarInt;
+use steel_utils::nbt::NbtNumeric as _;
 use steel_utils::serial::{ReadFrom, WriteTo};
 use steel_utils::{
     ArgbColor, BlockStateId, Downcast as _, DowncastType, DowncastTypeKey, ErasedType, Identifier,
@@ -134,6 +138,136 @@ impl PartialEq for ParticleData {
     fn eq(&self, other: &Self) -> bool {
         self.particle_type.key == other.particle_type.key
             && self.options.options_eq(other.options.as_ref())
+    }
+}
+
+impl ParticleData {
+    fn write_options_nbt(&self, compound: &mut NbtCompound) {
+        if let Some(color) = self.downcast_ref::<ColorParticleOption>() {
+            compound.insert("color", color.color().raw());
+        } else if let Some(dust) = self.downcast_ref::<DustParticleOptions>() {
+            compound.insert("color", dust.color().raw());
+            compound.insert("scale", dust.scale());
+        } else if let Some(dust) = self.downcast_ref::<DustColorTransitionOptions>() {
+            compound.insert("from_color", dust.source_color().raw());
+            compound.insert("to_color", dust.target_color().raw());
+            compound.insert("scale", dust.scale());
+        } else if let Some(power) = self.downcast_ref::<PowerParticleOption>() {
+            compound.insert("power", power.power());
+        } else if let Some(spell) = self.downcast_ref::<SpellParticleOption>() {
+            compound.insert("color", spell.color().raw());
+            compound.insert("power", spell.power());
+        } else if let Some(sculk) = self.downcast_ref::<SculkChargeParticleOptions>() {
+            compound.insert("roll", sculk.roll());
+        } else if let Some(shriek) = self.downcast_ref::<ShriekParticleOption>() {
+            compound.insert("delay", shriek.delay());
+        } else if let Some(geyser) = self.downcast_ref::<GeyserParticleOptions>() {
+            compound.insert("water_blocks", geyser.water_blocks());
+        } else if let Some(geyser) = self.downcast_ref::<GeyserBaseParticleOptions>() {
+            compound.insert("water_blocks", geyser.water_blocks());
+            compound.insert("burst_impulse_base", geyser.burst_impulse_base());
+        }
+    }
+
+    fn read_options_nbt(
+        particle_type: ParticleTypeRef,
+        compound: &NbtCompound,
+    ) -> Option<Box<dyn ErasedParticleOptions>> {
+        let key = particle_type.expected_type_key;
+        if key == ColorParticleOption::TYPE_KEY {
+            let color = compound.get("color")?.codec_i32()?;
+            Some(Box::new(ColorParticleOption::new(ArgbColor::new(color))))
+        } else if key == SimpleParticleOptions::TYPE_KEY {
+            Some(Box::new(SimpleParticleOptions))
+        } else if key == DustParticleOptions::TYPE_KEY {
+            Some(Box::new(DustParticleOptions::new(
+                RgbColor::new(compound.get("color")?.codec_i32()?),
+                compound.get("scale")?.codec_f32()?,
+            )))
+        } else if key == DustColorTransitionOptions::TYPE_KEY {
+            Some(Box::new(DustColorTransitionOptions::new(
+                RgbColor::new(compound.get("from_color")?.codec_i32()?),
+                RgbColor::new(compound.get("to_color")?.codec_i32()?),
+                compound.get("scale")?.codec_f32()?,
+            )))
+        } else if key == PowerParticleOption::TYPE_KEY {
+            let power = compound
+                .get("power")
+                .and_then(NbtTag::codec_f32)
+                .unwrap_or(1.0);
+            Some(Box::new(PowerParticleOption::new(power)))
+        } else if key == SpellParticleOption::TYPE_KEY {
+            let color = compound
+                .get("color")
+                .and_then(NbtTag::codec_i32)
+                .unwrap_or(-1);
+            let power = compound
+                .get("power")
+                .and_then(NbtTag::codec_f32)
+                .unwrap_or(1.0);
+            Some(Box::new(SpellParticleOption::new(
+                RgbColor::new(color),
+                power,
+            )))
+        } else if key == SculkChargeParticleOptions::TYPE_KEY {
+            Some(Box::new(SculkChargeParticleOptions::new(
+                compound.get("roll")?.codec_f32()?,
+            )))
+        } else if key == ShriekParticleOption::TYPE_KEY {
+            Some(Box::new(ShriekParticleOption::new(
+                compound.get("delay")?.codec_i32()?,
+            )))
+        } else if key == GeyserParticleOptions::TYPE_KEY {
+            Some(Box::new(GeyserParticleOptions::new(
+                compound.get("water_blocks")?.codec_i32()?,
+            )))
+        } else if key == GeyserBaseParticleOptions::TYPE_KEY {
+            Some(Box::new(GeyserBaseParticleOptions::new(
+                compound.get("water_blocks")?.codec_i32()?,
+                compound.get("burst_impulse_base")?.codec_f32()?,
+            )))
+        } else {
+            None
+        }
+    }
+}
+
+impl ToNbtTag for ParticleData {
+    fn to_nbt_tag(self) -> NbtTag {
+        self.to_nbt_tag_ref()
+    }
+}
+
+impl ParticleData {
+    /// Vanilla `ParticleTypes.CODEC` compound shape: `{type, ...options}`.
+    #[must_use]
+    pub fn to_nbt_tag_ref(&self) -> NbtTag {
+        let mut compound = NbtCompound::new();
+        compound.insert("type", self.particle_type.key.to_string());
+        self.write_options_nbt(&mut compound);
+        NbtTag::Compound(compound)
+    }
+}
+
+impl FromNbtTag for ParticleData {
+    fn from_nbt_tag(tag: simdnbt::borrow::NbtTag) -> Option<Self> {
+        Self::from_owned_nbt(&tag.to_owned())
+    }
+}
+
+impl ParticleData {
+    /// Decodes vanilla `ParticleTypes.CODEC` NBT.
+    #[must_use]
+    pub fn from_owned_nbt(tag: &NbtTag) -> Option<Self> {
+        let compound = tag.compound()?;
+        let type_name = compound.get("type")?.string()?;
+        let key = Identifier::from_str(&type_name.to_string()).ok()?;
+        let particle_type = crate::REGISTRY.particle_types.by_key(&key)?;
+        let options = Self::read_options_nbt(particle_type, compound)?;
+        Some(Self {
+            particle_type,
+            options,
+        })
     }
 }
 


### PR DESCRIPTION
## Type of change

- [x] Entity implementation
- [x] New feature

## Description

Implements vanilla `AreaEffectCloud` as a Steel entity (`AreaEffectCloudEntity`), registered through the generated entity factory.

Server-side behavior matches `net.minecraft.world.entity.AreaEffectCloud`:

- `noPhysics`, wait time, duration (`-1` infinite), radius growth/shrink, and discard below radius `0.5`
- Potion application every 5 ticks to living entities inside the horizontal radius, with reapplication delay, `radiusOnUse`, and `durationOnUse`
- Instantaneous effects (`instant_health` / `instant_damage` / `saturation`) at vanilla cloud scale `0.5`, including inverted heal/harm via `inverted_healing_and_harm`
- Synced radius, waiting, and particle data; dimensions are `radius * 2` by `0.5`
- Additional NBT: `Age`, `Duration`, `WaitTime`, `ReapplicationDelay`, `DurationOnUse`, `RadiusOnUse`, `RadiusPerTick`, `Radius`, `Owner`, `potion_contents`, `potion_duration_scale`, `custom_particle`

Client-local `clientTick` particles are omitted on purpose. The client renders them from synced data.

Shared helpers added only where the entity needs them: `PotionContents` effect/color APIs, `MobEffect::is_instantaneous`, `LivingEntity::apply_instantaneous_effect`, `EntityBase::set_tick_count`, `EntityDimensions::scalable`, and ParticleTypes-shaped NBT for the option types Steel already models.

`apply_components_from_item_stack` is on the entity so lingering potions can fill contents later. Thrown lingering potions, creeper clouds, and dragon fireballs are **not** wired in this PR.

## How this was tested

Minecraft target: **26.2** (workspace `+mc26.2`).

```bash
cargo test -p steel-core --lib entity::entities::objects::area_effect_cloud
cargo clippy -p steel-core -p steel-registry --all-targets -- -D warnings
```

Covered by tests: factory registration, defaults, radius clamp/dimensions, wait+duration discard, radius-per-tick discard, NBT round-trip (including poison contents and a simple custom particle), poison application at duration 900, and instantaneous harming `10 -> 7` HP.

### In-game

```text
/summon minecraft:area_effect_cloud ~ ~ ~
```

You should see wait-state particles for 1 second, then a radius-3 cloud that does not despawn (`Duration = -1`). Standing in it will **not** apply effects: `/summon` has no NBT branch yet, and lingering potions cannot be thrown.

```text
/kill @e[type=minecraft:area_effect_cloud]
```

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes modified:

- AreaEffectCloud

## Additional notes

**Standards self-review (AGENTS.md):**

- Vanilla tick/save/load/effect application was checked against `minecraft-src/.../AreaEffectCloud.java`. Instantaneous heal/harm uses vanilla `HealOrHarmMobEffect` amounts and `indirectMagic` when a source is present.
- `DowncastType` for the entity uses a Steel-owned key and a `// SAFETY:` comment.
- Generated files were not edited; factory registration comes from `#[entity_behavior(class = "AreaEffectCloud")]`.
- Client particle spawning is omitted with an explanatory comment (particle-routing rule).
- `custom_particle` NBT covers simple/color/dust/power/spell/sculk/shriek/geyser options. Item, block, vibration, and trail payloads are not encoded yet; loading those from vanilla worlds would drop the custom particle and fall back to potion color.
- Effect application cannot be exercised via `/summon` until summon NBT or lingering-potion impact exists.