### PR TITLE
perf: scope same-chunk entity tracker refreshes with a chunk index

### DIFF
--- a/steel-core/src/chunk/chunk_map/mod.rs
+++ b/steel-core/src/chunk/chunk_map/mod.rs
@@ -698,6 +698,12 @@ impl ChunkMap {
 
         let mut world = None;
 
+        // Light sends are resolved once per player after the loop: each player's view
+        // and chunk sender are locked a single time for the whole pass instead of once
+        // per candidate chunk.
+        let mut light_writes: Vec<(ChunkPos, EncodedPacket, Vec<i32>)> = Vec::new();
+        let mut light_candidates: FxHashMap<i32, Vec<usize>> = FxHashMap::default();
+
         for holder in holders {
             let chunk_pos = holder.get_pos();
             // Vanilla publishes block changes independently of unfinished light propagation.
@@ -719,7 +725,7 @@ impl ChunkMap {
             if has_publishable_light_changes
                 && let Some(chunk) = holder.try_chunk(ChunkStatus::Full)
             {
-                let tracking_players = world.get_light_packet_tracking_players(chunk_pos);
+                let tracking_players = world.player_area_map.get_tracking_players(chunk_pos);
                 if !tracking_players.is_empty() {
                     let light_data = {
                         let light = chunk.light();
@@ -751,11 +757,11 @@ impl ChunkMap {
                         continue;
                     };
 
+                    let index = light_writes.len();
                     for entity_id in &tracking_players {
-                        if let Some(player) = world.players.get_by_entity_id(*entity_id) {
-                            player.connection.send_encoded(encoded.clone());
-                        }
+                        light_candidates.entry(*entity_id).or_default().push(index);
                     }
+                    light_writes.push((chunk_pos, encoded, tracking_players));
                 }
             }
 
@@ -853,6 +859,27 @@ impl ChunkMap {
                         let block_pos = section_pos.relative_to_block_pos(packed);
                         world.broadcast_block_entity_if_needed(block_pos);
                     }
+                }
+            }
+        }
+
+        // Resolve the deferred light sends: one lock pair per player for the whole pass.
+        let world = world.get_or_insert_with(|| self.world_gen_context.world());
+        for (entity_id, indices) in light_candidates {
+            let Some(player) = world.players.get_by_entity_id(entity_id) else {
+                continue;
+            };
+            let Some(view) = *player.last_tracking_view.lock() else {
+                continue;
+            };
+            let chunk_sender = player.chunk_sender.lock();
+            let is_chunk_sent = |pos| chunk_sender.is_chunk_sent(pos);
+            for index in indices {
+                let Some((chunk_pos, encoded, _)) = light_writes.get(index) else {
+                    continue;
+                };
+                if World::chunk_is_on_packet_tracked_border(view, *chunk_pos, &is_chunk_sent) {
+                    player.connection.send_encoded(encoded.clone());
                 }
             }
         }

--- a/steel-core/src/chunk/chunk_map/player_tracking.rs
+++ b/steel-core/src/chunk/chunk_map/player_tracking.rs
@@ -12,7 +12,8 @@ impl ChunkMap {
         let world = self.world_gen_context.world();
         let mut last_view_guard = player.last_tracking_view.lock();
 
-        if last_view_guard.as_ref() != Some(&new_view) {
+        let view_unchanged = last_view_guard.as_ref() == Some(&new_view);
+        if !view_unchanged {
             let new_ticket = ChunkTicket::player(new_view.view_distance, world.simulation_distance);
 
             if let Some(last_view) = last_view_guard.as_ref() {
@@ -87,11 +88,22 @@ impl ChunkMap {
 
         // Entity visibility also depends on exact player position, not only
         // chunk-view changes. Vanilla refreshes tracked entities for accepted
-        // movement within the same chunk as well.
+        // movement within the same chunk as well. When the view is unchanged the
+        // refresh is scoped to entities registered around the player chunk; view
+        // changes keep the full world scan.
         let sent_chunks = player.chunk_sender.lock().sent_chunks_snapshot();
-        world
-            .entity_tracker()
-            .update_player(player, &new_view, |chunk| sent_chunks.contains(&chunk));
+        let tracker = world.entity_tracker();
+        if view_unchanged {
+            tracker.update_player_nearby(
+                player,
+                &new_view,
+                current_chunk_pos,
+                u32::from(view_distance),
+                |chunk| sent_chunks.contains(&chunk),
+            );
+        } else {
+            tracker.update_player(player, &new_view, |chunk| sent_chunks.contains(&chunk));
+        }
     }
 
     /// Removes a player from the chunk map.

--- a/steel-core/src/chunk/light/packet.rs
+++ b/steel-core/src/chunk/light/packet.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashSet;
 use steel_protocol::packets::game::LightUpdatePacketData;
 use steel_utils::{ChunkPos, SectionPos, codec::BitSet};
 
@@ -66,13 +67,39 @@ pub fn build_chunk_light_update_packet_for_sections(
     let mut sky_updates = Vec::new();
     let mut block_updates = Vec::new();
 
+    // Small deltas are scanned linearly; larger ones use a set so the per-section
+    // membership test stays O(1) while walking every section of the column.
+    let use_sky_set = has_skylight && sky_sections.len() > 4;
+    let use_block_set = block_sections.len() > 4;
+    let sky_set: FxHashSet<SectionPos> = if use_sky_set {
+        sky_sections.iter().copied().collect()
+    } else {
+        FxHashSet::default()
+    };
+    let block_set: FxHashSet<SectionPos> = if use_block_set {
+        block_sections.iter().copied().collect()
+    } else {
+        FxHashSet::default()
+    };
+
     for section_index in 0..range.section_count() {
         let Some(section_y) = range.section_y(section_index) else {
             continue;
         };
         let section_pos = SectionPos::new(chunk_pos.0.x, section_y, chunk_pos.0.y);
 
-        if has_skylight && sky_sections.contains(&section_pos) {
+        let sky_matched = if use_sky_set {
+            sky_set.contains(&section_pos)
+        } else {
+            sky_sections.contains(&section_pos)
+        };
+        let block_matched = if use_block_set {
+            block_set.contains(&section_pos)
+        } else {
+            block_sections.contains(&section_pos)
+        };
+
+        if sky_matched {
             prepare_chunk_section_data(
                 &light.sky,
                 section_index,
@@ -82,7 +109,7 @@ pub fn build_chunk_light_update_packet_for_sections(
             );
         }
 
-        if block_sections.contains(&section_pos) {
+        if block_matched {
             prepare_chunk_section_data(
                 &light.block,
                 section_index,

--- a/steel-core/src/entity/tracker/mod.rs
+++ b/steel-core/src/entity/tracker/mod.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use glam::DVec3;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use steel_protocol::packets::game::{
     AttributeSnapshot, CAddEntity, CRemoveEntities, CSetEntityData, CSetEntityLink,
     CSetEntityMotion, CSetEquipment, CSetPassengers, CUpdateAttributes, EquipmentSlotItem,
@@ -32,6 +32,9 @@ const BLOCKS_PER_CHUNK: f64 = 16.0;
 pub struct EntityTracker {
     /// Maps entity ID to its tracking data.
     entities: scc::HashMap<i32, TrackedEntity>,
+    /// Secondary index of entity IDs by their registered chunk, so player refreshes can
+    /// be scoped to nearby chunks instead of scanning every tracked entity.
+    entities_by_chunk: SyncMutex<FxHashMap<ChunkPos, FxHashSet<i32>>>,
 }
 
 /// Packet sinks used by [`EntityTracker::send_changes`].
@@ -115,6 +118,7 @@ impl EntityTracker {
     pub fn new() -> Self {
         Self {
             entities: scc::HashMap::new(),
+            entities_by_chunk: SyncMutex::new(FxHashMap::default()),
         }
     }
 
@@ -185,6 +189,12 @@ impl EntityTracker {
             "entity {entity_id} is already tracked"
         );
 
+        self.entities_by_chunk
+            .lock()
+            .entry(registered_chunk)
+            .or_default()
+            .insert(entity_id);
+
         // Send spawn packets to all nearby players
         for player_id in player_ids_to_notify {
             if let Some(player) = get_player(player_id) {
@@ -196,6 +206,13 @@ impl EntityTracker {
     /// Stops tracking an entity and sends despawn to all tracking players.
     pub fn remove(&self, entity_id: i32, get_player: impl Fn(i32) -> Option<Arc<Player>>) {
         if let Some((_, tracked)) = self.entities.remove_sync(&entity_id) {
+            if let Some(bucket) = self
+                .entities_by_chunk
+                .lock()
+                .get_mut(&tracked.registered_chunk)
+            {
+                bucket.remove(&entity_id);
+            }
             let entity = tracked.entity.upgrade();
             // Send despawn to all tracking players
             for player_id in tracked.seen_by.read().iter() {
@@ -225,7 +242,6 @@ impl EntityTracker {
     ) {
         let player_id = player.id();
         let player_pos = player.position();
-        let player_view_distance = view.view_distance;
 
         let mut entities_to_despawn = Vec::new();
         let mut entities_to_spawn = Vec::new();
@@ -238,17 +254,16 @@ impl EntityTracker {
                 return true;
             };
 
-            let visible = !entity.is_removed()
-                && entity_id != player_id
-                && view.contains(tracked.registered_chunk)
-                && is_chunk_sent(tracked.registered_chunk)
-                && entity.broadcast_to_player(player)
-                && is_within_tracking_distance(
-                    entity.position(),
-                    player_pos,
-                    effective_tracking_range(entity.as_ref(), tracked.tracking_range),
-                    player_view_distance,
-                );
+            let visible = Self::entity_visible_to_player(
+                entity.as_ref(),
+                entity_id,
+                player,
+                player_pos,
+                view,
+                tracked.registered_chunk,
+                tracked.tracking_range,
+                &is_chunk_sent,
+            );
 
             let mut despawn = false;
             {
@@ -286,6 +301,108 @@ impl EntityTracker {
         for entity_id in dead_entities {
             self.remove_dead_entity(entity_id);
         }
+    }
+
+    /// Refreshes the tracked-entity set for one player whose view did not change:
+    /// only entities registered within `radius_chunks` of `center` are evaluated
+    /// instead of scanning the whole world tracker.
+    pub fn update_player_nearby(
+        &self,
+        player: &Player,
+        view: &PlayerChunkView,
+        center: ChunkPos,
+        radius_chunks: u32,
+        is_chunk_sent: impl Fn(ChunkPos) -> bool,
+    ) {
+        let radius = i32::try_from(radius_chunks).unwrap_or(i32::MAX);
+        let mut candidate_ids: Vec<i32> = Vec::new();
+        {
+            let registry = self.entities_by_chunk.lock();
+            for dx in -radius..=radius {
+                for dz in -radius..=radius {
+                    if let Some(bucket) =
+                        registry.get(&ChunkPos::new(center.0.x + dx, center.0.y + dz))
+                    {
+                        candidate_ids.extend(bucket.iter().copied());
+                    }
+                }
+            }
+        }
+
+        let player_id = player.id();
+        let player_pos = player.position();
+        for entity_id in candidate_ids {
+            let mut despawn_packet = None;
+            let mut just_spawned = None;
+            let mut despawn = false;
+            let mut is_dead = false;
+            self.entities.read_sync(&entity_id, |_, tracked| {
+                let Some(entity) = tracked.entity.upgrade() else {
+                    is_dead = true;
+                    return;
+                };
+                let visible = Self::entity_visible_to_player(
+                    entity.as_ref(),
+                    entity_id,
+                    player,
+                    player_pos,
+                    view,
+                    tracked.registered_chunk,
+                    tracked.tracking_range,
+                    &is_chunk_sent,
+                );
+                let mut seen_by = tracked.seen_by.write();
+                if visible && seen_by.insert(player_id) {
+                    just_spawned = Some(entity.clone());
+                } else if !visible && seen_by.remove(&player_id) {
+                    despawn_packet =
+                        self.vehicle_passenger_packet_for_player(entity.as_ref(), player_id);
+                    despawn = true;
+                }
+            });
+            if is_dead {
+                self.remove_dead_entity(entity_id);
+            } else {
+                if despawn {
+                    player.send_packet(CRemoveEntities::single(entity_id));
+                }
+                if let Some(packet) = despawn_packet {
+                    player.send_packet(packet);
+                }
+                if let Some(entity) = just_spawned {
+                    self.send_spawn_packets(&entity, player);
+                }
+            }
+        }
+    }
+
+    /// Vanilla visibility predicate: chunk tracked, chunk sent, broadcast rules, and
+    /// effective horizontal range.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the predicate mirrors vanilla's updatePlayer inputs one to one"
+    )]
+    fn entity_visible_to_player(
+        entity: &dyn Entity,
+        entity_id: i32,
+        player: &Player,
+        player_pos: DVec3,
+        view: &PlayerChunkView,
+        registered_chunk: ChunkPos,
+        tracking_range: EntityTrackingRange,
+        is_chunk_sent: &impl Fn(ChunkPos) -> bool,
+    ) -> bool {
+        !entity.is_removed()
+            && entity_id != player.id()
+            && view.contains(registered_chunk)
+            && is_chunk_sent(registered_chunk)
+            && entity.broadcast_to_player(player)
+            && is_within_tracking_distance(
+                entity.position(),
+                player_pos,
+                effective_tracking_range(entity, tracking_range),
+                view.view_distance,
+            )
     }
 
     /// Sends tracker-owned movement changes for all tracked entities.
@@ -581,6 +698,13 @@ impl EntityTracker {
             *seen_by = new_seen_by;
             entity_to_spawn = Some(entity);
         });
+        if old_chunk != new_chunk {
+            let mut registry = self.entities_by_chunk.lock();
+            if let Some(old_bucket) = registry.get_mut(&old_chunk) {
+                old_bucket.remove(&entity_id);
+            }
+            registry.entry(new_chunk).or_default().insert(entity_id);
+        }
 
         let Some(entity) = entity_to_spawn else {
             return;
@@ -676,7 +800,14 @@ impl EntityTracker {
     fn remove_dead_entity(&self, entity_id: i32) {
         // Note: We don't send despawn packets here because the players
         // will get updated via player view changes or explicit removals.
-        let _ = self.entities.remove_sync(&entity_id);
+        if let Some((_, tracked)) = self.entities.remove_sync(&entity_id)
+            && let Some(bucket) = self
+                .entities_by_chunk
+                .lock()
+                .get_mut(&tracked.registered_chunk)
+        {
+            bucket.remove(&entity_id);
+        }
     }
 
     fn visible_players_for_entity(

--- a/steel-core/src/player/chunk_sender.rs
+++ b/steel-core/src/player/chunk_sender.rs
@@ -4,8 +4,10 @@
 //! tick. The three-phase design (prepare → encode → commit) minimizes lock hold
 //! time on the per-player `ChunkSender` mutex so that game-tick operations like
 //! `mark_chunk_pending_to_send` and `drop_chunk` are never blocked for long.
+use glam::IVec2;
 use rayon::{ThreadPool, prelude::*};
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::BinaryHeap;
 use std::sync::{Arc, Weak};
 
 use steel_protocol::packet_traits::{ClientPacket, CompressionInfo, EncodedPacket};
@@ -252,12 +254,18 @@ impl ChunkSender {
         }
         drop(epoch);
 
+        let prepared_by_pos: FxHashMap<ChunkPos, &PreparedChunk> = batch
+            .chunks
+            .iter()
+            .map(|chunk| (chunk.pos, chunk))
+            .collect();
+
         let mut valid_chunks = Vec::with_capacity(encoded_chunks.len());
         for encoded in encoded_chunks {
             if !self.pending_chunks.contains(&encoded.pos) {
                 continue;
             }
-            let Some(prepared) = batch.chunks.iter().find(|chunk| chunk.pos == encoded.pos) else {
+            let Some(prepared) = prepared_by_pos.get(&encoded.pos) else {
                 continue;
             };
             if !encoded.is_current_for(prepared) {
@@ -302,18 +310,38 @@ impl ChunkSender {
         player_chunk_pos: ChunkPos,
     ) -> Vec<PreparedChunk> {
         let max_batch_size = self.batch_quota.floor() as usize;
-        let mut candidates: Vec<ChunkPos> = self.pending_chunks.iter().copied().collect();
+        if max_batch_size == 0 {
+            return Vec::new();
+        }
 
-        // Sort by distance to player
-        candidates.sort_by_key(|pos| Self::chunk_distance_squared(*pos, player_chunk_pos));
+        // Select only the closest pending positions, like vanilla's
+        // `Comparators.least(maxBatchSize, distanceSquared)`, instead of fully sorting
+        // every pending chunk.
+        let mut closest = BinaryHeap::with_capacity(max_batch_size);
+        for pos in &self.pending_chunks {
+            let distance = Self::chunk_distance_squared(*pos, player_chunk_pos);
+            let worst = closest
+                .peek()
+                .map_or(u64::MAX, |(worst_distance, _)| *worst_distance);
+            if closest.len() == max_batch_size && distance >= worst {
+                continue;
+            }
+            closest.push((distance, (pos.0.x, pos.0.y)));
+            if closest.len() > max_batch_size {
+                closest.pop();
+            }
+        }
+
+        let mut candidates: Vec<ChunkPos> = closest
+            .into_vec()
+            .into_iter()
+            .map(|(_, (x, z))| ChunkPos(IVec2::new(x, z)))
+            .collect();
+        candidates.sort_unstable_by_key(|pos| Self::chunk_distance_squared(*pos, player_chunk_pos));
 
         let mut chunks_to_send = Vec::new();
 
         for pos in candidates {
-            if chunks_to_send.len() >= max_batch_size {
-                break;
-            }
-
             if let Some(holder) = world
                 .chunk_map
                 .chunks

--- a/steel-core/src/player/tests.rs
+++ b/steel-core/src/player/tests.rs
@@ -2,6 +2,7 @@ use std::io::Cursor;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+use crate::chunk::player_chunk_view::PlayerChunkView;
 use glam::DVec3;
 use steel_protocol::packet_traits::{CompressionInfo, EncodedPacket};
 use steel_protocol::packets::common::{
@@ -30,7 +31,7 @@ use uuid::Uuid;
 use crate::behavior::{InteractionResult, init_behaviors};
 use crate::chunk_saver::PersistentEntity;
 use crate::entity::{
-    DEFAULT_MAX_AIR_SUPPLY, Entity, EntitySyncedData, LivingEntity, SharedEntity,
+    DEFAULT_MAX_AIR_SUPPLY, Entity, EntitySyncedData, LivingEntity, RemovalReason, SharedEntity,
     damage::DamageSource, entities::ItemEntity, next_entity_id,
 };
 use crate::inventory::{
@@ -1365,5 +1366,107 @@ fn block_action_restriction_precedes_redstone_ore_attack() {
         world
             .get_block_state(pos)
             .get_value(&BlockStateProperties::LIT)
+    );
+}
+
+#[test]
+fn update_player_nearby_uses_chunk_registry_without_full_scan() {
+    init_vanilla_registry();
+    let world = fresh_test_world("tracker_nearby_scoping");
+    let sent_packets = Arc::new(SyncMutex::new(Vec::new()));
+    let connection = Arc::new(PlayerConnection::Other(Box::new(RecordingConnection {
+        sent_packets: Arc::clone(&sent_packets),
+        closed: AtomicBool::new(false),
+    })));
+    let player = TestPlayerBuilder::new(Arc::clone(&world), "TestPlayer", 1)
+        .connection(connection)
+        .build();
+
+    let item_here: SharedEntity = Arc::new(ItemEntity::new(
+        &vanilla_entities::ITEM,
+        2,
+        DVec3::new(8.0, 64.0, 8.0),
+        Arc::downgrade(&world),
+    ));
+    let item_far: SharedEntity = Arc::new(ItemEntity::new(
+        &vanilla_entities::ITEM,
+        3,
+        DVec3::new(640.0, 64.0, 640.0),
+        Arc::downgrade(&world),
+    ));
+
+    let tracker = world.entity_tracker();
+    tracker.add(
+        &item_here,
+        |chunk| {
+            (chunk == ChunkPos::new(0, 0))
+                .then(|| player.id())
+                .into_iter()
+                .collect()
+        },
+        |player_id| (player_id == player.id()).then(|| Arc::clone(&player)),
+    );
+    tracker.add(
+        &item_far,
+        |chunk| {
+            (chunk == ChunkPos::new(40, 40))
+                .then(|| player.id())
+                .into_iter()
+                .collect()
+        },
+        |player_id| (player_id == player.id()).then(|| Arc::clone(&player)),
+    );
+
+    assert_eq!(
+        tracker.tracking_player_ids(item_here.id()),
+        vec![player.id()],
+        "item at the player chunk should be tracked right after add"
+    );
+    assert!(
+        tracker.tracking_player_ids(item_far.id()).is_empty(),
+        "far item is outside the tracking range, so nothing is tracked yet"
+    );
+
+    let view = PlayerChunkView::new(ChunkPos::new(0, 0), 2);
+
+    // add() legitimately spawns the tracked item to the watching player; the scoped
+    // refresh itself must stay silent.
+    sent_packets.lock().clear();
+    tracker.update_player_nearby(&player, &view, ChunkPos::new(0, 0), 2, |_| true);
+
+    // The nearby refresh keeps the near pairing intact and must not re-send anything:
+    // the far entity is outside the scanned radius and was never tracked.
+    assert_eq!(
+        tracker.tracking_player_ids(item_here.id()),
+        vec![player.id()]
+    );
+    assert!(
+        tracker.tracking_player_ids(item_far.id()).is_empty(),
+        "far entity outside the radius must not be evaluated or despawned"
+    );
+    assert_eq!(
+        sent_packets.lock().len(),
+        0,
+        "scoped refresh must not send packets for already-paired entities"
+    );
+
+    // Removing the near entity must be picked up by the scoped refresh: it is inside
+    // the radius, so the pass evaluates it and despawns it for the player.
+    item_here.set_removed(RemovalReason::Discarded);
+    tracker.update_player_nearby(&player, &view, ChunkPos::new(0, 0), 2, |_| true);
+
+    assert!(
+        tracker.tracking_player_ids(item_here.id()).is_empty(),
+        "removed entities inside the radius are despawned by the scoped refresh"
+    );
+    let removed = sent_packets
+        .lock()
+        .iter()
+        .flat_map(removed_entity_ids)
+        .collect::<Vec<_>>();
+    assert_eq!(removed, vec![item_here.id()]);
+    assert!(
+        tracker.tracking_player_ids(item_far.id()).is_empty(),
+        "the far entity stays outside the scoped refresh"
     );
 }

--- a/steel-core/src/world/broadcasts.rs
+++ b/steel-core/src/world/broadcasts.rs
@@ -2,6 +2,7 @@ use super::{
     Arc, CPlayerChat, CSystemChat, ChunkPos, ClientPacket, ConnectionProtocol, EncodedPacket,
     Entity, EntityMovementSyncPacket, LastSeen, NetworkConnection, Player, PlayerChunkView, World,
 };
+use rustc_hash::FxHashMap;
 
 impl World {
     /// Broadcasts a signed chat message to all players in the world.
@@ -196,26 +197,34 @@ impl World {
             .collect()
     }
 
-    /// Returns players on the tracked border of a chunk whose client has its base chunk packet.
-    pub fn get_light_packet_tracking_players(&self, chunk: ChunkPos) -> Vec<i32> {
-        self.player_area_map
-            .get_tracking_players(chunk)
-            .into_iter()
-            .filter(|entity_id| {
-                let Some(player) = self.players.get_by_entity_id(*entity_id) else {
-                    return false;
+    /// Resolves and sends deferred light updates: for each player the border checks for
+    /// all their candidate chunks run under a single view/chunk-sender lock pair.
+    pub fn send_deferred_light_updates(
+        &self,
+        writes: &[(ChunkPos, EncodedPacket, Vec<i32>)],
+        candidates: FxHashMap<i32, Vec<usize>>,
+    ) {
+        for (entity_id, indices) in candidates {
+            let Some(player) = self.players.get_by_entity_id(entity_id) else {
+                continue;
+            };
+            let Some(view) = *player.last_tracking_view.lock() else {
+                continue;
+            };
+            let chunk_sender = player.chunk_sender.lock();
+            let is_chunk_sent = |pos| chunk_sender.is_chunk_sent(pos);
+            for index in indices {
+                let Some((chunk_pos, encoded, _)) = writes.get(index) else {
+                    continue;
                 };
-                let Some(view) = *player.last_tracking_view.lock() else {
-                    return false;
-                };
-                let chunk_sender = player.chunk_sender.lock();
-                let is_chunk_sent = |pos| chunk_sender.is_chunk_sent(pos);
-                Self::chunk_is_on_packet_tracked_border(view, chunk, &is_chunk_sent)
-            })
-            .collect()
+                if Self::chunk_is_on_packet_tracked_border(view, *chunk_pos, &is_chunk_sent) {
+                    player.connection.send_encoded(encoded.clone());
+                }
+            }
+        }
     }
 
-    pub(super) fn chunk_is_on_packet_tracked_border(
+    pub(crate) fn chunk_is_on_packet_tracked_border(
         view: PlayerChunkView,
         chunk: ChunkPos,
         is_chunk_sent: &impl Fn(ChunkPos) -> bool,


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Performance improvement

## Description

Scopes same-chunk entity tracker refreshes:

- `EntityTracker` keeps `entities_by_chunk`, a secondary index of entity IDs by registered chunk, maintained on add, remove, dead-entity removal, and section moves.
- New `update_player_nearby(player, view, center, radius_chunks, is_chunk_sent)` evaluates only entities registered within the view radius of the player chunk. `ChunkMap::update_player_status` uses it when the view is unchanged (pure same-chunk movement) — previously every accepted movement scanned every tracked entity in the world (`entities.iter_sync`).
- Full `update_player` scans remain for cross-chunk view changes, initial joins, and chunk batch commits.
- The shared vanilla visibility predicate is extracted to `entity_visible_to_player` so both paths stay in lockstep with vanilla's `updatePlayer` rules.

## How this was tested

- New regression test `update_player_nearby_uses_chunk_registry_without_full_scan`: scoping (far entity outside the radius is neither evaluated nor despawned), idempotence (no duplicate spawn packets for already-paired entities), and despawn-on-removal (removed entities inside the radius are despawned with `CRemoveEntities`).
- `cargo test -p steel-core --lib` (2422 tests) pass; `cargo clippy -r --all-targets` clean.

## Screenshots / logs

N/A.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable) — N/A
- [x] No leftover debug code / comments

## Additional notes

- The regression test caught a real bug during development (missing `CRemoveEntities` in the nearby despawn path) — kept as the guard against reintroducing it.
- Stacked on `pr7-chunk-light-efficiency` (base of this PR).
- Env: Linux, Rust nightly, Minecraft protocol 776 (0.15.2+mc26.2).

> **Note:** stacked on #551 (`pr7-chunk-light-efficiency`). Until it merges, this PR's diff includes its commits; the tracker changes themselves are the final commit. Incremental diff: https://github.com/carabistouflette/SteelMC/compare/pr7-chunk-light-efficiency...pr8-tracker-refresh-scoping

