### PR TITLE
feat: implement marker entity

### DIFF
--- a/steel-core/src/entity/entities/mod.rs
+++ b/steel-core/src/entity/entities/mod.rs
@@ -10,5 +10,6 @@ pub use objects::display_ui::{BlockDisplayEntity, ItemFrameEntity, LeashFenceKno
 pub use objects::explosives::EndCrystalEntity;
 pub use objects::items::{ExperienceOrbEntity, FallingBlockEntity, ItemEntity};
 pub use objects::projectiles::{EnderPearlEntity, FireworkRocketEntity, ThrownEggEntity};
+pub use objects::technical::MarkerEntity;
 pub use objects::vehicles::ChestMinecartEntity;
 pub use raw::RawEntity;

--- a/steel-core/src/entity/entities/objects/mod.rs
+++ b/steel-core/src/entity/entities/objects/mod.rs
@@ -4,4 +4,5 @@ pub mod display_ui;
 pub mod explosives;
 pub mod items;
 pub mod projectiles;
+pub mod technical;
 pub mod vehicles;

--- a/steel-core/src/entity/entities/objects/technical/marker.rs
+++ b/steel-core/src/entity/entities/objects/technical/marker.rs
@@ -10,7 +10,7 @@ use steel_utils::{DowncastType, DowncastTypeKey};
 use uuid::Uuid;
 
 /// An entity that is minimal. It cannot move, take damage, make sounds, and it doesn't
-/// have any functions. They are not sent to the client, and are primarily intended for use
+/// have any gameplay functions. Markers are not sent to the client, and are primarily intended for use
 /// in map-making and in data packs. This entity is purely server-side.
 #[entity_behavior(class = "Marker")]
 pub struct MarkerEntity {

--- a/steel-core/src/entity/entities/objects/technical/marker.rs
+++ b/steel-core/src/entity/entities/objects/technical/marker.rs
@@ -85,6 +85,10 @@ impl Entity for MarkerEntity {
 
     fn tick(&self) {}
 
+    fn no_physics(&self) -> bool {
+        true
+    }
+
     fn hurt(&self, _world: &World, _source: &DamageSource, _amount: f32) -> bool {
         false
     }

--- a/steel-core/src/entity/entities/objects/technical/marker.rs
+++ b/steel-core/src/entity/entities/objects/technical/marker.rs
@@ -1,0 +1,91 @@
+use crate::entity::damage::DamageSource;
+use crate::entity::{Entity, EntityBase, EntityBaseLoad};
+use crate::world::World;
+use glam::DVec3;
+use std::sync::Weak;
+use steel_macros::entity_behavior;
+use steel_registry::blocks::behavior::PushReaction;
+use steel_registry::entity_type::EntityTypeRef;
+use steel_utils::{DowncastType, DowncastTypeKey};
+use uuid::Uuid;
+
+/// An entity that is minimal. It cannot move, take damage, make sounds, and it doesn't
+/// have any functions. They are not sent to the client, and are primarily intended for use
+/// in map-making and in data packs. This entity is purely server-side.
+#[entity_behavior(class = "Marker")]
+pub struct MarkerEntity {
+    base: EntityBase,
+    entity_type: EntityTypeRef,
+}
+
+// SAFETY: This key is owned by Steel and uniquely identifies `MarkerEntity`.
+unsafe impl DowncastType for MarkerEntity {
+    const TYPE_KEY: DowncastTypeKey = DowncastTypeKey::new("steel:entity/marker");
+}
+
+impl MarkerEntity {
+    /// Creates a new marker entity.
+    #[must_use]
+    pub fn new(entity_type: EntityTypeRef, id: i32, position: DVec3, world: Weak<World>) -> Self {
+        Self {
+            base: EntityBase::new(id, position, entity_type.dimensions, world),
+            entity_type,
+        }
+    }
+
+    /// Creates a new marker entity with a specific UUID.
+    #[must_use]
+    pub fn with_uuid(
+        entity_type: EntityTypeRef,
+        id: i32,
+        position: DVec3,
+        uuid: Uuid,
+        world: Weak<World>,
+    ) -> Self {
+        Self {
+            base: EntityBase::with_uuid(id, uuid, position, entity_type.dimensions, world),
+            entity_type,
+        }
+    }
+
+    /// Creates a marker entity from saved data.
+    #[must_use]
+    pub fn from_saved(entity_type: EntityTypeRef, load: EntityBaseLoad) -> Self {
+        Self {
+            base: EntityBase::from_load(load, entity_type.dimensions),
+            entity_type,
+        }
+    }
+}
+
+impl Entity for MarkerEntity {
+    fn base(&self) -> &EntityBase {
+        &self.base
+    }
+
+    fn entity_type(&self) -> EntityTypeRef {
+        self.entity_type
+    }
+
+    fn is_ignoring_block_triggers(&self) -> bool {
+        true
+    }
+
+    fn piston_push_reaction(&self) -> PushReaction {
+        PushReaction::Ignore
+    }
+
+    fn can_add_passenger(&self, _passenger: &dyn Entity) -> bool {
+        false
+    }
+
+    fn could_accept_passenger(&self) -> bool {
+        false
+    }
+
+    fn tick(&self) {}
+
+    fn hurt(&self, _world: &World, _source: &DamageSource, _amount: f32) -> bool {
+        false
+    }
+}

--- a/steel-core/src/entity/entities/objects/technical/marker.rs
+++ b/steel-core/src/entity/entities/objects/technical/marker.rs
@@ -104,13 +104,15 @@ mod tests {
     use std::sync::Arc;
     use steel_registry::{vanilla_damage_types, vanilla_entities};
 
+    const TEST_POSITION: DVec3 = DVec3::new(-8.0, 128.0, 4.0);
+
     #[test]
     fn markers_cannot_get_hurt() {
         let world = test_world();
         let marker = MarkerEntity::new(
             &vanilla_entities::MARKER,
             0,
-            DVec3::ZERO,
+            TEST_POSITION,
             Arc::downgrade(world),
         );
         assert!(!marker.hurt(
@@ -126,13 +128,13 @@ mod tests {
         let marker = MarkerEntity::new(
             &vanilla_entities::MARKER,
             0,
-            DVec3::ZERO,
+            TEST_POSITION,
             Arc::downgrade(world),
         );
         for _ in 0..100 {
             marker.tick();
         }
-        assert_eq!(marker.position(), DVec3::ZERO);
+        assert_eq!(marker.position(), TEST_POSITION);
     }
 
     #[test]
@@ -141,13 +143,13 @@ mod tests {
         let marker: SharedEntity = Arc::new(MarkerEntity::new(
             &vanilla_entities::MARKER,
             0,
-            DVec3::ZERO,
+            TEST_POSITION,
             Arc::downgrade(world),
         ));
         let passenger: SharedEntity = Arc::new(PigEntity::new(
             &vanilla_entities::PIG,
             1,
-            DVec3::ZERO,
+            TEST_POSITION,
             Arc::downgrade(world),
         ));
         assert!(!start_riding_entities(&passenger, &marker));

--- a/steel-core/src/entity/entities/objects/technical/marker.rs
+++ b/steel-core/src/entity/entities/objects/technical/marker.rs
@@ -93,3 +93,63 @@ impl Entity for MarkerEntity {
         false
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::entity::damage::DamageSource;
+    use crate::entity::entities::{MarkerEntity, PigEntity};
+    use crate::entity::{Entity, SharedEntity, start_riding_entities};
+    use crate::test_support::test_world;
+    use glam::DVec3;
+    use std::sync::Arc;
+    use steel_registry::{vanilla_damage_types, vanilla_entities};
+
+    #[test]
+    fn markers_cannot_get_hurt() {
+        let world = test_world();
+        let marker = MarkerEntity::new(
+            &vanilla_entities::MARKER,
+            0,
+            DVec3::ZERO,
+            Arc::downgrade(world),
+        );
+        assert!(!marker.hurt(
+            world,
+            &DamageSource::environment(&vanilla_damage_types::GENERIC),
+            5.0
+        ));
+    }
+
+    #[test]
+    fn markers_cannot_fall() {
+        let world = test_world();
+        let marker = MarkerEntity::new(
+            &vanilla_entities::MARKER,
+            0,
+            DVec3::ZERO,
+            Arc::downgrade(world),
+        );
+        for _ in 0..100 {
+            marker.tick();
+        }
+        assert_eq!(marker.position(), DVec3::ZERO);
+    }
+
+    #[test]
+    fn markers_cannot_have_passenger() {
+        let world = test_world();
+        let marker: SharedEntity = Arc::new(MarkerEntity::new(
+            &vanilla_entities::MARKER,
+            0,
+            DVec3::ZERO,
+            Arc::downgrade(world),
+        ));
+        let passenger: SharedEntity = Arc::new(PigEntity::new(
+            &vanilla_entities::PIG,
+            1,
+            DVec3::ZERO,
+            Arc::downgrade(world),
+        ));
+        assert!(!start_riding_entities(&passenger, &marker));
+    }
+}

--- a/steel-core/src/entity/entities/objects/technical/mod.rs
+++ b/steel-core/src/entity/entities/objects/technical/mod.rs
@@ -1,0 +1,5 @@
+//! Technical entity implementations.
+
+mod marker;
+
+pub use marker::MarkerEntity;


### PR DESCRIPTION
## Type of change

- [x] Entity implementation

## Description

Implements the marker entity. This entity is not sent to the client and only exists server-side. It is used for map-making and for data packs. It cannot move (on its own), be damaged, or make sounds.

## How this was tested

1. Join the server
2. Summon the marker with the command `/summon marker`. It summons successfully.

## Screenshots / logs

N/A

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes modified:

- Marker

## Additional notes

<!-- Anything else reviewers should know -->
