### PR TITLE
feat: implement interaction entity

### DIFF
--- a/steel-core/src/entity/entities/mod.rs
+++ b/steel-core/src/entity/entities/mod.rs
@@ -10,6 +10,6 @@ pub use objects::display_ui::{BlockDisplayEntity, ItemFrameEntity, LeashFenceKno
 pub use objects::explosives::EndCrystalEntity;
 pub use objects::items::{ExperienceOrbEntity, FallingBlockEntity, ItemEntity};
 pub use objects::projectiles::{EnderPearlEntity, FireworkRocketEntity, ThrownEggEntity};
-pub use objects::technical::MarkerEntity;
+pub use objects::technical::{MarkerEntity, InteractionEntity};
 pub use objects::vehicles::ChestMinecartEntity;
 pub use raw::RawEntity;

--- a/steel-core/src/entity/entities/mod.rs
+++ b/steel-core/src/entity/entities/mod.rs
@@ -10,6 +10,6 @@ pub use objects::display_ui::{BlockDisplayEntity, ItemFrameEntity, LeashFenceKno
 pub use objects::explosives::EndCrystalEntity;
 pub use objects::items::{ExperienceOrbEntity, FallingBlockEntity, ItemEntity};
 pub use objects::projectiles::{EnderPearlEntity, FireworkRocketEntity, ThrownEggEntity};
-pub use objects::technical::{MarkerEntity, InteractionEntity};
+pub use objects::technical::{InteractionEntity, MarkerEntity};
 pub use objects::vehicles::ChestMinecartEntity;
 pub use raw::RawEntity;

--- a/steel-core/src/entity/entities/objects/technical/interaction.rs
+++ b/steel-core/src/entity/entities/objects/technical/interaction.rs
@@ -23,6 +23,9 @@ const DEFAULT_WIDTH: f32 = 1.0;
 const DEFAULT_HEIGHT: f32 = 1.0;
 const DEFAULT_RESPONSE: bool = false;
 
+const DEFAULT_DIMENSIONS: EntityDimensions =
+    InteractionEntity::dimensions_for_width_height(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+
 const TAG_WIDTH: &str = "width";
 const TAG_HEIGHT: &str = "height";
 const TAG_ATTACK: &str = "attack";
@@ -56,7 +59,7 @@ impl InteractionEntity {
     #[must_use]
     pub fn new(entity_type: EntityTypeRef, id: i32, position: DVec3, world: Weak<World>) -> Self {
         Self {
-            base: EntityBase::new(id, position, entity_type.dimensions, world),
+            base: EntityBase::new(id, position, DEFAULT_DIMENSIONS, world),
             entity_type,
             entity_data: SyncMutex::new(InteractionEntityData::new()),
             attack: SyncMutex::new(None),
@@ -74,7 +77,7 @@ impl InteractionEntity {
         world: Weak<World>,
     ) -> Self {
         Self {
-            base: EntityBase::with_uuid(id, uuid, position, entity_type.dimensions, world),
+            base: EntityBase::with_uuid(id, uuid, position, DEFAULT_DIMENSIONS, world),
             entity_type,
             entity_data: SyncMutex::new(InteractionEntityData::new()),
             attack: SyncMutex::new(None),
@@ -86,7 +89,7 @@ impl InteractionEntity {
     #[must_use]
     pub fn from_saved(entity_type: EntityTypeRef, load: EntityBaseLoad) -> Self {
         Self {
-            base: EntityBase::from_load(load, entity_type.dimensions),
+            base: EntityBase::from_load(load, DEFAULT_DIMENSIONS),
             entity_type,
             entity_data: SyncMutex::new(InteractionEntityData::new()),
             attack: SyncMutex::new(None),
@@ -117,14 +120,18 @@ impl InteractionEntity {
         value
     }
 
-    /// Provides the latest attack (right-click) on this entity.
+    /// Provides the latest attack (left-click) on this entity, if it exists.
     pub fn last_attack(&self) -> Option<PlayerAction> {
         *self.attack.lock()
     }
 
-    /// Provides the latest interaction (right-click) on this entity.
+    /// Provides the latest interaction (right-click) on this entity, if it exists.
     pub fn last_interaction(&self) -> Option<PlayerAction> {
         *self.interaction.lock()
+    }
+
+    const fn dimensions_for_width_height(width: f32, height: f32) -> EntityDimensions {
+        EntityDimensions::with_default_eye_height(width, height)
     }
 }
 
@@ -150,6 +157,7 @@ impl Entity for InteractionEntity {
                 player: player.uuid(),
                 timestamp: world.game_time(),
             });
+            // TODO: Trigger PLAYER_HURT_ENTITY advancement criterion trigger
         }
         !self.entity_data.lock().response.get()
     }
@@ -204,7 +212,7 @@ impl Entity for InteractionEntity {
 
     fn dimensions_for_pose(&self, _pose: EntityPose) -> EntityDimensions {
         let guard = self.entity_data.lock();
-        EntityDimensions::with_default_eye_height(*guard.width.get(), *guard.height.get())
+        Self::dimensions_for_width_height(*guard.width.get(), *guard.height.get())
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {
@@ -229,8 +237,9 @@ impl Entity for InteractionEntity {
     }
 
     fn load_additional(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
-        {
+        let dimensions_changed = {
             let mut guard = self.entity_data.lock();
+
             guard
                 .width
                 .set(nbt.float(TAG_WIDTH).unwrap_or(DEFAULT_WIDTH));
@@ -240,11 +249,18 @@ impl Entity for InteractionEntity {
             guard
                 .response
                 .set(nbt.byte(TAG_RESPONSE).map_or(DEFAULT_RESPONSE, |b| b != 0));
-        }
+
+            guard.width.is_dirty() || guard.height.is_dirty()
+        };
         *self.attack.lock() = nbt.get(TAG_ATTACK).and_then(PlayerAction::from_nbt_tag);
         *self.interaction.lock() = nbt
             .get(TAG_INTERACTION)
             .and_then(PlayerAction::from_nbt_tag);
+        if dimensions_changed {
+            self.refresh_dimensions();
+        }
+        self.base
+            .set_bounding_box(self.make_bounding_box_at(self.position()));
     }
 
     fn hurt(&self, _world: &World, _source: &DamageSource, _amount: f32) -> bool {
@@ -332,21 +348,172 @@ impl InteractionEntityDataView<'_> {
 
     /// Gets whether interacting with the interaction entity will trigger a response
     /// from the player. If `true`, this means that
-    /// - for left clicks, the player will play an attack animation, and
+    /// - for left clicks, a punching sound will play, and
     /// - for right clicks, the player's hand will swing.
-    ///
-    /// If `false`, no animation plays.
     pub fn response(&self) -> bool {
         *self.guard.response.get()
     }
 
     /// Sets whether interacting with the interaction entity will trigger a response
     /// from the player. If set to `true`, this means that
-    /// - for left clicks, the player will play an attack animation, and
+    /// - for left clicks, a punching sound will play, and
     /// - for right clicks, the player's hand will swing.
-    ///
-    /// If set to `false`, no animation plays.
     pub fn set_response(&mut self, response: bool) {
         self.guard.response.set(response);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::entity::Entity;
+    use crate::entity::entities::InteractionEntity;
+    use crate::entity::entities::objects::technical::interaction::{
+        DEFAULT_HEIGHT, DEFAULT_WIDTH, PlayerAction, TAG_HEIGHT, TAG_WIDTH,
+    };
+    use crate::test_support::{TestPlayerBuilder, fresh_test_world};
+    use glam::DVec3;
+    use simdnbt::borrow::read_compound;
+    use simdnbt::owned::NbtCompound;
+    use std::io::Cursor;
+    use std::sync::Arc;
+    use steel_registry::vanilla_entities;
+    use steel_utils::types::InteractionHand;
+
+    const TEST_POSITION: DVec3 = DVec3::new(-8.0, 128.0, 4.0);
+
+    #[test]
+    fn skip_attack_interaction_when_required() {
+        let world = fresh_test_world("skip_interaction_when_required");
+        let player = TestPlayerBuilder::new(world.clone(), "InteractPlayer", 0).build();
+
+        let response_false_interaction = InteractionEntity::new(
+            &vanilla_entities::INTERACTION,
+            1,
+            TEST_POSITION,
+            Arc::downgrade(&world),
+        );
+        let response_true_interaction = InteractionEntity::new(
+            &vanilla_entities::INTERACTION,
+            2,
+            TEST_POSITION,
+            Arc::downgrade(&world),
+        );
+        response_true_interaction.with_entity_data(|data| data.set_response(true));
+
+        assert!(response_false_interaction.skip_attack_interaction(player.as_ref()));
+        assert!(!response_true_interaction.skip_attack_interaction(player.as_ref()));
+    }
+
+    #[test]
+    fn record_player_actions() {
+        let world = fresh_test_world("interaction_records_player_actions");
+        let player = TestPlayerBuilder::new(world.clone(), "InteractPlayer", 0).build();
+
+        let interaction = InteractionEntity::new(
+            &vanilla_entities::INTERACTION,
+            1,
+            TEST_POSITION,
+            Arc::downgrade(&world),
+        );
+
+        assert_eq!(interaction.last_attack(), None);
+        assert_eq!(interaction.last_interaction(), None);
+
+        world.tick_game(0, true);
+        world.tick_game(1, true);
+        world.tick_game(2, true);
+
+        interaction.skip_attack_interaction(player.as_ref());
+        assert_eq!(
+            interaction.last_attack(),
+            Some(PlayerAction {
+                player: player.uuid(),
+                timestamp: 3
+            })
+        );
+        assert_eq!(interaction.last_interaction(), None);
+
+        world.tick_game(3, true);
+        world.tick_game(4, true);
+
+        interaction.interact(player.as_ref(), InteractionHand::MainHand, TEST_POSITION);
+        assert_eq!(
+            interaction.last_attack(),
+            Some(PlayerAction {
+                player: player.uuid(),
+                timestamp: 3
+            })
+        );
+        assert_eq!(
+            interaction.last_interaction(),
+            Some(PlayerAction {
+                player: player.uuid(),
+                timestamp: 5
+            })
+        );
+
+        world.tick_game(5, true);
+
+        interaction.skip_attack_interaction(player.as_ref());
+        assert_eq!(
+            interaction.last_attack(),
+            Some(PlayerAction {
+                player: player.uuid(),
+                timestamp: 6
+            })
+        );
+    }
+
+    #[test]
+    fn update_dimensions_on_edit() {
+        let world = fresh_test_world("interaction_updates_dimensions_on_edit");
+
+        let interaction = InteractionEntity::new(
+            &vanilla_entities::INTERACTION,
+            0,
+            TEST_POSITION,
+            Arc::downgrade(&world),
+        );
+
+        let check_dimensions_and_bounding_box = |expected_width: f32, expected_height: f32| {
+            let dimensions = interaction.base.dimensions();
+            assert_eq!(dimensions.width, expected_width);
+            assert_eq!(dimensions.height, expected_height);
+
+            let bounding_box = interaction.base.bounding_box();
+            assert_eq!(bounding_box.width(), f64::from(expected_width));
+            assert_eq!(bounding_box.height(), f64::from(expected_height));
+        };
+
+        check_dimensions_and_bounding_box(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+
+        interaction.with_entity_data(|data| {
+            data.set_width(2.0);
+        });
+        check_dimensions_and_bounding_box(2.0, DEFAULT_HEIGHT);
+
+        interaction.with_entity_data(|data| {
+            data.set_height(4.0);
+        });
+        check_dimensions_and_bounding_box(2.0, 4.0);
+
+        interaction.with_entity_data(|data| {
+            data.set_width(0.5);
+            data.set_height(0.25);
+        });
+        check_dimensions_and_bounding_box(0.5, 0.25);
+
+        let bytes = {
+            let mut compound = NbtCompound::new();
+            compound.insert(TAG_WIDTH, 2.0f32);
+            compound.remove(TAG_HEIGHT);
+            let mut bytes = Vec::new();
+            compound.write(&mut bytes);
+            bytes
+        };
+        let borrowed = read_compound(&mut Cursor::new(&bytes))
+            .unwrap_or_else(|error| panic!("test nbt should reborrow: {error}"));
+        interaction.load_additional((&borrowed).into());
+        check_dimensions_and_bounding_box(2.0, DEFAULT_HEIGHT);
     }
 }

--- a/steel-core/src/entity/entities/objects/technical/interaction.rs
+++ b/steel-core/src/entity/entities/objects/technical/interaction.rs
@@ -1,3 +1,4 @@
+use crate::entity::BorrowedNbtCompoundView;
 use std::sync::Weak;
 use glam::DVec3;
 use parking_lot::MutexGuard;
@@ -5,11 +6,17 @@ use simdnbt::owned::{NbtCompound, NbtTag};
 use simdnbt::{FromNbtTag, ToNbtTag};
 use uuid::Uuid;
 use steel_macros::entity_behavior;
-use steel_registry::entity_type::EntityTypeRef;
+use steel_registry::blocks::behavior::PushReaction;
+use steel_registry::entity_data::EntityPose;
+use steel_registry::entity_type::{EntityDimensions, EntityTypeRef};
 use steel_registry::vanilla_entity_data::InteractionEntityData;
-use steel_utils::{DowncastType, DowncastTypeKey, UuidExt};
+use steel_utils::{DowncastType, DowncastTypeKey, UuidExt, WorldAabb};
 use steel_utils::locks::SyncMutex;
+use steel_utils::types::InteractionHand;
+use crate::behavior::InteractionResult;
 use crate::entity::{Entity, EntityBase, EntityBaseLoad, EntitySyncedData};
+use crate::entity::damage::DamageSource;
+use crate::player::Player;
 use crate::world::World;
 
 const DEFAULT_WIDTH: f32 = 1.0;
@@ -99,12 +106,68 @@ impl Entity for InteractionEntity {
         self.entity_type
     }
 
+    fn is_pickable(&self) -> bool {
+        true
+    }
+
+    fn skip_attack_interaction(&self, source: &dyn Entity) -> bool {
+        let Some(player) = source.as_player() else {
+            return false;
+        };
+        *self.attack.lock() = Some(PlayerAction {
+            player: player.uuid(),
+            timestamp: player.get_world().game_time()
+        });
+        !self.entity_data.lock().response.get()
+    }
+
+    fn is_ignoring_block_triggers(&self) -> bool {
+        true
+    }
+
+    fn piston_push_reaction(&self) -> PushReaction {
+        PushReaction::Ignore
+    }
+
+    fn can_be_hit_by_projectile(&self) -> bool {
+        false
+    }
+
+    fn make_bounding_box_at(&self, position: DVec3) -> WorldAabb {
+        let guard = self.entity_data.lock();
+        WorldAabb::entity_box(
+            position.x,
+            position.y,
+            position.z,
+            f64::from(*guard.width.get() / 2.0),
+            f64::from(*guard.height.get()),
+        )
+    }
+
+    fn tick(&self) {}
+
+    fn synced_data(&self) -> Option<&dyn EntitySyncedData> {
+        Some(&self.entity_data)
+    }
+
+    fn interact(&self, player: &Player, _hand: InteractionHand, _location: DVec3) -> InteractionResult {
+        *self.interaction.lock() = Some(PlayerAction {
+            player: player.uuid(),
+            timestamp: player.get_world().game_time()
+        });
+        InteractionResult::Consume
+    }
+
     fn no_physics(&self) -> bool {
         true
     }
 
-    fn synced_data(&self) -> Option<&dyn EntitySyncedData> {
-        Some(&self.entity_data)
+    fn dimensions_for_pose(&self, _pose: EntityPose) -> EntityDimensions {
+        let guard = self.entity_data.lock();
+        EntityDimensions::with_default_eye_height(
+            *guard.width.get(),
+            *guard.height.get()
+        )
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {
@@ -122,10 +185,25 @@ impl Entity for InteractionEntity {
         }
         {
             let guard = self.interaction.lock();
-            if let Some(attack) = guard.as_ref() {
-                nbt.insert(TAG_INTERACTION, attack);
+            if let Some(interaction) = guard.as_ref() {
+                nbt.insert(TAG_INTERACTION, interaction);
             }
         }
+    }
+
+    fn load_additional(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
+        {
+            let mut guard = self.entity_data.lock();
+            guard.width.set(nbt.float(TAG_WIDTH).unwrap_or(DEFAULT_WIDTH));
+            guard.height.set(nbt.float(TAG_HEIGHT).unwrap_or(DEFAULT_HEIGHT));
+            guard.response.set(nbt.byte(TAG_RESPONSE).map(|b| b != 0).unwrap_or(DEFAULT_RESPONSE));
+        }
+        *self.attack.lock() = nbt.get(TAG_ATTACK).and_then(PlayerAction::from_nbt_tag);
+        *self.interaction.lock() = nbt.get(TAG_INTERACTION).and_then(PlayerAction::from_nbt_tag);
+    }
+
+    fn hurt(&self, _world: &World, _source: &DamageSource, _amount: f32) -> bool {
+        false
     }
 }
 

--- a/steel-core/src/entity/entities/objects/technical/interaction.rs
+++ b/steel-core/src/entity/entities/objects/technical/interaction.rs
@@ -268,7 +268,8 @@ impl Entity for InteractionEntity {
     }
 }
 
-/// Represents an action of a player.
+/// Represents an action of a player. It contains the UUID of the player who executed this action
+/// and the timestamp (based on game time, expressed in ticks) when it was executed.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PlayerAction {
     /// The player who executed the action.
@@ -280,11 +281,13 @@ pub struct PlayerAction {
 
 impl PlayerAction {
     /// Returns the unique ID of the player who executed this action.
+    #[must_use]
     pub const fn player(&self) -> Uuid {
         self.player
     }
 
     /// Returns the game time (in ticks) when the player executed the action.
+    #[must_use]
     pub const fn timestamp(&self) -> i64 {
         self.timestamp
     }
@@ -321,6 +324,7 @@ pub struct InteractionEntityDataView<'a> {
 
 impl InteractionEntityDataView<'_> {
     /// Gets the width of the bounding box of the interaction entity.
+    #[must_use]
     pub fn width(&self) -> f32 {
         *self.guard.width.get()
     }
@@ -334,6 +338,7 @@ impl InteractionEntityDataView<'_> {
     }
 
     /// Gets the height of the bounding box of the interaction entity.
+    #[must_use]
     pub fn height(&self) -> f32 {
         *self.guard.height.get()
     }
@@ -350,6 +355,7 @@ impl InteractionEntityDataView<'_> {
     /// from the player. If `true`, this means that
     /// - for left clicks, a punching sound will play, and
     /// - for right clicks, the player's hand will swing.
+    #[must_use]
     pub fn response(&self) -> bool {
         *self.guard.response.get()
     }

--- a/steel-core/src/entity/entities/objects/technical/interaction.rs
+++ b/steel-core/src/entity/entities/objects/technical/interaction.rs
@@ -24,7 +24,7 @@ const DEFAULT_HEIGHT: f32 = 1.0;
 const DEFAULT_RESPONSE: bool = false;
 
 const DEFAULT_DIMENSIONS: EntityDimensions =
-    InteractionEntity::dimensions_for_width_height(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+    EntityDimensions::with_default_eye_height(DEFAULT_WIDTH, DEFAULT_HEIGHT);
 
 const TAG_WIDTH: &str = "width";
 const TAG_HEIGHT: &str = "height";
@@ -129,10 +129,6 @@ impl InteractionEntity {
     pub fn last_interaction(&self) -> Option<PlayerAction> {
         *self.interaction.lock()
     }
-
-    const fn dimensions_for_width_height(width: f32, height: f32) -> EntityDimensions {
-        EntityDimensions::with_default_eye_height(width, height)
-    }
 }
 
 impl Entity for InteractionEntity {
@@ -212,7 +208,7 @@ impl Entity for InteractionEntity {
 
     fn dimensions_for_pose(&self, _pose: EntityPose) -> EntityDimensions {
         let guard = self.entity_data.lock();
-        Self::dimensions_for_width_height(*guard.width.get(), *guard.height.get())
+        EntityDimensions::with_default_eye_height(*guard.width.get(), *guard.height.get())
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {

--- a/steel-core/src/entity/entities/objects/technical/interaction.rs
+++ b/steel-core/src/entity/entities/objects/technical/interaction.rs
@@ -1,23 +1,23 @@
+use crate::behavior::InteractionResult;
 use crate::entity::BorrowedNbtCompoundView;
-use std::sync::Weak;
+use crate::entity::damage::DamageSource;
+use crate::entity::{Entity, EntityBase, EntityBaseLoad, EntitySyncedData};
+use crate::player::Player;
+use crate::world::World;
 use glam::DVec3;
 use parking_lot::MutexGuard;
 use simdnbt::owned::{NbtCompound, NbtTag};
 use simdnbt::{FromNbtTag, ToNbtTag};
-use uuid::Uuid;
+use std::sync::Weak;
 use steel_macros::entity_behavior;
 use steel_registry::blocks::behavior::PushReaction;
 use steel_registry::entity_data::EntityPose;
 use steel_registry::entity_type::{EntityDimensions, EntityTypeRef};
 use steel_registry::vanilla_entity_data::InteractionEntityData;
-use steel_utils::{DowncastType, DowncastTypeKey, UuidExt, WorldAabb};
 use steel_utils::locks::SyncMutex;
 use steel_utils::types::InteractionHand;
-use crate::behavior::InteractionResult;
-use crate::entity::{Entity, EntityBase, EntityBaseLoad, EntitySyncedData};
-use crate::entity::damage::DamageSource;
-use crate::player::Player;
-use crate::world::World;
+use steel_utils::{DowncastType, DowncastTypeKey, UuidExt, WorldAabb};
+use uuid::Uuid;
 
 const DEFAULT_WIDTH: f32 = 1.0;
 const DEFAULT_HEIGHT: f32 = 1.0;
@@ -32,15 +32,18 @@ const TAG_RESPONSE: &str = "response";
 const TAG_PLAYER: &str = "player";
 const TAG_TIMESTAMP: &str = "timestamp";
 
-/// An invisible, invincible, interactable entity which records when a player clicks in its bounding
+/// An invisible, invincible, interactable entity which records when a player clicks on its bounding
 /// box. It is used in map-making or data packs, and its bounding box is customizable.
+///
+/// The dimensions of its bounding box (`width` and `height`) and whether it triggers a response from
+/// the player (`response`) can be accessed and/or modified with [`InteractionEntity::with_entity_data`].
 #[entity_behavior(class = "Interaction")]
 pub struct InteractionEntity {
     base: EntityBase,
     entity_type: EntityTypeRef,
     entity_data: SyncMutex<InteractionEntityData>,
     interaction: SyncMutex<Option<PlayerAction>>,
-    attack: SyncMutex<Option<PlayerAction>>
+    attack: SyncMutex<Option<PlayerAction>>,
 }
 
 // SAFETY: This key is owned by Steel and uniquely identifies `InteractionEntity`.
@@ -79,7 +82,7 @@ impl InteractionEntity {
         }
     }
 
-    /// Creates a interaction entity from saved data.
+    /// Creates an interaction entity from saved data.
     #[must_use]
     pub fn from_saved(entity_type: EntityTypeRef, load: EntityBaseLoad) -> Self {
         Self {
@@ -91,9 +94,37 @@ impl InteractionEntity {
         }
     }
 
-    /// Gets a reference to the entity data for reading/modifying synced state.
-    pub const fn entity_data(&self) -> &SyncMutex<InteractionEntityData> {
-        &self.entity_data
+    /// Provides an exclusive view to the synced entity data to the given closure, which includes
+    /// the dimensions of its bounding box (`width` and `height`), and whether it triggers a response
+    /// from the player (`response`).
+    ///
+    /// Do not attempt to lock entity data within the closure provided.
+    pub fn with_entity_data<R>(
+        &self,
+        f: impl FnOnce(&mut InteractionEntityDataView<'_>) -> R,
+    ) -> R {
+        let (value, dimensions_changed) = {
+            let mut view = InteractionEntityDataView {
+                guard: self.entity_data.lock(),
+                dimensions_changed: false,
+            };
+            let value = f(&mut view);
+            (value, view.dimensions_changed)
+        };
+        if dimensions_changed {
+            self.refresh_dimensions();
+        }
+        value
+    }
+
+    /// Provides the latest attack (right-click) on this entity.
+    pub fn last_attack(&self) -> Option<PlayerAction> {
+        *self.attack.lock()
+    }
+
+    /// Provides the latest interaction (right-click) on this entity.
+    pub fn last_interaction(&self) -> Option<PlayerAction> {
+        *self.interaction.lock()
     }
 }
 
@@ -114,10 +145,12 @@ impl Entity for InteractionEntity {
         let Some(player) = source.as_player() else {
             return false;
         };
-        *self.attack.lock() = Some(PlayerAction {
-            player: player.uuid(),
-            timestamp: player.get_world().game_time()
-        });
+        if let Some(world) = self.level() {
+            *self.attack.lock() = Some(PlayerAction {
+                player: player.uuid(),
+                timestamp: world.game_time(),
+            });
+        }
         !self.entity_data.lock().response.get()
     }
 
@@ -150,11 +183,18 @@ impl Entity for InteractionEntity {
         Some(&self.entity_data)
     }
 
-    fn interact(&self, player: &Player, _hand: InteractionHand, _location: DVec3) -> InteractionResult {
-        *self.interaction.lock() = Some(PlayerAction {
-            player: player.uuid(),
-            timestamp: player.get_world().game_time()
-        });
+    fn interact(
+        &self,
+        player: &Player,
+        _hand: InteractionHand,
+        _location: DVec3,
+    ) -> InteractionResult {
+        if let Some(world) = self.level() {
+            *self.interaction.lock() = Some(PlayerAction {
+                player: player.uuid(),
+                timestamp: world.game_time(),
+            });
+        }
         InteractionResult::Consume
     }
 
@@ -164,10 +204,7 @@ impl Entity for InteractionEntity {
 
     fn dimensions_for_pose(&self, _pose: EntityPose) -> EntityDimensions {
         let guard = self.entity_data.lock();
-        EntityDimensions::with_default_eye_height(
-            *guard.width.get(),
-            *guard.height.get()
-        )
+        EntityDimensions::with_default_eye_height(*guard.width.get(), *guard.height.get())
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {
@@ -194,12 +231,20 @@ impl Entity for InteractionEntity {
     fn load_additional(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
         {
             let mut guard = self.entity_data.lock();
-            guard.width.set(nbt.float(TAG_WIDTH).unwrap_or(DEFAULT_WIDTH));
-            guard.height.set(nbt.float(TAG_HEIGHT).unwrap_or(DEFAULT_HEIGHT));
-            guard.response.set(nbt.byte(TAG_RESPONSE).map(|b| b != 0).unwrap_or(DEFAULT_RESPONSE));
+            guard
+                .width
+                .set(nbt.float(TAG_WIDTH).unwrap_or(DEFAULT_WIDTH));
+            guard
+                .height
+                .set(nbt.float(TAG_HEIGHT).unwrap_or(DEFAULT_HEIGHT));
+            guard
+                .response
+                .set(nbt.byte(TAG_RESPONSE).map_or(DEFAULT_RESPONSE, |b| b != 0));
         }
         *self.attack.lock() = nbt.get(TAG_ATTACK).and_then(PlayerAction::from_nbt_tag);
-        *self.interaction.lock() = nbt.get(TAG_INTERACTION).and_then(PlayerAction::from_nbt_tag);
+        *self.interaction.lock() = nbt
+            .get(TAG_INTERACTION)
+            .and_then(PlayerAction::from_nbt_tag);
     }
 
     fn hurt(&self, _world: &World, _source: &DamageSource, _amount: f32) -> bool {
@@ -208,37 +253,100 @@ impl Entity for InteractionEntity {
 }
 
 /// Represents an action of a player.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PlayerAction {
-    /// The player who did the action.
+    /// The player who executed the action.
     player: Uuid,
 
-    /// The game time (in ticks) when the player did the action.
-    timestamp: i64
+    /// The game time (in ticks) when the player executed the action.
+    timestamp: i64,
+}
+
+impl PlayerAction {
+    /// Returns the unique ID of the player who executed this action.
+    pub const fn player(&self) -> Uuid {
+        self.player
+    }
+
+    /// Returns the game time (in ticks) when the player executed the action.
+    pub const fn timestamp(&self) -> i64 {
+        self.timestamp
+    }
 }
 
 impl FromNbtTag for PlayerAction {
     fn from_nbt_tag(tag: simdnbt::borrow::NbtTag) -> Option<Self> {
         let compound = tag.compound()?;
-        Some(
-            Self {
-                player: Uuid::from_int_array(&*compound.int_array(TAG_PLAYER)?)?,
-                timestamp: compound.long(TAG_TIMESTAMP)?
-            }
-        )
+        Some(Self {
+            player: Uuid::from_int_array(&compound.int_array(TAG_PLAYER)?)?,
+            timestamp: compound.long(TAG_TIMESTAMP)?,
+        })
     }
 }
 
 impl ToNbtTag for &PlayerAction {
     fn to_nbt_tag(self) -> NbtTag {
         let mut compound = NbtCompound::new();
-        compound.insert(TAG_PLAYER, NbtTag::IntArray(self.player.to_int_array().to_vec()));
+        compound.insert(
+            TAG_PLAYER,
+            NbtTag::IntArray(self.player.to_int_array().to_vec()),
+        );
         compound.insert(TAG_TIMESTAMP, self.timestamp);
         NbtTag::Compound(compound)
     }
 }
 
-/// Provides the view of an interaction entity.
-pub struct InteractionEntityView<'a> {
-    guard: MutexGuard<'a, InteractionEntityData>
+/// Provides an exclusive view of the synchronized entity data of an interaction entity.
+/// This includes its `width`, its `height`, and the `response` boolean.
+pub struct InteractionEntityDataView<'a> {
+    guard: MutexGuard<'a, InteractionEntityData>,
+    dimensions_changed: bool,
+}
+
+impl InteractionEntityDataView<'_> {
+    /// Gets the width of the bounding box of the interaction entity.
+    pub fn width(&self) -> f32 {
+        *self.guard.width.get()
+    }
+
+    /// Sets the width of the bounding box of the interaction entity to the provided value.
+    pub fn set_width(&mut self, width: f32) {
+        self.guard.width.set(width);
+        if self.guard.width.is_dirty() {
+            self.dimensions_changed = true;
+        }
+    }
+
+    /// Gets the height of the bounding box of the interaction entity.
+    pub fn height(&self) -> f32 {
+        *self.guard.height.get()
+    }
+
+    /// Sets the height of the bounding box of the interaction entity to the provided value.
+    pub fn set_height(&mut self, height: f32) {
+        self.guard.height.set(height);
+        if self.guard.height.is_dirty() {
+            self.dimensions_changed = true;
+        }
+    }
+
+    /// Gets whether interacting with the interaction entity will trigger a response
+    /// from the player. If `true`, this means that
+    /// - for left clicks, the player will play an attack animation, and
+    /// - for right clicks, the player's hand will swing.
+    ///
+    /// If `false`, no animation plays.
+    pub fn response(&self) -> bool {
+        *self.guard.response.get()
+    }
+
+    /// Sets whether interacting with the interaction entity will trigger a response
+    /// from the player. If set to `true`, this means that
+    /// - for left clicks, the player will play an attack animation, and
+    /// - for right clicks, the player's hand will swing.
+    ///
+    /// If set to `false`, no animation plays.
+    pub fn set_response(&mut self, response: bool) {
+        self.guard.response.set(response);
+    }
 }

--- a/steel-core/src/entity/entities/objects/technical/interaction.rs
+++ b/steel-core/src/entity/entities/objects/technical/interaction.rs
@@ -1,0 +1,166 @@
+use std::sync::Weak;
+use glam::DVec3;
+use parking_lot::MutexGuard;
+use simdnbt::owned::{NbtCompound, NbtTag};
+use simdnbt::{FromNbtTag, ToNbtTag};
+use uuid::Uuid;
+use steel_macros::entity_behavior;
+use steel_registry::entity_type::EntityTypeRef;
+use steel_registry::vanilla_entity_data::InteractionEntityData;
+use steel_utils::{DowncastType, DowncastTypeKey, UuidExt};
+use steel_utils::locks::SyncMutex;
+use crate::entity::{Entity, EntityBase, EntityBaseLoad, EntitySyncedData};
+use crate::world::World;
+
+const DEFAULT_WIDTH: f32 = 1.0;
+const DEFAULT_HEIGHT: f32 = 1.0;
+const DEFAULT_RESPONSE: bool = false;
+
+const TAG_WIDTH: &str = "width";
+const TAG_HEIGHT: &str = "height";
+const TAG_ATTACK: &str = "attack";
+const TAG_INTERACTION: &str = "interaction";
+const TAG_RESPONSE: &str = "response";
+
+const TAG_PLAYER: &str = "player";
+const TAG_TIMESTAMP: &str = "timestamp";
+
+/// An invisible, invincible, interactable entity which records when a player clicks in its bounding
+/// box. It is used in map-making or data packs, and its bounding box is customizable.
+#[entity_behavior(class = "Interaction")]
+pub struct InteractionEntity {
+    base: EntityBase,
+    entity_type: EntityTypeRef,
+    entity_data: SyncMutex<InteractionEntityData>,
+    interaction: SyncMutex<Option<PlayerAction>>,
+    attack: SyncMutex<Option<PlayerAction>>
+}
+
+// SAFETY: This key is owned by Steel and uniquely identifies `InteractionEntity`.
+unsafe impl DowncastType for InteractionEntity {
+    const TYPE_KEY: DowncastTypeKey = DowncastTypeKey::new("steel:entity/interaction");
+}
+
+impl InteractionEntity {
+    /// Creates a new interaction entity.
+    #[must_use]
+    pub fn new(entity_type: EntityTypeRef, id: i32, position: DVec3, world: Weak<World>) -> Self {
+        Self {
+            base: EntityBase::new(id, position, entity_type.dimensions, world),
+            entity_type,
+            entity_data: SyncMutex::new(InteractionEntityData::new()),
+            attack: SyncMutex::new(None),
+            interaction: SyncMutex::new(None),
+        }
+    }
+
+    /// Creates a new interaction entity with a specific UUID.
+    #[must_use]
+    pub fn with_uuid(
+        entity_type: EntityTypeRef,
+        id: i32,
+        position: DVec3,
+        uuid: Uuid,
+        world: Weak<World>,
+    ) -> Self {
+        Self {
+            base: EntityBase::with_uuid(id, uuid, position, entity_type.dimensions, world),
+            entity_type,
+            entity_data: SyncMutex::new(InteractionEntityData::new()),
+            attack: SyncMutex::new(None),
+            interaction: SyncMutex::new(None),
+        }
+    }
+
+    /// Creates a interaction entity from saved data.
+    #[must_use]
+    pub fn from_saved(entity_type: EntityTypeRef, load: EntityBaseLoad) -> Self {
+        Self {
+            base: EntityBase::from_load(load, entity_type.dimensions),
+            entity_type,
+            entity_data: SyncMutex::new(InteractionEntityData::new()),
+            attack: SyncMutex::new(None),
+            interaction: SyncMutex::new(None),
+        }
+    }
+
+    /// Gets a reference to the entity data for reading/modifying synced state.
+    pub const fn entity_data(&self) -> &SyncMutex<InteractionEntityData> {
+        &self.entity_data
+    }
+}
+
+impl Entity for InteractionEntity {
+    fn base(&self) -> &EntityBase {
+        &self.base
+    }
+
+    fn entity_type(&self) -> EntityTypeRef {
+        self.entity_type
+    }
+
+    fn no_physics(&self) -> bool {
+        true
+    }
+
+    fn synced_data(&self) -> Option<&dyn EntitySyncedData> {
+        Some(&self.entity_data)
+    }
+
+    fn save_additional(&self, nbt: &mut NbtCompound) {
+        {
+            let guard = self.entity_data.lock();
+            nbt.insert(TAG_WIDTH, *guard.width.get());
+            nbt.insert(TAG_HEIGHT, *guard.height.get());
+            nbt.insert(TAG_RESPONSE, *guard.response.get());
+        }
+        {
+            let guard = self.attack.lock();
+            if let Some(attack) = guard.as_ref() {
+                nbt.insert(TAG_ATTACK, attack);
+            }
+        }
+        {
+            let guard = self.interaction.lock();
+            if let Some(attack) = guard.as_ref() {
+                nbt.insert(TAG_INTERACTION, attack);
+            }
+        }
+    }
+}
+
+/// Represents an action of a player.
+#[derive(Debug, Copy, Clone)]
+pub struct PlayerAction {
+    /// The player who did the action.
+    player: Uuid,
+
+    /// The game time (in ticks) when the player did the action.
+    timestamp: i64
+}
+
+impl FromNbtTag for PlayerAction {
+    fn from_nbt_tag(tag: simdnbt::borrow::NbtTag) -> Option<Self> {
+        let compound = tag.compound()?;
+        Some(
+            Self {
+                player: Uuid::from_int_array(&*compound.int_array(TAG_PLAYER)?)?,
+                timestamp: compound.long(TAG_TIMESTAMP)?
+            }
+        )
+    }
+}
+
+impl ToNbtTag for &PlayerAction {
+    fn to_nbt_tag(self) -> NbtTag {
+        let mut compound = NbtCompound::new();
+        compound.insert(TAG_PLAYER, NbtTag::IntArray(self.player.to_int_array().to_vec()));
+        compound.insert(TAG_TIMESTAMP, self.timestamp);
+        NbtTag::Compound(compound)
+    }
+}
+
+/// Provides the view of an interaction entity.
+pub struct InteractionEntityView<'a> {
+    guard: MutexGuard<'a, InteractionEntityData>
+}

--- a/steel-core/src/entity/entities/objects/technical/mod.rs
+++ b/steel-core/src/entity/entities/objects/technical/mod.rs
@@ -1,5 +1,7 @@
 //! Technical entity implementations.
 
 mod marker;
+mod interaction;
 
 pub use marker::MarkerEntity;
+pub use interaction::InteractionEntity;

--- a/steel-core/src/entity/entities/objects/technical/mod.rs
+++ b/steel-core/src/entity/entities/objects/technical/mod.rs
@@ -1,7 +1,7 @@
 //! Technical entity implementations.
 
-mod marker;
 mod interaction;
+mod marker;
 
-pub use marker::MarkerEntity;
 pub use interaction::InteractionEntity;
+pub use marker::MarkerEntity;

--- a/steel-core/src/entity/entities/objects/technical/mod.rs
+++ b/steel-core/src/entity/entities/objects/technical/mod.rs
@@ -3,5 +3,5 @@
 mod interaction;
 mod marker;
 
-pub use interaction::InteractionEntity;
+pub use interaction::{InteractionEntity, InteractionEntityDataView, PlayerAction};
 pub use marker::MarkerEntity;

--- a/steel-registry/src/entity_type.rs
+++ b/steel-registry/src/entity_type.rs
@@ -4,6 +4,8 @@ use steel_utils::{DowncastType, DowncastTypeKey, Identifier};
 
 use crate::{RegistryTags, blocks::behavior::PushReaction};
 
+pub const DEFAULT_EYE_HEIGHT_FACTOR: f32 = 0.85;
+
 /// Mob category for spawn classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MobCategory {
@@ -215,6 +217,17 @@ impl EntityDimensions {
         }
     }
 
+    /// Creates new entity dimensions with a default eye height.
+    #[must_use]
+    pub const fn with_default_eye_height(width: f32, height: f32) -> Self {
+        Self {
+            width,
+            height,
+            eye_height: Self::default_eye_height(height),
+            attachments: EntityAttachments::fallback(),
+        }
+    }
+
     /// Scale dimensions by a factor (for baby entities, etc.)
     #[must_use]
     pub fn scale(&self, factor: f32) -> Self {
@@ -230,6 +243,12 @@ impl EntityDimensions {
     #[must_use]
     pub fn half_width(&self) -> f32 {
         self.width / 2.0
+    }
+
+    /// Gets the default eye height for a given entity height.
+    #[must_use]
+    const fn default_eye_height(height: f32) -> f32 {
+        height * DEFAULT_EYE_HEIGHT_FACTOR
     }
 }
 

--- a/steel-registry/src/entity_type.rs
+++ b/steel-registry/src/entity_type.rs
@@ -4,7 +4,7 @@ use steel_utils::{DowncastType, DowncastTypeKey, Identifier};
 
 use crate::{RegistryTags, blocks::behavior::PushReaction};
 
-pub const DEFAULT_EYE_HEIGHT_FACTOR: f32 = 0.85;
+const DEFAULT_EYE_HEIGHT_FACTOR: f32 = 0.85;
 
 /// Mob category for spawn classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [x] Entity implementation

## Description

Implements the [interaction entity](https://minecraft.wiki/w/Interaction) from Vanilla. This is an invisible, invincible, interactable entity whose bounding box can be customized, and keeps track of the latest interaction (right-click) and attack (left-click). Used by map and data pack makers.

## How this was tested

1. Join the server
2. Summon the entity with `/summon minecraft:interaction`

## Screenshots / logs

With hitboxes enabled (`F3`+`B`):
<img width="844" height="634" alt="interactions" src="https://github.com/user-attachments/assets/42498d6b-ad33-4069-8571-bcebdaad0fc1" />

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes modified:

- Interaction

## Additional notes

<!-- Anything else reviewers should know -->
