### PR TITLE
perf: batch join tab-list sync into a single CPlayerInfoUpdate

### DIFF
--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -89,7 +89,7 @@ use steel_protocol::packet_traits::{ClientPacket, EncodedPacket};
 use steel_protocol::packets::game::{
     CCommandSuggestions, CEntityEvent, CLogin, CPlayerInfoUpdate, CRemovePlayerInfo,
     CSetDefaultSpawnPosition, CSystemChat, CTabList, CTickingState, CTickingStep,
-    CommonPlayerSpawnInfo, RelativeMovement,
+    CommonPlayerSpawnInfo, PLAYER_INFO_INIT_ACTIONS, PlayerInfoEntry, RelativeMovement,
 };
 use steel_protocol::utils::ConnectionProtocol;
 use steel_registry::vanilla_game_rules::{

--- a/steel-core/src/server/player_admission.rs
+++ b/steel-core/src/server/player_admission.rs
@@ -3,8 +3,8 @@ use steel_utils::translations;
 use super::{
     Arc, CPlayerInfoUpdate, CRemovePlayerInfo, CancellationToken, ClientPacket, ConnectionProtocol,
     DomainPlayerState, EncodedPacket, Entity, GlobalPlayerData, Instant, JoinSet,
-    NetworkConnection, PendingWorldChangeToken, PersistentPlayerData, Player, ResetReason,
-    SegQueue, Server, SyncMutex, Uuid, mpsc,
+    NetworkConnection, PLAYER_INFO_INIT_ACTIONS, PendingWorldChangeToken, PersistentPlayerData,
+    Player, PlayerInfoEntry, ResetReason, SegQueue, Server, SyncMutex, Uuid, mpsc,
 };
 
 pub(super) struct PendingPlayerJoin {
@@ -641,13 +641,17 @@ impl Server {
     ///
     /// Server membership mirrors vanilla `PlayerList`; world entity spawning remains
     /// owned by the per-world entity tracker.
-    fn sync_tab_list(&self, player: &Arc<Player>) {
+    pub(super) fn sync_tab_list(&self, player: &Arc<Player>) {
+        // Vanilla PlayerList.placeNewPlayer announces every online player to the joiner
+        // with a single createPlayerInitializing packet; chat session data rides on the
+        // same entries via the InitializeChat action.
+        let mut entries: Vec<PlayerInfoEntry> = Vec::new();
         self.online_players.iter_players(|_, existing_player| {
             if existing_player.gameprofile.id == player.gameprofile.id {
                 return true;
             }
 
-            let add_existing = CPlayerInfoUpdate::create_player_initializing(
+            let mut entry = CPlayerInfoUpdate::create_player_initializing_entry(
                 existing_player.gameprofile.id,
                 existing_player.gameprofile.name.clone(),
                 existing_player.gameprofile.properties.clone(),
@@ -656,19 +660,21 @@ impl Server {
                 None,
                 existing_player.shows_hat(),
             );
-            player.send_packet(add_existing);
-
             if let Some(session) = existing_player.chat_session()
                 && let Ok(protocol_data) = session.as_data().to_protocol_data()
             {
-                player.send_packet(CPlayerInfoUpdate::update_chat_session(
-                    existing_player.gameprofile.id,
-                    protocol_data,
-                ));
+                entry = entry.with_chat_session(protocol_data);
             }
-
+            entries.push(entry);
             true
         });
+
+        if !entries.is_empty() {
+            player.send_packet(CPlayerInfoUpdate {
+                actions: PLAYER_INFO_INIT_ACTIONS,
+                entries,
+            });
+        }
 
         let player_info_packet = CPlayerInfoUpdate::create_player_initializing(
             player.gameprofile.id,

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -3117,3 +3117,56 @@ fn damage_command_records_by_entity_as_the_responsible_player() {
         }
     });
 }
+
+#[test]
+fn sync_tab_list_sends_single_batched_update_to_joiner() {
+    let world = fresh_test_world("sync-tab-list-batch");
+    let runtime = Builder::new_current_thread().enable_all().build();
+    let Ok(runtime) = runtime else {
+        panic!("test runtime should initialize");
+    };
+    runtime.block_on(async {
+        let storage_root = test_storage_root("sync-tab-list-batch");
+        let Ok(server) = test_server(
+            Arc::clone(&world),
+            PermissionSubjectIndex::new(),
+            &storage_root,
+        )
+        .await
+        else {
+            panic!("test server should initialize");
+        };
+
+        let (existing1, existing1_packets) =
+            test_player_with_packets(&server, Arc::clone(&world), "Existing1", 1);
+        let (existing2, existing2_packets) =
+            test_player_with_packets(&server, Arc::clone(&world), "Existing2", 2);
+        let (joiner, joiner_packets) =
+            test_player_with_packets(&server, Arc::clone(&world), "Joiner", 3);
+        assert!(server.online_players.insert(existing1));
+        assert!(server.online_players.insert(existing2));
+
+        server.sync_tab_list(&joiner);
+
+        assert_eq!(
+            joiner_packets.lock().len(),
+            1,
+            "the joiner must receive exactly one batched tab list packet"
+        );
+        assert_eq!(
+            existing1_packets.lock().len(),
+            1,
+            "existing players receive only the join announcement"
+        );
+        assert_eq!(
+            existing2_packets.lock().len(),
+            1,
+            "existing players receive only the join announcement"
+        );
+
+        drop(server);
+        if let Err(error) = fs::remove_dir_all(&storage_root).await {
+            panic!("test storage should be removed: {error}");
+        }
+    });
+}

--- a/steel-protocol/src/packets/game/c_player_info_update.rs
+++ b/steel-protocol/src/packets/game/c_player_info_update.rs
@@ -143,6 +143,31 @@ pub struct CPlayerInfoUpdate {
 }
 
 impl CPlayerInfoUpdate {
+    /// Creates the full initializing entry for a single player.
+    #[must_use]
+    pub fn create_player_initializing_entry(
+        uuid: Uuid,
+        name: String,
+        properties: Vec<GameProfileProperty>,
+        game_mode: i32,
+        latency: i32,
+        display_name: Option<TextComponent>,
+        show_hat: bool,
+    ) -> PlayerInfoEntry {
+        PlayerInfoEntry {
+            uuid,
+            name: Some(name),
+            properties,
+            chat_session: None,
+            game_mode: Some(VarInt(game_mode)),
+            listed: Some(true),
+            latency: Some(VarInt(latency)),
+            display_name: Some(display_name.into()),
+            list_order: Some(VarInt(0)),
+            show_hat: Some(show_hat),
+        }
+    }
+
     /// Creates a full player initializing packet with all information.
     /// This is sent when a player joins to add them to the tab list.
     /// Matches vanilla's `ClientboundPlayerInfoUpdatePacket.createPlayerInitializing()`
@@ -158,18 +183,15 @@ impl CPlayerInfoUpdate {
     ) -> Self {
         Self {
             actions: PLAYER_INFO_INIT_ACTIONS,
-            entries: vec![PlayerInfoEntry {
+            entries: vec![Self::create_player_initializing_entry(
                 uuid,
-                name: Some(name),
+                name,
                 properties,
-                chat_session: None,
-                game_mode: Some(VarInt(game_mode)),
-                listed: Some(true),
-                latency: Some(VarInt(latency)),
-                display_name: Some(display_name.into()),
-                list_order: Some(VarInt(0)),
-                show_hat: Some(show_hat),
-            }],
+                game_mode,
+                latency,
+                display_name,
+                show_hat,
+            )],
         }
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Performance improvement

## Description

Batches tab-list initialization for joining players. `sync_tab_list` previously queued O(N) `create_player_initializing` packets plus an optional `update_chat_session` packet per online player to the joiner. Mirroring vanilla `PlayerList.placeNewPlayer`, the joiner now receives a single `CPlayerInfoUpdate` whose entries carry every online player with their chat session data attached directly via the `InitializeChat` action. The broadcast announcing the joiner to existing players is unchanged.

`CPlayerInfoUpdate::create_player_initializing_entry` is extracted so single-entry and batched construction share one code path.

## How this was tested

- New regression test `sync_tab_list_sends_single_batched_update_to_joiner`: with two existing players, the joiner receives exactly **one** tab-list packet and each existing player receives exactly one join announcement.
- `cargo test -p steel-core --lib` (2422 tests) pass; `cargo clippy -r --all-targets` clean.

## Screenshots / logs

N/A.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable) — N/A
- [x] No leftover debug code / comments

## Additional notes

- Env: Linux, Rust nightly, Minecraft protocol 776 (0.15.2+mc26.2).
