### PR TITLE
feat: vanilla framing parity, read-path hardening, and malformed packet kicks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -2801,6 +2802,7 @@ version = "0.15.2+mc26.2"
 dependencies = [
  "aes",
  "cfb8",
+ "criterion",
  "flate2",
  "glam",
  "log",

--- a/steel-core/src/player/connection/java.rs
+++ b/steel-core/src/player/connection/java.rs
@@ -811,7 +811,7 @@ impl JavaConnection {
                     .lock()
                     .on_chunk_batch_received_by_client(packet.desired_chunks_per_tick);
             }
-            ImmediatePlayPacket::Unknown(id) => log::info!("play packet id {id} is not known"),
+            ImmediatePlayPacket::Unknown(id) => log::debug!("play packet id {id} is not known"),
         }
     }
 
@@ -830,10 +830,14 @@ impl JavaConnection {
                     match packet {
                         Ok(packet) => {
                             if let Some(player) = self.player.upgrade()
-                                && let Err(err) = self.process_packet(packet, player, &server) {
-                                log::warn!(
-                                    "Failed to get packet from client {}: {err}",
-                                    self.id
+                                && let Err(err) = self.process_packet(packet, player, &server)
+                            {
+                                // A packet failed to decode or dispatch. The stream framing
+                                // is still intact, so the vanilla invalid-packet disconnect
+                                // reaches the client before the connection closes.
+                                log::warn!("Failed to process packet from client {}: {err}", self.id);
+                                self.disconnect(
+                                    translations::MULTIPLAYER_DISCONNECT_INVALID_PACKET.msg(),
                                 );
                             }
                         }

--- a/steel-login/src/tcp_client.rs
+++ b/steel-login/src/tcp_client.rs
@@ -524,6 +524,10 @@ impl JavaTcpClient {
                             }
                             LoginOperationResult::Completed(Err(err)) => {
                                 log::warn!("Failed to get packet from client {id}: {err}");
+                                let reason = TextComponent::translated(
+                                    translations::MULTIPLAYER_DISCONNECT_INVALID_PACKET.msg(),
+                                );
+                                self_clone.kick(reason).await;
                             }
                             LoginOperationResult::Cancelled => break,
                             LoginOperationResult::TimedOut => {

--- a/steel-protocol/Cargo.toml
+++ b/steel-protocol/Cargo.toml
@@ -45,3 +45,10 @@ text_components.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+criterion = { workspace = true, features = ["async_tokio"] }
+
+[[bench]]
+name = "packet_reader_framing"
+harness = false

--- a/steel-protocol/benches/packet_reader_framing.rs
+++ b/steel-protocol/benches/packet_reader_framing.rs
@@ -1,0 +1,50 @@
+#![expect(missing_docs, reason = "benchmarks")]
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use steel_protocol::packet_reader::TCPNetworkDecoder;
+use steel_utils::codec::VarInt;
+use steel_utils::serial::WriteTo;
+use tokio::runtime::Builder;
+
+/// Decodes 256 framed packets from a pre-built wire buffer, exercising the length
+/// framing path.
+fn bench_packet_reader_framing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("packet_reader_framing");
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut wire = Vec::new();
+    for i in 0i32..256 {
+        let mut packet = Vec::new();
+        VarInt::from(i)
+            .write(&mut packet)
+            .expect("packet id should encode");
+        packet.extend_from_slice(&[0xABu8; 32]);
+        VarInt::from(packet.len() as i32)
+            .write(&mut wire)
+            .expect("packet length should encode");
+        wire.extend_from_slice(&packet);
+    }
+    group.throughput(Throughput::Elements(256));
+
+    group.bench_function("decode_256_packets", |b| {
+        b.to_async(&rt).iter(|| async {
+            let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+            for _ in 0..256 {
+                let packet = decoder
+                    .get_raw_packet()
+                    .await
+                    .expect("packet should decode");
+                black_box(packet.id);
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_packet_reader_framing);
+criterion_main!(benches);

--- a/steel-protocol/src/packet_reader.rs
+++ b/steel-protocol/src/packet_reader.rs
@@ -18,9 +18,7 @@ use steel_utils::codec::VarInt;
 use steel_utils::serial::ReadFrom;
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 
-use crate::utils::{
-    Aes128Cfb8Dec, MAX_PACKET_DATA_SIZE, MAX_PACKET_SIZE, PacketError, RawPacket, StreamDecryptor,
-};
+use crate::utils::{Aes128Cfb8Dec, MAX_PACKET_DATA_SIZE, PacketError, RawPacket, StreamDecryptor};
 
 /// A reader that can decrypt data.
 pub enum DecryptionReader<R: AsyncRead + Unpin> {
@@ -108,10 +106,32 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
     /// - If the packet fails to decompress.
     #[expect(clippy::cast_sign_loss)]
     pub async fn get_raw_packet(&mut self) -> Result<RawPacket, PacketError> {
-        let packet_len = VarInt::read_async(&mut self.reader).await? as usize;
+        // Decode the packet length VarInt manually, capping it at 3 bytes like vanilla
+        // `Varint21FrameDecoder`, so oversized lengths fail fast instead of consuming
+        // unbounded input.
+        let mut packet_len: usize = 0;
+        let mut length_bytes = 0;
+        loop {
+            if length_bytes == 3 {
+                Err(PacketError::MalformedLength(
+                    "packet length varint exceeds 3 bytes".to_string(),
+                ))?;
+            }
 
-        if packet_len > MAX_PACKET_SIZE {
-            Err(PacketError::OutOfBounds)?;
+            let mut byte = [0u8; 1];
+            self.reader.read_exact(&mut byte).await?;
+            packet_len |= ((byte[0] & 0x7F) as usize) << (7 * length_bytes);
+            length_bytes += 1;
+
+            if byte[0] & 0x80 == 0 {
+                break;
+            }
+        }
+
+        if packet_len == 0 {
+            Err(PacketError::MalformedLength(
+                "packet length cannot be zero".to_string(),
+            ))?;
         }
 
         // Read the entire packet data into a buffer
@@ -132,6 +152,10 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
             }
 
             if decompressed_len > 0 {
+                if decompressed_len < threshold.get() as usize {
+                    Err(PacketError::BelowThreshold(decompressed_len))?;
+                }
+
                 let mut decompressed = vec![0; decompressed_len];
                 let mut decoder = ZlibDecoder::new(&mut cursor);
                 decoder
@@ -603,5 +627,45 @@ mod compression_security_tests {
 
         assert_eq!(raw_packet.id, 2);
         assert_eq!(raw_packet.payload(), b"hello");
+    }
+
+    #[tokio::test]
+    async fn rejects_length_varint_wider_than_21_bits() {
+        // Four-byte length VarInt: three continuation bytes then a terminator, like
+        // vanilla `Varint21FrameDecoder`'s "length wider than 21-bit" case.
+        let wire = [0x80, 0x80, 0x80, 0x01];
+        let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::MalformedLength(message))
+                if message.contains("exceeds 3 bytes")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_length_frames() {
+        let wire = [0x00];
+        let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::MalformedLength(message))
+                if message.contains("cannot be zero")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_compressed_size_below_server_threshold() {
+        // A well-formed compressed packet whose declared size is under the server
+        // threshold: vanilla `CompressionDecoder` rejects it before inflating.
+        let packet = compressed_packet(5, b"hello");
+        let mut decoder = TCPNetworkDecoder::new(packet.as_slice());
+        decoder.set_compression(NonZeroU32::new(256).expect("nonzero threshold"));
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::BelowThreshold(5))
+        ));
     }
 }

--- a/steel-protocol/src/utils.rs
+++ b/steel-protocol/src/utils.rs
@@ -97,9 +97,6 @@ pub enum PacketError {
     #[error("packet length {0} exceeds maximum length")]
     /// The packet length exceeds the maximum length.
     TooLong(usize),
-    #[error("packet length is out of bounds")]
-    /// The packet length is out of bounds.
-    OutOfBounds,
     #[error("malformed packet length VarInt: {0}")]
     /// The packet length `VarInt` is malformed.
     MalformedLength(String),
@@ -112,6 +109,9 @@ pub enum PacketError {
     #[error("failed to compress packet: {0}")]
     /// Failed to compress the packet.
     CompressionFailed(String),
+    #[error("badly compressed packet - size of {0} is below the server threshold")]
+    /// The packet declares a compressed size below the server's compression threshold.
+    BelowThreshold(usize),
     #[error("packet is uncompressed but greater than the threshold")]
     /// The packet is uncompressed but greater than the threshold.
     NotCompressed,


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [x] Performance improvement

## Description

Hardens the read path to vanilla framing parity:

- `get_raw_packet` decodes the packet length `VarInt` with a manual 3-byte cap, matching vanilla `Varint21FrameDecoder` (`MAX_VARINT21_BYTES = 3`, "length wider than 21-bit"): lengths wider than 21 bits and zero-length frames ("Frame length cannot be zero") are rejected with `PacketError::MalformedLength` before consuming unbounded input (previously an unconstrained `VarInt::read_async` accepted up to 5 bytes). The now-provably-dead `packet_len > MAX_PACKET_SIZE` read check is removed (a 3-byte `VarInt` cannot exceed 2^21-1; vanilla has no extra read-side maximum), along with the `PacketError::OutOfBounds` variant that only it constructed.
- Compressed packets whose declared uncompressed size is nonzero and below the server threshold are rejected with a new `PacketError::BelowThreshold` before inflation, matching vanilla `CompressionDecoder` ("Badly compressed packet - size of N is below server threshold"). The check only applies to nonzero payloads, so legitimate uncompressed packets still pass.
- Malformed-packet kicks: pre-play connections are kicked with `multiplayer.disconnect.invalid_packet` when packet processing fails; play connections now do the same (a failed `process_packet` leaves the stream framing intact, so the vanilla invalid-packet disconnect still reaches the client instead of a bare close). Frame-level read failures close without a packet (a desynced stream cannot parse one). Unrecognized immediate packets log at debug level.

## How this was tested

- `cargo test -p steel-protocol --lib` — new vanilla-parity tests: `rejects_length_varint_wider_than_21_bits`, `rejects_zero_length_frames`, `rejects_compressed_size_below_server_threshold` (54 tests total). Full `steel-core` (2466 tests) and `steel-login` suites pass; `cargo clippy -r --all-targets` clean.
- Benchmark: numbers and replication steps in [Measurements](#measurements) below.

## Measurements

Back-to-back criterion runs on the same idle machine (Linux x86_64 laptop, Intel Core Ultra 7 258V, Rust nightly, criterion defaults: 3 s warmup, 5 s measurement, 100 samples), decoding 256 framed packets per iteration from an in-memory buffer:

| reader | mean time / 256 packets | throughput |
|---|---|---|
| `master` (36156e984): `VarInt::read_async` | 6.609 µs | 38.7 Melem/s |
| this PR: manual 3-byte length loop | **6.285 µs** | **40.7 Melem/s** |

**+5.2%** decode throughput (confidence intervals do not overlap; absolute numbers are machine-specific).

### How to replicate

On this branch:

```bash
cargo bench -p steel-protocol --bench packet_reader_framing
```

For the `master` row, copy the bench onto a `master` worktree (it uses only pre-existing APIs, so it compiles unchanged):

```bash
git worktree add --detach /tmp/steel-master 36156e984
mkdir -p /tmp/steel-master/steel-protocol/benches
git show pr3-read-path-hardening:steel-protocol/benches/packet_reader_framing.rs \
  > /tmp/steel-master/steel-protocol/benches/packet_reader_framing.rs
cat >> /tmp/steel-master/steel-protocol/Cargo.toml <<'EOF'

[dev-dependencies]
criterion = { workspace = true, features = ["async_tokio"] }

[[bench]]
name = "packet_reader_framing"
harness = false
EOF
cd /tmp/steel-master && cargo bench -p steel-protocol --bench packet_reader_framing
```

## Screenshots / logs

N/A.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable) — N/A
- [x] No leftover debug code / comments

## Additional notes

- The bench lives in `steel-protocol/benches/packet_reader_framing.rs` (renamed from `packet_codec.rs`) so it cannot add/add-conflict with #545's `packet_codec.rs` bench; the two PRs now merge cleanly in either order.
- Vanilla references verified against the local `minecraft-src` tree: `Varint21FrameDecoder.java` (3-byte cap, zero-length rejection) and `CompressionDecoder.java` (nonzero below-threshold rejection before inflation).
- Adds a `criterion` `async_tokio` dev-feature for `steel-protocol`.
- Env: Linux, Rust nightly, Minecraft protocol 776 (0.15.2+mc26.2).
