### PR TITLE
feat: harden session-server authentication HTTP path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -2801,6 +2802,7 @@ version = "0.15.2+mc26.2"
 dependencies = [
  "aes",
  "cfb8",
+ "criterion",
  "flate2",
  "glam",
  "log",

--- a/steel-core/src/player/connection/java.rs
+++ b/steel-core/src/player/connection/java.rs
@@ -811,7 +811,7 @@ impl JavaConnection {
                     .lock()
                     .on_chunk_batch_received_by_client(packet.desired_chunks_per_tick);
             }
-            ImmediatePlayPacket::Unknown(id) => log::info!("play packet id {id} is not known"),
+            ImmediatePlayPacket::Unknown(id) => log::debug!("play packet id {id} is not known"),
         }
     }
 
@@ -830,11 +830,12 @@ impl JavaConnection {
                     match packet {
                         Ok(packet) => {
                             if let Some(player) = self.player.upgrade()
-                                && let Err(err) = self.process_packet(packet, player, &server) {
-                                log::warn!(
-                                    "Failed to get packet from client {}: {err}",
-                                    self.id
-                                );
+                                && let Err(err) = self.process_packet(packet, player, &server)
+                            {
+                                // The stream is desynchronized or the client sent a packet it
+                                // may not send; drop the connection instead of resyncing.
+                                log::warn!("Failed to process packet from client {}: {err}", self.id);
+                                self.close();
                             }
                         }
                         Err(err) => {

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -77,7 +77,7 @@ use rustc_hash::FxHashMap;
 use std::sync::atomic::AtomicI32;
 use std::{
     collections::BTreeSet,
-    io, mem,
+    fs, io, mem,
     num::NonZero,
     path::Path,
     sync::{Arc, mpsc},
@@ -401,6 +401,8 @@ use jobs::teleport::{
 pub struct Server {
     /// Runtime configuration (view distance, compression, etc.).
     pub config: Arc<RuntimeConfig>,
+    /// Favicon data URL loaded once at startup, if configured.
+    pub favicon: Option<String>,
     /// Runtime permission groups and their persistence boundary.
     pub permission_groups: PermissionGroupManager,
     /// The cancellation token for graceful shutdown.
@@ -727,8 +729,11 @@ impl Server {
             log::error!("Minecraft services key fetch task stopped before its initial attempt");
         }
 
+        let favicon = load_favicon(&config);
+
         Ok(Server {
             config,
+            favicon,
             permission_groups,
             cancel_token,
             key_store: KeyStore::create(),
@@ -854,4 +859,32 @@ impl Server {
             }
         }
     }
+}
+/// Loads the configured favicon into its data-URL representation once at startup so the
+/// status ping path performs no disk I/O.
+fn load_favicon(config: &RuntimeConfig) -> Option<String> {
+    use base64::{Engine, prelude::BASE64_STANDARD};
+
+    const ICON_PREFIX: &str = "data:image/png;base64,";
+
+    if !config.use_favicon {
+        return None;
+    }
+
+    let icon = match fs::read(&config.favicon) {
+        Ok(icon) => icon,
+        Err(error) => {
+            log::warn!(
+                "Failed to read configured favicon {}: {error}",
+                config.favicon
+            );
+            return None;
+        }
+    };
+
+    let cap = ICON_PREFIX.len() + icon.len().div_ceil(3) * 4;
+    let mut base64 = String::with_capacity(cap);
+    base64 += ICON_PREFIX;
+    BASE64_STANDARD.encode_string(icon, &mut base64);
+    Some(base64)
 }

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -452,8 +452,9 @@ pub struct Server {
     known_players: SyncMutex<KnownPlayerCacheState>,
     /// Wakes shutdown when the single known-player save worker becomes idle.
     known_player_save_idle: Notify,
-    /// HTTP client used by online-mode name-to-profile lookups.
-    profile_lookup_client: reqwest::Client,
+    /// Shared HTTP client used by online-mode name-to-profile lookups and
+    /// session-server authentication.
+    pub profile_lookup_client: reqwest::Client,
     /// Cached Mojang service keys used to validate player-key certificates.
     service_keys: Arc<ServiceKeyStore>,
     /// Player joins prepared by async I/O and finalized at the game tick safe point.
@@ -758,7 +759,11 @@ impl Server {
             player_permission_updates: AsyncMutex::new(()),
             known_players: SyncMutex::new(KnownPlayerCacheState::new(known_players)),
             known_player_save_idle: Notify::new(),
-            profile_lookup_client: reqwest::Client::new(),
+            profile_lookup_client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(5))
+                .timeout(Duration::from_secs(10))
+                .build()
+                .map_err(|error| format!("failed to build HTTP client: {error}"))?,
             service_keys,
             pending_player_joins: PlayerJoinQueue::new(),
             pending_player_disconnects: PlayerDisconnectQueue::new(),

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -229,6 +229,7 @@ async fn test_server_with_worlds(
 
     Ok(Arc::new(Server {
         config,
+        favicon: None,
         permission_groups,
         cancel_token: CancellationToken::new(),
         key_store: KeyStore::create(),

--- a/steel-login/src/authentication.rs
+++ b/steel-login/src/authentication.rs
@@ -57,36 +57,50 @@ pub enum TextureError {
     JSONError(String),
 }
 
-const MAX_RETRIES: u32 = 3;
+/// One initial attempt plus a single retry for transient transport failures.
+const MAX_ATTEMPTS: u32 = 2;
 
-/// Authenticates a player with the configured session server.
+/// Authenticates a player with the configured session server over the shared HTTP
+/// client.
+///
+/// Deterministic failures (unverified username, unexpected status, malformed JSON) are
+/// returned immediately without retrying.
 pub async fn mojang_authenticate(
+    client: &reqwest::Client,
     username: &str,
     server_hash: &str,
     auth_server: Option<&str>,
 ) -> Result<GameProfile, AuthError> {
     let auth_url = build_auth_url(auth_server, username, server_hash)?;
 
-    let mut last_error = AuthError::FailedResponse;
-
-    for _ in 0..MAX_RETRIES {
-        let Ok(response) = reqwest::get(auth_url.clone()).await else {
-            last_error = AuthError::FailedResponse;
-            continue;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let response = match client.get(auth_url.clone()).send().await {
+            Ok(response) => response,
+            Err(error) => {
+                if attempt == MAX_ATTEMPTS {
+                    log::warn!("Player {username} auth failed: {error}");
+                    return Err(AuthError::FailedResponse);
+                }
+                continue;
+            }
         };
 
         match response.status() {
             StatusCode::OK => {
                 return response.json().await.map_err(|_| AuthError::FailedParse);
             }
-            StatusCode::NO_CONTENT => last_error = AuthError::UnverifiedUsername,
-            other => last_error = AuthError::UnknownStatusCode(other),
+            StatusCode::NO_CONTENT => {
+                log::debug!("Player {username} is not verified by the session server");
+                return Err(AuthError::UnverifiedUsername);
+            }
+            other => {
+                log::warn!("Player {username} auth failed");
+                return Err(AuthError::UnknownStatusCode(other));
+            }
         }
     }
 
-    log::warn!("Player {username} auth failed");
-
-    Err(last_error)
+    Err(AuthError::FailedResponse)
 }
 
 fn build_auth_url(

--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -1,5 +1,7 @@
 //! Login state packet handlers.
 
+use std::time::Instant;
+
 use rsa::Pkcs1v15Encrypt;
 use sha1::Sha1;
 use sha2::Digest;
@@ -245,6 +247,7 @@ impl JavaTcpClient {
         }
         self.login_deadline.store(None);
         self.protocol.store(ConnectionProtocol::Config);
+        self.config_keepalive.lock().last_sent = Instant::now();
 
         self.start_configuration().await;
         ConnectionAction::none()

--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -104,6 +104,27 @@ impl JavaTcpClient {
         self.finish_verified_login(profile, None).await
     }
 
+    /// Authenticates the joining player against the configured session server.
+    async fn authenticate_online_player(
+        &self,
+        requested_username: &str,
+        secret_key: &[u8; 16],
+    ) -> Result<GameProfile, AuthError> {
+        let server_hash = &Sha1::new()
+            .chain_update(secret_key)
+            .chain_update(&self.server.key_store.public_key_der)
+            .finalize();
+        let server_hash = signed_bytes_be_to_hex(server_hash);
+
+        mojang_authenticate(
+            &self.server.profile_lookup_client,
+            requested_username,
+            &server_hash,
+            self.server.config.auth_server.as_deref(),
+        )
+        .await
+    }
+
     /// Handles the key packet during the login state, used for encryption.
     pub(crate) async fn handle_key(&self, packet: SKey) -> ConnectionAction {
         let sequence_result = self.pre_play_state.lock().begin_authentication();
@@ -159,19 +180,9 @@ impl JavaTcpClient {
         }
 
         let profile = if self.server.config.online_mode {
-            let server_hash = &Sha1::new()
-                .chain_update(secret_key)
-                .chain_update(&self.server.key_store.public_key_der)
-                .finalize();
-
-            let server_hash = signed_bytes_be_to_hex(server_hash);
-
-            match mojang_authenticate(
-                &requested_username,
-                &server_hash,
-                self.server.config.auth_server.as_deref(),
-            )
-            .await
+            match self
+                .authenticate_online_player(&requested_username, &secret_key)
+                .await
             {
                 Ok(profile) => profile,
                 Err(error) => {

--- a/steel-login/src/handlers/status.rs
+++ b/steel-login/src/handlers/status.rs
@@ -1,6 +1,5 @@
 //! Status state packet handlers (server list ping).
 
-use steel_core::config::RuntimeConfig;
 use steel_protocol::packets::{
     common::{CPongResponse, SPingRequest},
     status::{CStatusResponse, Players, Sample, Status, Version},
@@ -26,7 +25,7 @@ impl JavaTcpClient {
                     .collect(),
             }),
             enforces_secure_chat: self.server.enforces_secure_chat(),
-            favicon: load_favicon(&self.server.config),
+            favicon: self.server.favicon.clone(),
             version: Some(Version {
                 name: MC_VERSION,
                 protocol: CURRENT_MC_PROTOCOL,
@@ -41,28 +40,4 @@ impl JavaTcpClient {
             .await;
         self.close();
     }
-}
-
-/// Loads the favicon from config.
-fn load_favicon(config: &RuntimeConfig) -> Option<String> {
-    use base64::{Engine, prelude::BASE64_STANDARD};
-    use std::fs;
-    use std::path::Path;
-
-    const ICON_PREFIX: &str = "data:image/png;base64,";
-
-    if !config.use_favicon {
-        return None;
-    }
-
-    let path = Path::new(&config.favicon);
-    let Ok(icon) = fs::read(path) else {
-        return None;
-    };
-
-    let cap = ICON_PREFIX.len() + icon.len().div_ceil(3) * 4;
-    let mut base64 = String::with_capacity(cap);
-    base64 += ICON_PREFIX;
-    BASE64_STANDARD.encode_string(icon, &mut base64);
-    Some(base64)
 }

--- a/steel-login/src/tcp_client.rs
+++ b/steel-login/src/tcp_client.rs
@@ -10,7 +10,7 @@ use std::{
     io::Cursor,
     net::SocketAddr,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use crossbeam::atomic::AtomicCell;
@@ -24,7 +24,9 @@ use steel_protocol::{
     packet_traits::{ClientPacket, CompressionInfo, EncodedPacket, ServerPacket},
     packet_writer::TCPNetworkEncoder,
     packets::{
-        common::{CDisconnect, SClientInformation, SCustomPayload, SPingRequest},
+        common::{
+            CDisconnect, CKeepAlive, SClientInformation, SCustomPayload, SKeepAlive, SPingRequest,
+        },
         config::SSelectKnownPacks,
         handshake::{ClientIntent, SClientIntention},
         login::{CLoginDisconnect, SHello, SKey},
@@ -42,6 +44,7 @@ use steel_utils::{
 use text_components::{
     TextComponent, content::Resolvable, custom::CustomData, resolving::TextResolutor,
 };
+use tokio::time::{Interval, interval};
 use tokio::{
     io::{BufReader, BufWriter},
     net::{TcpStream, tcp::OwnedReadHalf},
@@ -88,6 +91,7 @@ enum LoginOperationResult<T> {
 enum IncomingEvent {
     Packet(Result<RawPacket, PacketError>),
     ConnectionUpdate(Result<ConnectionUpdate, RecvError>),
+    KeepAliveTick,
 }
 
 async fn await_login_operation<T, O, D>(
@@ -192,6 +196,14 @@ impl ConnectionAction {
     }
 }
 
+/// Configuration keep-alive state, mirroring vanilla's pre-play keep-alive timing.
+pub(crate) struct PrePlayKeepAliveTracker {
+    /// Last time a challenge was sent (or the phase was entered).
+    pub(crate) last_sent: Instant,
+    /// The challenge the client has not answered yet.
+    pub(crate) pending: Option<i64>,
+}
+
 /// Connection for pre-play packets.
 ///
 /// Gets dropped by `incoming_packet_task` if closed or upgraded to play connection.
@@ -220,6 +232,8 @@ pub struct JavaTcpClient {
     pub connection_session: Arc<ServerConnectionSession>,
     /// The challenge sent to the client during login.
     pub challenge: AtomicCell<[u8; 4]>,
+    /// Outstanding configuration keep-alive challenge awaiting the client response.
+    pub(crate) config_keepalive: SyncMutex<PrePlayKeepAliveTracker>,
 
     /// Channel for broadcasting connection state updates.
     pub connection_updates: Sender<ConnectionUpdate>,
@@ -266,6 +280,10 @@ impl JavaTcpClient {
             server,
             connection_session,
             challenge: AtomicCell::new([0; 4]),
+            config_keepalive: SyncMutex::new(PrePlayKeepAliveTracker {
+                last_sent: Instant::now(),
+                pending: None,
+            }),
             connection_updates,
             connection_updated: Arc::new(Notify::new()),
             pre_play_state: SyncMutex::new(PrePlayState::new()),
@@ -482,26 +500,13 @@ impl JavaTcpClient {
 
         self.task_tracker.spawn(async move {
             let mut connection = None;
+            let mut config_keepalive_tick = interval(Duration::from_secs(15));
+            // Consume the immediate first tick so the cadence starts at 15 seconds.
+            config_keepalive_tick.tick().await;
             loop {
-                let incoming_event = if self_clone.login_deadline_expired() {
-                    LoginOperationResult::TimedOut
-                } else {
-                    let incoming_event = async {
-                        select! {
-                            packet = reader.get_raw_packet() => IncomingEvent::Packet(packet),
-                            connection_update = connection_updates_recv.recv() => {
-                                IncomingEvent::ConnectionUpdate(connection_update)
-                            }
-                        }
-                    };
-                    await_login_operation(
-                        &cancel_token,
-                        &self_clone.login_deadline,
-                        incoming_event,
-                        self_clone.wait_for_login_deadline(),
-                    )
-                    .await
-                };
+                let incoming_event = self_clone
+                    .await_incoming_event(&mut reader, &mut connection_updates_recv, &mut config_keepalive_tick)
+                    .await;
 
                 match incoming_event {
                     LoginOperationResult::Completed(IncomingEvent::Packet(Ok(packet))) => {
@@ -557,6 +562,11 @@ impl JavaTcpClient {
                             cancel_token.cancel();
                         }
                     },
+                    LoginOperationResult::Completed(IncomingEvent::KeepAliveTick) => {
+                        if self_clone.protocol.load() == ConnectionProtocol::Config {
+                            self_clone.tick_config_keepalive().await;
+                        }
+                    }
                     LoginOperationResult::Cancelled => break,
                     LoginOperationResult::TimedOut => {
                         if self_clone.login_deadline_expired() {
@@ -580,6 +590,35 @@ impl JavaTcpClient {
                 }
             }
         });
+    }
+
+    /// Awaits the next pre-play event: an inbound packet, a connection update, or a
+    /// configuration keep-alive tick, bounded by the login deadline when one is set.
+    async fn await_incoming_event(
+        &self,
+        reader: &mut TCPNetworkDecoder<BufReader<OwnedReadHalf>>,
+        connection_updates_recv: &mut broadcast::Receiver<ConnectionUpdate>,
+        config_keepalive_tick: &mut Interval,
+    ) -> LoginOperationResult<IncomingEvent> {
+        if self.login_deadline_expired() {
+            return LoginOperationResult::TimedOut;
+        }
+        let incoming_event = async {
+            select! {
+                packet = reader.get_raw_packet() => IncomingEvent::Packet(packet),
+                connection_update = connection_updates_recv.recv() => {
+                    IncomingEvent::ConnectionUpdate(connection_update)
+                }
+                _ = config_keepalive_tick.tick() => IncomingEvent::KeepAliveTick,
+            }
+        };
+        await_login_operation(
+            &self.cancel_token,
+            &self.login_deadline,
+            incoming_event,
+            self.wait_for_login_deadline(),
+        )
+        .await
     }
 
     fn login_deadline_expired(&self) -> bool {
@@ -773,6 +812,27 @@ impl JavaTcpClient {
                     .await;
                 Ok(ConnectionAction::none())
             }
+            config::S_KEEP_ALIVE => {
+                let packet = SKeepAlive::read_packet(data)?;
+                let accepted = {
+                    let mut tracker = self.config_keepalive.lock();
+                    let accepted = tracker.pending == Some(packet.id);
+                    if accepted {
+                        tracker.pending = None;
+                    }
+                    accepted
+                };
+                if accepted {
+                    Ok(ConnectionAction::none())
+                } else {
+                    // Vanilla disconnects clients answering out of order with a timeout.
+                    self.kick(TextComponent::translated(
+                        translations::DISCONNECT_TIMEOUT.msg(),
+                    ))
+                    .await;
+                    Ok(ConnectionAction::none())
+                }
+            }
             config::S_FINISH_CONFIGURATION => {
                 if let Err(error) = self.expect_pre_play_packet(PrePlayPacket::FinishConfiguration)
                 {
@@ -781,6 +841,36 @@ impl JavaTcpClient {
                 Ok(self.finish_configuration().await)
             }
             _ => Err(PacketError::InvalidProtocol("Config".to_string())),
+        }
+    }
+
+    /// Ticks the configuration keep-alive: sends a challenge after 15 idle seconds and
+    /// disconnects clients that ignore one for 30 seconds (vanilla timing).
+    async fn tick_config_keepalive(&self) {
+        let now = Instant::now();
+        let mut send_challenge = None;
+        let mut timed_out = false;
+        {
+            let mut tracker = self.config_keepalive.lock();
+            if tracker.pending.is_some() {
+                timed_out = now.duration_since(tracker.last_sent) >= Duration::from_secs(30);
+            } else if now.duration_since(tracker.last_sent) >= Duration::from_secs(15) {
+                let challenge = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("system time before epoch")
+                    .as_millis() as i64;
+                tracker.pending = Some(challenge);
+                tracker.last_sent = now;
+                send_challenge = Some(challenge);
+            }
+        }
+        if let Some(challenge) = send_challenge {
+            self.send_bare_packet_now(CKeepAlive::new(challenge)).await;
+        } else if timed_out {
+            self.kick(TextComponent::translated(
+                translations::DISCONNECT_TIMEOUT.msg(),
+            ))
+            .await;
         }
     }
 

--- a/steel-login/src/tcp_client.rs
+++ b/steel-login/src/tcp_client.rs
@@ -524,6 +524,10 @@ impl JavaTcpClient {
                             }
                             LoginOperationResult::Completed(Err(err)) => {
                                 log::warn!("Failed to get packet from client {id}: {err}");
+                                let reason = TextComponent::translated(
+                                    translations::MULTIPLAYER_DISCONNECT_INVALID_PACKET.msg(),
+                                );
+                                self_clone.kick(reason).await;
                             }
                             LoginOperationResult::Cancelled => break,
                             LoginOperationResult::TimedOut => {

--- a/steel-protocol/Cargo.toml
+++ b/steel-protocol/Cargo.toml
@@ -45,3 +45,10 @@ text_components.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+criterion = { workspace = true, features = ["async_tokio"] }
+
+[[bench]]
+name = "packet_codec"
+harness = false

--- a/steel-protocol/benches/packet_codec.rs
+++ b/steel-protocol/benches/packet_codec.rs
@@ -1,0 +1,50 @@
+#![expect(missing_docs, reason = "benchmarks")]
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use steel_protocol::packet_reader::TCPNetworkDecoder;
+use steel_utils::codec::VarInt;
+use steel_utils::serial::WriteTo;
+use tokio::runtime::Builder;
+
+/// Decodes 256 framed packets from a pre-built wire buffer, exercising the length
+/// framing path.
+fn bench_packet_reader_framing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("packet_reader_framing");
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut wire = Vec::new();
+    for i in 0i32..256 {
+        let mut packet = Vec::new();
+        VarInt::from(i)
+            .write(&mut packet)
+            .expect("packet id should encode");
+        packet.extend_from_slice(&[0xABu8; 32]);
+        VarInt::from(packet.len() as i32)
+            .write(&mut wire)
+            .expect("packet length should encode");
+        wire.extend_from_slice(&packet);
+    }
+    group.throughput(Throughput::Elements(256));
+
+    group.bench_function("decode_256_packets", |b| {
+        b.to_async(&rt).iter(|| async {
+            let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+            for _ in 0..256 {
+                let packet = decoder
+                    .get_raw_packet()
+                    .await
+                    .expect("packet should decode");
+                black_box(packet.id);
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_packet_reader_framing);
+criterion_main!(benches);

--- a/steel-protocol/src/packet_reader.rs
+++ b/steel-protocol/src/packet_reader.rs
@@ -108,7 +108,33 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
     /// - If the packet fails to decompress.
     #[expect(clippy::cast_sign_loss)]
     pub async fn get_raw_packet(&mut self) -> Result<RawPacket, PacketError> {
-        let packet_len = VarInt::read_async(&mut self.reader).await? as usize;
+        // Decode the packet length VarInt manually, capping it at 3 bytes like vanilla
+        // `Varint21FrameDecoder`, so oversized lengths fail fast instead of consuming
+        // unbounded input.
+        let mut packet_len: usize = 0;
+        let mut length_bytes = 0;
+        loop {
+            if length_bytes == 3 {
+                Err(PacketError::MalformedLength(
+                    "packet length varint exceeds 3 bytes".to_string(),
+                ))?;
+            }
+
+            let mut byte = [0u8; 1];
+            self.reader.read_exact(&mut byte).await?;
+            packet_len |= ((byte[0] & 0x7F) as usize) << (7 * length_bytes);
+            length_bytes += 1;
+
+            if byte[0] & 0x80 == 0 {
+                break;
+            }
+        }
+
+        if packet_len == 0 {
+            Err(PacketError::MalformedLength(
+                "packet length cannot be zero".to_string(),
+            ))?;
+        }
 
         if packet_len > MAX_PACKET_SIZE {
             Err(PacketError::OutOfBounds)?;
@@ -132,6 +158,10 @@ impl<R: AsyncRead + Unpin> TCPNetworkDecoder<R> {
             }
 
             if decompressed_len > 0 {
+                if decompressed_len < threshold.get() as usize {
+                    Err(PacketError::BelowThreshold(decompressed_len))?;
+                }
+
                 let mut decompressed = vec![0; decompressed_len];
                 let mut decoder = ZlibDecoder::new(&mut cursor);
                 decoder
@@ -603,5 +633,45 @@ mod compression_security_tests {
 
         assert_eq!(raw_packet.id, 2);
         assert_eq!(raw_packet.payload(), b"hello");
+    }
+
+    #[tokio::test]
+    async fn rejects_length_varint_wider_than_21_bits() {
+        // Four-byte length VarInt: three continuation bytes then a terminator, like
+        // vanilla `Varint21FrameDecoder`'s "length wider than 21-bit" case.
+        let wire = [0x80, 0x80, 0x80, 0x01];
+        let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::MalformedLength(message))
+                if message.contains("exceeds 3 bytes")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_length_frames() {
+        let wire = [0x00];
+        let mut decoder = TCPNetworkDecoder::new(wire.as_slice());
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::MalformedLength(message))
+                if message.contains("cannot be zero")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_compressed_size_below_server_threshold() {
+        // A well-formed compressed packet whose declared size is under the server
+        // threshold: vanilla `CompressionDecoder` rejects it before inflating.
+        let packet = compressed_packet(5, b"hello");
+        let mut decoder = TCPNetworkDecoder::new(packet.as_slice());
+        decoder.set_compression(NonZeroU32::new(256).expect("nonzero threshold"));
+
+        assert!(matches!(
+            decoder.get_raw_packet().await,
+            Err(PacketError::BelowThreshold(5))
+        ));
     }
 }

--- a/steel-protocol/src/utils.rs
+++ b/steel-protocol/src/utils.rs
@@ -112,6 +112,9 @@ pub enum PacketError {
     #[error("failed to compress packet: {0}")]
     /// Failed to compress the packet.
     CompressionFailed(String),
+    #[error("badly compressed packet - size of {0} is below the server threshold")]
+    /// The packet declares a compressed size below the server's compression threshold.
+    BelowThreshold(usize),
     #[error("packet is uncompressed but greater than the threshold")]
     /// The packet is uncompressed but greater than the threshold.
     NotCompressed,


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Performance improvement

## Description

Hardens the Mojang session-server authentication path:

- `mojang_authenticate` now takes the shared pooled `reqwest` client from `Server` (`profile_lookup_client`) instead of the unpooled global `reqwest::get` helper, so connection pooling is reused for name-to-profile verification.
- The client enforces a 5 s connect timeout and a 10 s total timeout, bounding the whole authentication flow to ~20 s across one transport retry — inside the 30 s login deadline.
- `204 No Content` (unverified username) and unexpected status codes return immediately instead of consuming the remaining retry attempts; only transient transport errors are retried, once.

## How this was tested

- `cargo test -p steel-login` (16 tests) and `cargo test -p steel-core --lib` (2422 tests) pass; `cargo clippy -r --all-targets` clean.
- Behavior is network-bound; the verification is structural (previous path could hang the login flow indefinitely on a stalled session server, new path is bounded and non-retrying on deterministic failures).

## Screenshots / logs

N/A.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable) — N/A
- [x] No leftover debug code / comments

## Additional notes

- Stacked on `pr4-preplay-lifecycle` (base of this PR).
- Env: Linux, Rust nightly, Minecraft protocol 776 (0.15.2+mc26.2).

> **Note:** stacked on #548 (`pr4-preplay-lifecycle`, itself stacked on #547). Until those merge, this PR's diff includes their commits; the authentication changes themselves are the final commit. Incremental diff: https://github.com/carabistouflette/SteelMC/compare/pr4-preplay-lifecycle...pr5-auth-hardening

