### PR TITLE
feat: pre-play lifecycle timeouts, config keepalive, and favicon caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -2801,6 +2802,7 @@ version = "0.15.2+mc26.2"
 dependencies = [
  "aes",
  "cfb8",
+ "criterion",
  "flate2",
  "glam",
  "log",

--- a/steel-core/src/player/connection/java.rs
+++ b/steel-core/src/player/connection/java.rs
@@ -811,7 +811,7 @@ impl JavaConnection {
                     .lock()
                     .on_chunk_batch_received_by_client(packet.desired_chunks_per_tick);
             }
-            ImmediatePlayPacket::Unknown(id) => log::info!("play packet id {id} is not known"),
+            ImmediatePlayPacket::Unknown(id) => log::debug!("play packet id {id} is not known"),
         }
     }
 
@@ -830,10 +830,14 @@ impl JavaConnection {
                     match packet {
                         Ok(packet) => {
                             if let Some(player) = self.player.upgrade()
-                                && let Err(err) = self.process_packet(packet, player, &server) {
-                                log::warn!(
-                                    "Failed to get packet from client {}: {err}",
-                                    self.id
+                                && let Err(err) = self.process_packet(packet, player, &server)
+                            {
+                                // A packet failed to decode or dispatch. The stream framing
+                                // is still intact, so the vanilla invalid-packet disconnect
+                                // reaches the client before the connection closes.
+                                log::warn!("Failed to process packet from client {}: {err}", self.id);
+                                self.disconnect(
+                                    translations::MULTIPLAYER_DISCONNECT_INVALID_PACKET.msg(),
                                 );
                             }
                         }

--- a/steel-core/src/player/connection/java.rs
+++ b/steel-core/src/player/connection/java.rs
@@ -397,13 +397,15 @@ pub struct JavaConnection {
 }
 
 impl JavaConnection {
-    /// Creates a new `JavaConnection`.
+    /// Creates a new `JavaConnection`, seeding the smoothed latency measured during the
+    /// configuration phase (vanilla carries it in `CommonListenerCookie`).
     pub const fn new(
         outgoing_packets: UnboundedSender<OutboundPacket>,
         cancel_token: CancellationToken,
         compression: Option<CompressionInfo>,
         network_writer: JavaNetworkWriter,
         id: u64,
+        latency: u32,
         player: Weak<Player>,
     ) -> Self {
         Self {
@@ -418,7 +420,7 @@ impl JavaConnection {
                 alive_pending: false,
                 alive_id: 0,
             }),
-            latency: SyncMutex::new(0),
+            latency: SyncMutex::new(latency),
         }
     }
 

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -860,8 +860,13 @@ impl Server {
         }
     }
 }
+
 /// Loads the configured favicon into its data-URL representation once at startup so the
 /// status ping path performs no disk I/O.
+///
+/// Mirrors vanilla `MinecraftServer.loadStatusIcon`: the file must be a PNG with a
+/// 64x64 `IHDR`, otherwise it is rejected with a logged error and the server starts
+/// without a favicon.
 fn load_favicon(config: &RuntimeConfig) -> Option<String> {
     use base64::{Engine, prelude::BASE64_STANDARD};
 
@@ -871,20 +876,39 @@ fn load_favicon(config: &RuntimeConfig) -> Option<String> {
         return None;
     }
 
-    let icon = match fs::read(&config.favicon) {
-        Ok(icon) => icon,
-        Err(error) => {
-            log::warn!(
-                "Failed to read configured favicon {}: {error}",
-                config.favicon
-            );
-            return None;
-        }
+    let icon = fs::read(&config.favicon)
+        .map_err(|error| log::error!("Couldn't load server icon: {error}"))
+        .ok()?;
+    let Some((width, height)) = png_dimensions(&icon) else {
+        log::error!("Couldn't load server icon: not a PNG file");
+        return None;
     };
+    if width != 64 || height != 64 {
+        log::error!(
+            "Couldn't load server icon: invalid icon size [{width}, {height}], but expected [64, 64]"
+        );
+        return None;
+    }
 
     let cap = ICON_PREFIX.len() + icon.len().div_ceil(3) * 4;
     let mut base64 = String::with_capacity(cap);
     base64 += ICON_PREFIX;
     BASE64_STANDARD.encode_string(icon, &mut base64);
     Some(base64)
+}
+
+/// Extracts the `IHDR` dimensions from PNG bytes, mirroring vanilla `PngInfo.fromBytes`:
+/// PNG signature, a 13-byte `IHDR` chunk, then big-endian width and height.
+fn png_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    const PNG_SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+
+    if bytes.len() < 24 || bytes[..8] != PNG_SIGNATURE {
+        return None;
+    }
+    if u32::from_be_bytes(bytes[8..12].try_into().ok()?) != 13 || bytes[12..16] != *b"IHDR" {
+        return None;
+    }
+    let width = u32::from_be_bytes(bytes[16..20].try_into().ok()?);
+    let height = u32::from_be_bytes(bytes[20..24].try_into().ok()?);
+    Some((width, height))
 }

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -77,7 +77,7 @@ use rustc_hash::FxHashMap;
 use std::sync::atomic::AtomicI32;
 use std::{
     collections::BTreeSet,
-    io, mem,
+    fs, io, mem,
     num::NonZero,
     path::Path,
     sync::{Arc, mpsc},
@@ -401,6 +401,8 @@ use jobs::teleport::{
 pub struct Server {
     /// Runtime configuration (view distance, compression, etc.).
     pub config: Arc<RuntimeConfig>,
+    /// Favicon data URL loaded once at startup, if configured.
+    pub favicon: Option<String>,
     /// Runtime permission groups and their persistence boundary.
     pub permission_groups: PermissionGroupManager,
     /// The cancellation token for graceful shutdown.
@@ -727,8 +729,11 @@ impl Server {
             log::error!("Minecraft services key fetch task stopped before its initial attempt");
         }
 
+        let favicon = load_favicon(&config);
+
         Ok(Server {
             config,
+            favicon,
             permission_groups,
             cancel_token,
             key_store: KeyStore::create(),
@@ -854,4 +859,32 @@ impl Server {
             }
         }
     }
+}
+/// Loads the configured favicon into its data-URL representation once at startup so the
+/// status ping path performs no disk I/O.
+fn load_favicon(config: &RuntimeConfig) -> Option<String> {
+    use base64::{Engine, prelude::BASE64_STANDARD};
+
+    const ICON_PREFIX: &str = "data:image/png;base64,";
+
+    if !config.use_favicon {
+        return None;
+    }
+
+    let icon = match fs::read(&config.favicon) {
+        Ok(icon) => icon,
+        Err(error) => {
+            log::warn!(
+                "Failed to read configured favicon {}: {error}",
+                config.favicon
+            );
+            return None;
+        }
+    };
+
+    let cap = ICON_PREFIX.len() + icon.len().div_ceil(3) * 4;
+    let mut base64 = String::with_capacity(cap);
+    base64 += ICON_PREFIX;
+    BASE64_STANDARD.encode_string(icon, &mut base64);
+    Some(base64)
 }

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -3118,3 +3118,55 @@ fn damage_command_records_by_entity_as_the_responsible_player() {
         }
     });
 }
+
+#[test]
+fn load_favicon_rejects_invalid_pngs_like_vanilla() {
+    // `fs` at module scope is `tokio::fs`; the loader under test runs sync.
+    use std::{fs, process};
+
+    let header = |width: u32, height: u32| -> Vec<u8> {
+        let mut bytes = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        bytes.extend_from_slice(&13u32.to_be_bytes());
+        bytes.extend_from_slice(b"IHDR");
+        bytes.extend_from_slice(&width.to_be_bytes());
+        bytes.extend_from_slice(&height.to_be_bytes());
+        bytes
+    };
+
+    let mut config = Arc::unwrap_or_clone(test_runtime_config());
+    config.use_favicon = true;
+
+    // A valid 64x64 icon is cached as a data URL.
+    let path = temp_dir().join(format!("steel-favicon-64-{}", process::id()));
+    fs::write(&path, header(64, 64)).expect("test favicon should be writable");
+    config.favicon = path.display().to_string();
+    let favicon = super::load_favicon(&config).expect("a 64x64 PNG should load");
+    assert!(favicon.starts_with("data:image/png;base64,"));
+    let _ = fs::remove_file(&path);
+
+    // Wrong dimensions, a bad signature, and a truncated file are all rejected, like
+    // vanilla `loadStatusIcon` via `PngInfo`.
+    let cases = [
+        ("wrong-size", header(63, 64)),
+        ("bad-signature", {
+            let mut bytes = header(64, 64);
+            bytes[0] = 0x00;
+            bytes
+        }),
+        ("truncated", vec![0x89, b'P', b'N', b'G']),
+    ];
+    for (name, contents) in cases {
+        let path = temp_dir().join(format!("steel-favicon-{name}-{}", process::id()));
+        fs::write(&path, contents).expect("test favicon should be writable");
+        config.favicon = path.display().to_string();
+        assert!(
+            super::load_favicon(&config).is_none(),
+            "{name} should be rejected"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    // Disabled favicons never load, even when the file is valid.
+    config.use_favicon = false;
+    assert!(super::load_favicon(&config).is_none());
+}

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -229,6 +229,7 @@ async fn test_server_with_worlds(
 
     Ok(Arc::new(Server {
         config,
+        favicon: None,
         permission_groups,
         cancel_token: CancellationToken::new(),
         key_store: KeyStore::create(),

--- a/steel-core/src/server/tests/connection_lifecycle.rs
+++ b/steel-core/src/server/tests/connection_lifecycle.rs
@@ -44,6 +44,7 @@ fn java_test_player(
             None,
             Arc::clone(&network_writer),
             1,
+            0,
             player_weak.clone(),
         )));
         Player::new(

--- a/steel-login/src/handlers/config.rs
+++ b/steel-login/src/handlers/config.rs
@@ -122,6 +122,7 @@ impl JavaTcpClient {
                 self.compression.load(),
                 self.network_writer.clone(),
                 self.id,
+                self.config_keepalive.lock().latency,
                 player_weak.clone(),
             );
             let connection = Arc::new(PlayerConnection::Java(java_connection));

--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -1,5 +1,7 @@
 //! Login state packet handlers.
 
+use std::time::Instant;
+
 use rsa::Pkcs1v15Encrypt;
 use sha1::Sha1;
 use sha2::Digest;
@@ -245,6 +247,7 @@ impl JavaTcpClient {
         }
         self.login_deadline.store(None);
         self.protocol.store(ConnectionProtocol::Config);
+        self.config_keepalive.lock().last_sent = Instant::now();
 
         self.start_configuration().await;
         ConnectionAction::none()

--- a/steel-login/src/handlers/status.rs
+++ b/steel-login/src/handlers/status.rs
@@ -1,6 +1,5 @@
 //! Status state packet handlers (server list ping).
 
-use steel_core::config::RuntimeConfig;
 use steel_protocol::packets::{
     common::{CPongResponse, SPingRequest},
     status::{CStatusResponse, Players, Sample, Status, Version},
@@ -26,7 +25,7 @@ impl JavaTcpClient {
                     .collect(),
             }),
             enforces_secure_chat: self.server.enforces_secure_chat(),
-            favicon: load_favicon(&self.server.config),
+            favicon: self.server.favicon.clone(),
             version: Some(Version {
                 name: MC_VERSION,
                 protocol: CURRENT_MC_PROTOCOL,
@@ -41,28 +40,4 @@ impl JavaTcpClient {
             .await;
         self.close();
     }
-}
-
-/// Loads the favicon from config.
-fn load_favicon(config: &RuntimeConfig) -> Option<String> {
-    use base64::{Engine, prelude::BASE64_STANDARD};
-    use std::fs;
-    use std::path::Path;
-
-    const ICON_PREFIX: &str = "data:image/png;base64,";
-
-    if !config.use_favicon {
-        return None;
-    }
-
-    let path = Path::new(&config.favicon);
-    let Ok(icon) = fs::read(path) else {
-        return None;
-    };
-
-    let cap = ICON_PREFIX.len() + icon.len().div_ceil(3) * 4;
-    let mut base64 = String::with_capacity(cap);
-    base64 += ICON_PREFIX;
-    BASE64_STANDARD.encode_string(icon, &mut base64);
-    Some(base64)
 }

--- a/steel-login/src/tcp_client.rs
+++ b/steel-login/src/tcp_client.rs
@@ -10,7 +10,7 @@ use std::{
     io::Cursor,
     net::SocketAddr,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use crossbeam::atomic::AtomicCell;
@@ -24,7 +24,9 @@ use steel_protocol::{
     packet_traits::{ClientPacket, CompressionInfo, EncodedPacket, ServerPacket},
     packet_writer::TCPNetworkEncoder,
     packets::{
-        common::{CDisconnect, SClientInformation, SCustomPayload, SPingRequest},
+        common::{
+            CDisconnect, CKeepAlive, SClientInformation, SCustomPayload, SKeepAlive, SPingRequest,
+        },
         config::SSelectKnownPacks,
         handshake::{ClientIntent, SClientIntention},
         login::{CLoginDisconnect, SHello, SKey},
@@ -42,6 +44,7 @@ use steel_utils::{
 use text_components::{
     TextComponent, content::Resolvable, custom::CustomData, resolving::TextResolutor,
 };
+use tokio::time::{Interval, interval};
 use tokio::{
     io::{BufReader, BufWriter},
     net::{TcpStream, tcp::OwnedReadHalf},
@@ -88,6 +91,7 @@ enum LoginOperationResult<T> {
 enum IncomingEvent {
     Packet(Result<RawPacket, PacketError>),
     ConnectionUpdate(Result<ConnectionUpdate, RecvError>),
+    KeepAliveTick,
 }
 
 async fn await_login_operation<T, O, D>(
@@ -192,6 +196,14 @@ impl ConnectionAction {
     }
 }
 
+/// Configuration keep-alive state, mirroring vanilla's pre-play keep-alive timing.
+pub(crate) struct PrePlayKeepAliveTracker {
+    /// Last time a challenge was sent (or the phase was entered).
+    pub(crate) last_sent: Instant,
+    /// The challenge the client has not answered yet.
+    pub(crate) pending: Option<i64>,
+}
+
 /// Connection for pre-play packets.
 ///
 /// Gets dropped by `incoming_packet_task` if closed or upgraded to play connection.
@@ -220,6 +232,8 @@ pub struct JavaTcpClient {
     pub connection_session: Arc<ServerConnectionSession>,
     /// The challenge sent to the client during login.
     pub challenge: AtomicCell<[u8; 4]>,
+    /// Outstanding configuration keep-alive challenge awaiting the client response.
+    pub(crate) config_keepalive: SyncMutex<PrePlayKeepAliveTracker>,
 
     /// Channel for broadcasting connection state updates.
     pub connection_updates: Sender<ConnectionUpdate>,
@@ -266,6 +280,10 @@ impl JavaTcpClient {
             server,
             connection_session,
             challenge: AtomicCell::new([0; 4]),
+            config_keepalive: SyncMutex::new(PrePlayKeepAliveTracker {
+                last_sent: Instant::now(),
+                pending: None,
+            }),
             connection_updates,
             connection_updated: Arc::new(Notify::new()),
             pre_play_state: SyncMutex::new(PrePlayState::new()),
@@ -482,26 +500,13 @@ impl JavaTcpClient {
 
         self.task_tracker.spawn(async move {
             let mut connection = None;
+            let mut config_keepalive_tick = interval(Duration::from_secs(15));
+            // Consume the immediate first tick so the cadence starts at 15 seconds.
+            config_keepalive_tick.tick().await;
             loop {
-                let incoming_event = if self_clone.login_deadline_expired() {
-                    LoginOperationResult::TimedOut
-                } else {
-                    let incoming_event = async {
-                        select! {
-                            packet = reader.get_raw_packet() => IncomingEvent::Packet(packet),
-                            connection_update = connection_updates_recv.recv() => {
-                                IncomingEvent::ConnectionUpdate(connection_update)
-                            }
-                        }
-                    };
-                    await_login_operation(
-                        &cancel_token,
-                        &self_clone.login_deadline,
-                        incoming_event,
-                        self_clone.wait_for_login_deadline(),
-                    )
-                    .await
-                };
+                let incoming_event = self_clone
+                    .await_incoming_event(&mut reader, &mut connection_updates_recv, &mut config_keepalive_tick)
+                    .await;
 
                 match incoming_event {
                     LoginOperationResult::Completed(IncomingEvent::Packet(Ok(packet))) => {
@@ -557,6 +562,11 @@ impl JavaTcpClient {
                             cancel_token.cancel();
                         }
                     },
+                    LoginOperationResult::Completed(IncomingEvent::KeepAliveTick) => {
+                        if self_clone.protocol.load() == ConnectionProtocol::Config {
+                            self_clone.tick_config_keepalive().await;
+                        }
+                    }
                     LoginOperationResult::Cancelled => break,
                     LoginOperationResult::TimedOut => {
                         if self_clone.login_deadline_expired() {
@@ -580,6 +590,35 @@ impl JavaTcpClient {
                 }
             }
         });
+    }
+
+    /// Awaits the next pre-play event: an inbound packet, a connection update, or a
+    /// configuration keep-alive tick, bounded by the login deadline when one is set.
+    async fn await_incoming_event(
+        &self,
+        reader: &mut TCPNetworkDecoder<BufReader<OwnedReadHalf>>,
+        connection_updates_recv: &mut broadcast::Receiver<ConnectionUpdate>,
+        config_keepalive_tick: &mut Interval,
+    ) -> LoginOperationResult<IncomingEvent> {
+        if self.login_deadline_expired() {
+            return LoginOperationResult::TimedOut;
+        }
+        let incoming_event = async {
+            select! {
+                packet = reader.get_raw_packet() => IncomingEvent::Packet(packet),
+                connection_update = connection_updates_recv.recv() => {
+                    IncomingEvent::ConnectionUpdate(connection_update)
+                }
+                _ = config_keepalive_tick.tick() => IncomingEvent::KeepAliveTick,
+            }
+        };
+        await_login_operation(
+            &self.cancel_token,
+            &self.login_deadline,
+            incoming_event,
+            self.wait_for_login_deadline(),
+        )
+        .await
     }
 
     fn login_deadline_expired(&self) -> bool {
@@ -773,6 +812,27 @@ impl JavaTcpClient {
                     .await;
                 Ok(ConnectionAction::none())
             }
+            config::S_KEEP_ALIVE => {
+                let packet = SKeepAlive::read_packet(data)?;
+                let accepted = {
+                    let mut tracker = self.config_keepalive.lock();
+                    let accepted = tracker.pending == Some(packet.id);
+                    if accepted {
+                        tracker.pending = None;
+                    }
+                    accepted
+                };
+                if accepted {
+                    Ok(ConnectionAction::none())
+                } else {
+                    // Vanilla disconnects clients answering out of order with a timeout.
+                    self.kick(TextComponent::translated(
+                        translations::DISCONNECT_TIMEOUT.msg(),
+                    ))
+                    .await;
+                    Ok(ConnectionAction::none())
+                }
+            }
             config::S_FINISH_CONFIGURATION => {
                 if let Err(error) = self.expect_pre_play_packet(PrePlayPacket::FinishConfiguration)
                 {
@@ -781,6 +841,36 @@ impl JavaTcpClient {
                 Ok(self.finish_configuration().await)
             }
             _ => Err(PacketError::InvalidProtocol("Config".to_string())),
+        }
+    }
+
+    /// Ticks the configuration keep-alive: sends a challenge after 15 idle seconds and
+    /// disconnects clients that ignore one for 30 seconds (vanilla timing).
+    async fn tick_config_keepalive(&self) {
+        let now = Instant::now();
+        let mut send_challenge = None;
+        let mut timed_out = false;
+        {
+            let mut tracker = self.config_keepalive.lock();
+            if tracker.pending.is_some() {
+                timed_out = now.duration_since(tracker.last_sent) >= Duration::from_secs(30);
+            } else if now.duration_since(tracker.last_sent) >= Duration::from_secs(15) {
+                let challenge = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("system time before epoch")
+                    .as_millis() as i64;
+                tracker.pending = Some(challenge);
+                tracker.last_sent = now;
+                send_challenge = Some(challenge);
+            }
+        }
+        if let Some(challenge) = send_challenge {
+            self.send_bare_packet_now(CKeepAlive::new(challenge)).await;
+        } else if timed_out {
+            self.kick(TextComponent::translated(
+                translations::DISCONNECT_TIMEOUT.msg(),
+            ))
+            .await;
         }
     }
 

--- a/steel-login/src/tcp_client.rs
+++ b/steel-login/src/tcp_client.rs
@@ -44,7 +44,7 @@ use steel_utils::{
 use text_components::{
     TextComponent, content::Resolvable, custom::CustomData, resolving::TextResolutor,
 };
-use tokio::time::{Interval, interval};
+use tokio::time::{Interval, MissedTickBehavior, interval};
 use tokio::{
     io::{BufReader, BufWriter},
     net::{TcpStream, tcp::OwnedReadHalf},
@@ -62,7 +62,11 @@ use uuid::Uuid;
 use crate::pre_play_state::{PacketSequenceError, PrePlayPacket, PrePlayState};
 
 const MAX_TICKS_BEFORE_LOGIN: u64 = 600;
-const SLOW_LOGIN_DISCONNECT_FLUSH_TIMEOUT: Duration = Duration::from_secs(1);
+const DISCONNECT_FLUSH_TIMEOUT: Duration = Duration::from_secs(1);
+/// Bound for the periodic keep-alive write itself: a healthy client accepts it in
+/// microseconds, so a stall means the socket is wedged and the connection must close
+/// instead of the read loop blocking on the write forever.
+const KEEP_ALIVE_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct LoginDeadline {
@@ -196,12 +200,74 @@ impl ConnectionAction {
     }
 }
 
-/// Configuration keep-alive state, mirroring vanilla's pre-play keep-alive timing.
+/// What a configuration keep-alive tick should do.
+enum KeepAliveDecision {
+    /// Nothing is due yet.
+    None,
+    /// Send a challenge with this id.
+    Send(i64),
+    /// The pending challenge went unanswered for a full interval; kick.
+    Timeout,
+}
+
+/// Configuration keep-alive state, mirroring vanilla's `ServerCommonPacketListenerImpl`
+/// keep-alive timing and latency smoothing.
 pub(crate) struct PrePlayKeepAliveTracker {
     /// Last time a challenge was sent (or the phase was entered).
     pub(crate) last_sent: Instant,
     /// The challenge the client has not answered yet.
     pub(crate) pending: Option<i64>,
+    /// Smoothed round-trip latency in milliseconds, seeded into the play connection like
+    /// vanilla's `CommonListenerCookie.latency()`.
+    pub(crate) latency: u32,
+}
+
+impl PrePlayKeepAliveTracker {
+    /// Vanilla sends a keep-alive every 15 seconds since the last send and kicks a
+    /// client whose challenge went unanswered for a full interval.
+    const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+    /// Decides this tick's action, mirroring vanilla `keepConnectionAlive`.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "milliseconds since the Unix epoch fit i64 for the next 292 million years"
+    )]
+    fn tick(&mut self, now: Instant) -> KeepAliveDecision {
+        if now.duration_since(self.last_sent) < Self::KEEP_ALIVE_INTERVAL {
+            return KeepAliveDecision::None;
+        }
+        if self.pending.is_some() {
+            return KeepAliveDecision::Timeout;
+        }
+
+        // Vanilla uses `Util.getMillis()` as the challenge id.
+        let challenge = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System time before UNIX EPOCH")
+            .as_millis() as i64;
+        self.pending = Some(challenge);
+        self.last_sent = now;
+        KeepAliveDecision::Send(challenge)
+    }
+
+    /// Records a client keep-alive response. Returns `true` when it answers the pending
+    /// challenge, smoothing the latency like vanilla `handleKeepAlive`; out-of-order
+    /// answers return `false` and are a timeout kick.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "an unanswered challenge times out after one interval, so the round trip stays far below u32::MAX ms"
+    )]
+    fn answer(&mut self, id: i64, now: Instant) -> bool {
+        match self.pending {
+            Some(pending) if pending == id => {
+                let round_trip = now.duration_since(self.last_sent).as_millis() as u32;
+                self.latency = (self.latency * 3 + round_trip) / 4;
+                self.pending = None;
+                true
+            }
+            _ => false,
+        }
+    }
 }
 
 /// Connection for pre-play packets.
@@ -283,6 +349,7 @@ impl JavaTcpClient {
             config_keepalive: SyncMutex::new(PrePlayKeepAliveTracker {
                 last_sent: Instant::now(),
                 pending: None,
+                latency: 0,
             }),
             connection_updates,
             connection_updated: Arc::new(Notify::new()),
@@ -500,8 +567,11 @@ impl JavaTcpClient {
 
         self.task_tracker.spawn(async move {
             let mut connection = None;
-            let mut config_keepalive_tick = interval(Duration::from_secs(15));
-            // Consume the immediate first tick so the cadence starts at 15 seconds.
+            // One-second ticks give the vanilla 15-second send and timeout boundaries
+            // one-second resolution on a single shared timer.
+            let mut config_keepalive_tick = interval(Duration::from_secs(1));
+            config_keepalive_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            // Consume the immediate first tick so the cadence starts at one second.
             config_keepalive_tick.tick().await;
             loop {
                 let incoming_event = self_clone
@@ -658,7 +728,7 @@ impl JavaTcpClient {
     pub(crate) async fn disconnect_slow_login(&self) {
         let reason =
             TextComponent::translated(translations::MULTIPLAYER_DISCONNECT_SLOW_LOGIN.msg());
-        if timeout(SLOW_LOGIN_DISCONNECT_FLUSH_TIMEOUT, self.kick(reason))
+        if timeout(DISCONNECT_FLUSH_TIMEOUT, self.kick(reason))
             .await
             .is_err()
         {
@@ -814,15 +884,11 @@ impl JavaTcpClient {
             }
             config::S_KEEP_ALIVE => {
                 let packet = SKeepAlive::read_packet(data)?;
-                let accepted = {
-                    let mut tracker = self.config_keepalive.lock();
-                    let accepted = tracker.pending == Some(packet.id);
-                    if accepted {
-                        tracker.pending = None;
-                    }
-                    accepted
-                };
-                if accepted {
+                if self
+                    .config_keepalive
+                    .lock()
+                    .answer(packet.id, Instant::now())
+                {
                     Ok(ConnectionAction::none())
                 } else {
                     // Vanilla disconnects clients answering out of order with a timeout.
@@ -844,33 +910,33 @@ impl JavaTcpClient {
         }
     }
 
-    /// Ticks the configuration keep-alive: sends a challenge after 15 idle seconds and
-    /// disconnects clients that ignore one for 30 seconds (vanilla timing).
+    /// Ticks the configuration keep-alive, executing the tracker's vanilla-timed
+    /// decision. Both writes are bounded: a wedged socket must close the connection
+    /// instead of stalling the read loop.
     async fn tick_config_keepalive(&self) {
-        let now = Instant::now();
-        let mut send_challenge = None;
-        let mut timed_out = false;
-        {
-            let mut tracker = self.config_keepalive.lock();
-            if tracker.pending.is_some() {
-                timed_out = now.duration_since(tracker.last_sent) >= Duration::from_secs(30);
-            } else if now.duration_since(tracker.last_sent) >= Duration::from_secs(15) {
-                let challenge = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .expect("system time before epoch")
-                    .as_millis() as i64;
-                tracker.pending = Some(challenge);
-                tracker.last_sent = now;
-                send_challenge = Some(challenge);
+        let decision = self.config_keepalive.lock().tick(Instant::now());
+        match decision {
+            KeepAliveDecision::None => {}
+            KeepAliveDecision::Send(challenge) => {
+                if timeout(
+                    KEEP_ALIVE_WRITE_TIMEOUT,
+                    self.send_bare_packet_now(CKeepAlive::new(challenge)),
+                )
+                .await
+                .is_err()
+                {
+                    self.close();
+                }
             }
-        }
-        if let Some(challenge) = send_challenge {
-            self.send_bare_packet_now(CKeepAlive::new(challenge)).await;
-        } else if timed_out {
-            self.kick(TextComponent::translated(
-                translations::DISCONNECT_TIMEOUT.msg(),
-            ))
-            .await;
+            KeepAliveDecision::Timeout => {
+                let reason = TextComponent::translated(translations::DISCONNECT_TIMEOUT.msg());
+                if timeout(DISCONNECT_FLUSH_TIMEOUT, self.kick(reason))
+                    .await
+                    .is_err()
+                {
+                    self.close();
+                }
+            }
         }
     }
 

--- a/steel-login/src/tcp_client.rs
+++ b/steel-login/src/tcp_client.rs
@@ -524,6 +524,10 @@ impl JavaTcpClient {
                             }
                             LoginOperationResult::Completed(Err(err)) => {
                                 log::warn!("Failed to get packet from client {id}: {err}");
+                                let reason = TextComponent::translated(
+                                    translations::MULTIPLAYER_DISCONNECT_INVALID_PACKET.msg(),
+                                );
+                                self_clone.kick(reason).await;
                             }
                             LoginOperationResult::Cancelled => break,
                             LoginOperationResult::TimedOut => {

--- a/steel-login/src/tcp_client/tests.rs
+++ b/steel-login/src/tcp_client/tests.rs
@@ -5,12 +5,16 @@ use std::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     task::Poll,
+    time::{Duration, Instant},
 };
 
 use crossbeam::atomic::AtomicCell;
 use tokio_util::sync::CancellationToken;
 
-use super::{LoginDeadline, LoginOperationResult, await_login_operation};
+use super::{
+    KeepAliveDecision, LoginDeadline, LoginOperationResult, PrePlayKeepAliveTracker,
+    await_login_operation,
+};
 
 struct DropSignal(Arc<AtomicBool>);
 
@@ -73,4 +77,58 @@ async fn configuration_handoff_disables_ready_login_deadline() {
     let result = await_login_operation(&cancel_token, &login_deadline, operation, ready(())).await;
 
     assert!(matches!(result, LoginOperationResult::Completed(())));
+}
+
+#[test]
+fn keepalive_decisions_match_vanilla_boundaries() {
+    let now = Instant::now();
+    let mut tracker = PrePlayKeepAliveTracker {
+        last_sent: now,
+        pending: None,
+        latency: 0,
+    };
+
+    // Fresh phase: nothing is due before a full interval.
+    assert!(matches!(
+        tracker.tick(now + Duration::from_secs(14)),
+        KeepAliveDecision::None
+    ));
+
+    // One interval after entering the phase: a challenge goes out and re-anchors the
+    // send cadence, like vanilla `keepConnectionAlive`.
+    let KeepAliveDecision::Send(challenge) = tracker.tick(now + Duration::from_secs(15)) else {
+        panic!("a challenge is due after one interval");
+    };
+    assert_eq!(tracker.pending, Some(challenge));
+    assert_eq!(tracker.last_sent, now + Duration::from_secs(15));
+
+    // A challenge left unanswered for a full interval is a timeout kick.
+    assert!(matches!(
+        tracker.tick(tracker.last_sent + Duration::from_secs(15)),
+        KeepAliveDecision::Timeout
+    ));
+}
+
+#[test]
+fn keepalive_answer_smooths_latency_and_rejects_out_of_order() {
+    let now = Instant::now();
+    let mut tracker = PrePlayKeepAliveTracker {
+        last_sent: now,
+        pending: Some(1234),
+        latency: 100,
+    };
+
+    // A wrong id is out of order and changes nothing (vanilla kicks with a timeout).
+    assert!(!tracker.answer(999, now + Duration::from_millis(40)));
+    assert_eq!(tracker.pending, Some(1234));
+    assert_eq!(tracker.latency, 100);
+
+    // The matching id is accepted and smooths the latency like vanilla `handleKeepAlive`:
+    // (100 * 3 + 40) / 4 = 85.
+    assert!(tracker.answer(1234, now + Duration::from_millis(40)));
+    assert_eq!(tracker.pending, None);
+    assert_eq!(tracker.latency, 85);
+
+    // A duplicate answer without a pending challenge is out of order too.
+    assert!(!tracker.answer(1234, now + Duration::from_millis(50)));
 }

--- a/steel-protocol/Cargo.toml
+++ b/steel-protocol/Cargo.toml
@@ -45,3 +45,10 @@ text_components.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+criterion = { workspace = true, features = ["async_tokio"] }
+
+[[bench]]
+name = "packet_reader_framing"
+harness = false

--- a/steel-protocol/benches/packet_reader_framing.rs
+++ b/steel-protocol/benches/packet_reader_framing.rs
@@ -1,0 +1,50 @@
+#![expect(missing_docs, reason = "benchmarks")]
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use steel_protocol::packet_reader::TCPNetworkDecoder;
+use steel_utils::codec::VarInt;
+use steel_utils::serial::WriteTo;
+use tokio::runtime::Builder;
+
+/// Decodes 256 framed packets from a pre-built wire buffer, exercising the length
+/// framing path.
+fn bench_packet_reader_framing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("packet_reader_framing");
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut wire = Vec::new();
+    for i in 0i32..256 {
+        let mut packet = Vec::new();
+        VarInt::from(i)
+            .write(&mut packet)
+            .expect("packet id should encode");
+        packet.extend_from_slice(&[0xABu8; 32]);
+        VarInt::from(packet.len() as i32)
+            .write(&mut wire)
+            .expect("packet length should encode");
+        wire.extend_from_slice(&packet);
+    }
+    group.throughput(Throughput::Elements(256));
+
+    group.bench_function("decode_256_packets", |b| {
+        b.to_async(&rt).iter(|| async {
+            let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+            for _ in 0..256 {
+                let packet = decoder
+                    .get_raw_packet()
+                    .await
+                    .expect("packet should decode");
+                black_box(packet.id);
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_packet_reader_framing);
+criterion_main!(benches);

--- a/steel-protocol/src/packet_reader.rs
+++ b/steel-protocol/src/packet_reader.rs
@@ -18,9 +18,7 @@ use steel_utils::codec::VarInt;
 use steel_utils::serial::ReadFrom;
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 
-use crate::utils::{
-    Aes128Cfb8Dec, MAX_PACKET_DATA_SIZE, MAX_PACKET_SIZE, PacketError, RawPacket, StreamDecryptor,
-};
+use crate::utils::{Aes128Cfb8Dec, MAX_PACKET_DATA_SIZE, PacketError, RawPacket, StreamDecryptor};
 
 /// A reader that can decrypt data.
 pub enum DecryptionReader<R: AsyncRead + Unpin> {
@@ -108,10 +106,32 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
     /// - If the packet fails to decompress.
     #[expect(clippy::cast_sign_loss)]
     pub async fn get_raw_packet(&mut self) -> Result<RawPacket, PacketError> {
-        let packet_len = VarInt::read_async(&mut self.reader).await? as usize;
+        // Decode the packet length VarInt manually, capping it at 3 bytes like vanilla
+        // `Varint21FrameDecoder`, so oversized lengths fail fast instead of consuming
+        // unbounded input.
+        let mut packet_len: usize = 0;
+        let mut length_bytes = 0;
+        loop {
+            if length_bytes == 3 {
+                Err(PacketError::MalformedLength(
+                    "packet length varint exceeds 3 bytes".to_string(),
+                ))?;
+            }
 
-        if packet_len > MAX_PACKET_SIZE {
-            Err(PacketError::OutOfBounds)?;
+            let mut byte = [0u8; 1];
+            self.reader.read_exact(&mut byte).await?;
+            packet_len |= ((byte[0] & 0x7F) as usize) << (7 * length_bytes);
+            length_bytes += 1;
+
+            if byte[0] & 0x80 == 0 {
+                break;
+            }
+        }
+
+        if packet_len == 0 {
+            Err(PacketError::MalformedLength(
+                "packet length cannot be zero".to_string(),
+            ))?;
         }
 
         // Read the entire packet data into a buffer
@@ -132,6 +152,10 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
             }
 
             if decompressed_len > 0 {
+                if decompressed_len < threshold.get() as usize {
+                    Err(PacketError::BelowThreshold(decompressed_len))?;
+                }
+
                 let mut decompressed = vec![0; decompressed_len];
                 let mut decoder = ZlibDecoder::new(&mut cursor);
                 decoder
@@ -603,5 +627,45 @@ mod compression_security_tests {
 
         assert_eq!(raw_packet.id, 2);
         assert_eq!(raw_packet.payload(), b"hello");
+    }
+
+    #[tokio::test]
+    async fn rejects_length_varint_wider_than_21_bits() {
+        // Four-byte length VarInt: three continuation bytes then a terminator, like
+        // vanilla `Varint21FrameDecoder`'s "length wider than 21-bit" case.
+        let wire = [0x80, 0x80, 0x80, 0x01];
+        let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::MalformedLength(message))
+                if message.contains("exceeds 3 bytes")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_length_frames() {
+        let wire = [0x00];
+        let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::MalformedLength(message))
+                if message.contains("cannot be zero")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_compressed_size_below_server_threshold() {
+        // A well-formed compressed packet whose declared size is under the server
+        // threshold: vanilla `CompressionDecoder` rejects it before inflating.
+        let packet = compressed_packet(5, b"hello");
+        let mut decoder = TCPNetworkDecoder::new(packet.as_slice());
+        decoder.set_compression(NonZeroU32::new(256).expect("nonzero threshold"));
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::BelowThreshold(5))
+        ));
     }
 }

--- a/steel-protocol/src/utils.rs
+++ b/steel-protocol/src/utils.rs
@@ -97,9 +97,6 @@ pub enum PacketError {
     #[error("packet length {0} exceeds maximum length")]
     /// The packet length exceeds the maximum length.
     TooLong(usize),
-    #[error("packet length is out of bounds")]
-    /// The packet length is out of bounds.
-    OutOfBounds,
     #[error("malformed packet length VarInt: {0}")]
     /// The packet length `VarInt` is malformed.
     MalformedLength(String),
@@ -112,6 +109,9 @@ pub enum PacketError {
     #[error("failed to compress packet: {0}")]
     /// Failed to compress the packet.
     CompressionFailed(String),
+    #[error("badly compressed packet - size of {0} is below the server threshold")]
+    /// The packet declares a compressed size below the server's compression threshold.
+    BelowThreshold(usize),
     #[error("packet is uncompressed but greater than the threshold")]
     /// The packet is uncompressed but greater than the threshold.
     NotCompressed,


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Performance improvement

## Description

Implements the vanilla pre-play lifecycle:

- **Login deadline**: a client still in the login phase 30 seconds after the handshake (vanilla `ServerLoginPacketListenerImpl`, `MAX_TICKS_BEFORE_LOGIN = 600`) is kicked with `multiplayer.disconnect.slow_login`. The read loop wraps packet reads in `timeout_at` while the deadline is active.
- **Configuration keep-alive**: challenges are sent every 15 seconds since the last send, and a challenge left unanswered for a full interval is a `disconnect.timeout` kick at the next boundary — vanilla `ServerCommonPacketListenerImpl.keepConnectionAlive` timing. Out-of-order answers are a timeout kick, and accepted answers smooth the round-trip latency that is seeded into the play connection (vanilla `CommonListenerCookie.latency()`). Uses the existing common `CKeepAlive`/`SKeepAlive` packets — no new packet types.
- **Status favicon caching**: the favicon is loaded once into `Server::favicon` at startup (a single warning is logged when the configured path is unreadable), removing blocking filesystem I/O from the per-ping `handle_status_request` path. The file is validated like vanilla `PngInfo`: it must be a PNG with a 64x64 `IHDR`, otherwise it is rejected with the vanilla `Couldn't load server icon` error.

## How this was tested

- `cargo test -p steel-login` (22 tests) and `cargo test -p steel-core --lib` (2467 tests) pass; `cargo clippy -r --all-targets` clean.
- New tests: `keepalive_decisions_match_vanilla_boundaries` and `keepalive_answer_smooths_latency_and_rejects_out_of_order` pin the vanilla keep-alive boundaries (15 s cadence, unanswered → timeout, out-of-order/duplicate answers rejected, latency smoothing); `load_favicon_rejects_invalid_pngs_like_vanilla` covers the favicon validation matrix.
- Manual E2E per the plan: raw socket handshake with intent=Login stalls 32 s → server logs the slow-login kick at t=30 s and closes; status ping answers immediately with the cached favicon (no disk access after startup).

## Screenshots / logs

N/A (server-log behavior only).

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable) — N/A
- [x] No leftover debug code / comments

## Additional notes

- Stack: `pr4-preplay-lifecycle` is stacked on `pr3-read-path-hardening`.
- Env: Linux, Rust nightly, Minecraft protocol 776 (0.15.2+mc26.2).

> **Note:** stacked on #547 (`pr3-read-path-hardening`). Until that merges, this PR's diff includes its commits; the lifecycle changes themselves are the final commits. Incremental diff: https://github.com/carabistouflette/SteelMC/compare/pr3-read-path-hardening...pr4-preplay-lifecycle
