### PR TITLE
fix: accept any numeric NBT tag when loading entity fields

### DIFF
--- a/steel-core/src/block_entity/entities/barrel.rs
+++ b/steel-core/src/block_entity/entities/barrel.rs
@@ -19,6 +19,7 @@ use crate::block_entity::{BlockEntity, BlockEntityBase};
 use crate::inventory::container::Container;
 use crate::inventory::lock::{ContainerRef, SharedContainer};
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 /// Number of slots in a barrel (3 rows of 9).
 pub const BARREL_SLOTS: usize = 27;
@@ -99,7 +100,7 @@ impl BlockEntity for BarrelBlockEntity {
         {
             for compound in compounds {
                 // Each item has a "Slot" byte and item data
-                if let Some(slot) = compound.byte("Slot") {
+                if let Some(slot) = compound.get_i8("Slot") {
                     let slot = slot as usize;
                     if slot < BARREL_SLOTS {
                         // Parse item directly from the borrowed compound

--- a/steel-core/src/block_entity/entities/beehive.rs
+++ b/steel-core/src/block_entity/entities/beehive.rs
@@ -9,6 +9,7 @@ use steel_utils::{BlockPos, BlockStateId, DowncastType, DowncastTypeKey, locks::
 
 use crate::block_entity::{BlockEntity, BlockEntityBase};
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 /// Maximum number of occupants in a vanilla beehive.
 pub const BEEHIVE_MAX_OCCUPANTS: usize = 3;
@@ -36,10 +37,9 @@ impl BeeOccupant {
             .map_or_else(default_bee_entity_data, |entity_data| {
                 entity_data.to_owned()
             });
-        let ticks_in_hive = nbt.int("ticks_in_hive").unwrap_or(0);
-        let min_ticks_in_hive = nbt
-            .int("min_ticks_in_hive")
-            .unwrap_or(BEEHIVE_MIN_OCCUPATION_TICKS_NECTARLESS);
+        let ticks_in_hive = nbt.get_i32_or("ticks_in_hive", 0);
+        let min_ticks_in_hive =
+            nbt.get_i32_or("min_ticks_in_hive", BEEHIVE_MIN_OCCUPATION_TICKS_NECTARLESS);
 
         Self {
             entity_data,

--- a/steel-core/src/block_entity/entities/brushable.rs
+++ b/steel-core/src/block_entity/entities/brushable.rs
@@ -24,6 +24,7 @@ use crate::block_entity::{BlockEntity, BlockEntityBase};
 use crate::entity::{LivingEntity as _, entity_loot_ref};
 use crate::player::Player;
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 const BRUSH_COOLDOWN_TICKS: i64 = 10;
 const BRUSH_RESET_TICKS: i64 = 40;
@@ -325,7 +326,7 @@ impl BlockEntity for BrushableBlockEntity {
         state.loot_table = nbt_view
             .string("LootTable")
             .and_then(|value| Identifier::from_str(&value.to_str()).ok());
-        state.loot_table_seed = nbt_view.long("LootTableSeed").unwrap_or(0);
+        state.loot_table_seed = nbt_view.get_i64_or("LootTableSeed", 0);
 
         // Vanilla: LootTable and item are mutually exclusive on load.
         if state.loot_table.is_some() {
@@ -339,7 +340,7 @@ impl BlockEntity for BrushableBlockEntity {
 
         // Vanilla Direction.LEGACY_ID_CODEC: byte 3D data value.
         state.hit_direction = nbt_view
-            .byte("hit_direction")
+            .get_i8("hit_direction")
             .map(|value| Direction::from_3d_data_value(i32::from(value)));
     }
 

--- a/steel-core/src/block_entity/entities/chiseled_bookshelf.rs
+++ b/steel-core/src/block_entity/entities/chiseled_bookshelf.rs
@@ -15,6 +15,7 @@ use steel_registry::item_stack::ItemStack;
 use steel_registry::vanilla_block_entity_types;
 use steel_registry::vanilla_item_tags::ItemTag;
 use steel_registry::{vanilla_blocks, vanilla_game_events};
+use steel_utils::nbt::NbtValueInput as _;
 use steel_utils::types::UpdateFlags;
 use steel_utils::{BlockPos, BlockStateId, DowncastType, DowncastTypeKey, locks::SyncMutex};
 
@@ -251,7 +252,7 @@ impl BlockEntity for ChiseledBookShelfBlockEntity {
             && let Some(compounds) = items.compounds()
         {
             for compound in compounds {
-                let Some(slot) = compound.byte(ITEM_SLOT_NBT_KEY) else {
+                let Some(slot) = compound.get_i8(ITEM_SLOT_NBT_KEY) else {
                     continue;
                 };
                 let Ok(slot) = usize::try_from(slot) else {
@@ -264,9 +265,8 @@ impl BlockEntity for ChiseledBookShelfBlockEntity {
                 }
             }
         }
-        container.last_interacted_slot = nbt
-            .int(LAST_INTERACTED_SLOT_NBT_KEY)
-            .unwrap_or(DEFAULT_LAST_INTERACTED_SLOT);
+        container.last_interacted_slot =
+            nbt.get_i32_or(LAST_INTERACTED_SLOT_NBT_KEY, DEFAULT_LAST_INTERACTED_SLOT);
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {

--- a/steel-core/src/block_entity/entities/comparator.rs
+++ b/steel-core/src/block_entity/entities/comparator.rs
@@ -9,6 +9,7 @@ use steel_utils::{BlockPos, BlockStateId, DowncastType, DowncastTypeKey, locks::
 
 use crate::block_entity::{BlockEntity, BlockEntityBase};
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 struct ComparatorState {
     output_signal: i32,
@@ -54,7 +55,7 @@ impl BlockEntity for ComparatorBlockEntity {
 
     fn load_additional(&self, nbt: &BorrowedNbtCompound<'_>) {
         let nbt: NbtCompoundView<'_, '_> = nbt.into();
-        self.state.lock().output_signal = nbt.int("OutputSignal").unwrap_or(0);
+        self.state.lock().output_signal = nbt.get_i32_or("OutputSignal", 0);
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {

--- a/steel-core/src/block_entity/entities/end_gateway.rs
+++ b/steel-core/src/block_entity/entities/end_gateway.rs
@@ -10,6 +10,7 @@ use steel_utils::{BlockPos, BlockStateId, DowncastType, DowncastTypeKey, locks::
 
 use crate::block_entity::{BlockEntity, BlockEntityBase, BlockEntityLifecycleExt as _};
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 const SPAWN_TIME: i64 = 200;
 const COOLDOWN_TIME: i32 = 40;
@@ -126,9 +127,9 @@ impl BlockEntity for EndGatewayBlockEntity {
     fn load_additional(&self, nbt: &BorrowedNbtCompound<'_>) {
         let nbt: NbtCompoundView<'_, '_> = nbt.into();
         let mut gateway = self.gateway.lock();
-        gateway.age = nbt.long("Age").unwrap_or(0);
+        gateway.age = nbt.get_i64_or("Age", 0);
         gateway.exit_portal = Self::load_exit_portal(&nbt);
-        gateway.exact_teleport = nbt.byte("ExactTeleport").is_some_and(|value| value != 0);
+        gateway.exact_teleport = nbt.get_bool_or("ExactTeleport", false);
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {

--- a/steel-core/src/block_entity/entities/jukebox.rs
+++ b/steel-core/src/block_entity/entities/jukebox.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Weak};
 use glam::DVec3;
 use simdnbt::borrow::{
     BaseNbtCompound as BorrowedNbtCompound, NbtCompound as NbtCompoundView,
-    NbtTag as BorrowedNbtTag, read_compound as read_borrowed_compound,
+    read_compound as read_borrowed_compound,
 };
 use simdnbt::owned::NbtCompound;
 use steel_registry::blocks::block_state_ext::BlockStateExt as _;
@@ -20,7 +20,7 @@ use steel_registry::{
     RegistryEntry, level_events, vanilla_block_entity_types, vanilla_game_events,
     vanilla_particle_types,
 };
-use steel_utils::nbt::{merge_nbt_compounds, nbt_compounds_equal};
+use steel_utils::nbt::{NbtNumericTag as _, merge_nbt_compounds, nbt_compounds_equal};
 use steel_utils::types::UpdateFlags;
 use steel_utils::{BlockPos, BlockStateId, DowncastType, DowncastTypeKey, locks::SyncMutex};
 
@@ -95,17 +95,6 @@ impl JukeboxBlockEntity {
         // the padding addition as a wrapping Java `int` before widening.
         let length_in_ticks = (song.length_in_seconds * TICKS_PER_SECOND).ceil() as i32;
         ticks_elapsed >= i64::from(length_in_ticks.wrapping_add(SONG_END_PADDING_TICKS))
-    }
-
-    fn value_input_long(tag: BorrowedNbtTag<'_, '_>) -> Option<i64> {
-        tag.byte()
-            .map(i64::from)
-            .or_else(|| tag.short().map(i64::from))
-            .or_else(|| tag.int().map(i64::from))
-            .or_else(|| tag.long())
-            .or_else(|| tag.float().map(|value| value as i64))
-            // Vanilla's DoubleTag.longValue floors before narrowing.
-            .or_else(|| tag.double().map(|value| value.floor() as i64))
     }
 
     fn on_song_changed(&self, world: &Arc<World>) {
@@ -274,7 +263,7 @@ impl BlockEntity for JukeboxBlockEntity {
             .unwrap_or_else(ItemStack::empty);
         let saved_ticks = nbt
             .get(TICKS_SINCE_SONG_STARTED_TAG)
-            .and_then(Self::value_input_long);
+            .and_then(|tag| tag.numeric_i64());
 
         let should_stop = {
             let state = self.state.lock();
@@ -513,29 +502,6 @@ mod tests {
                 .try_id()
                 .and_then(|id| i32::try_from(id).ok())
                 .unwrap_or(UNKNOWN_SONG_REGISTRY_ID)
-        );
-    }
-
-    #[test]
-    fn value_input_long_uses_each_numeric_tag_long_value() {
-        let mut nbt = NbtCompound::new();
-        nbt.insert("double", -0.5_f64);
-        nbt.insert("float", -0.5_f32);
-        let mut bytes = Vec::new();
-        nbt.write(&mut bytes);
-        let borrowed = read_compound(&mut Cursor::new(bytes.as_slice()))
-            .expect("numeric test NBT should reborrow");
-        let view: NbtCompoundView<'_, '_> = (&borrowed).into();
-
-        assert_eq!(
-            view.get("double")
-                .and_then(JukeboxBlockEntity::value_input_long),
-            Some(-1)
-        );
-        assert_eq!(
-            view.get("float")
-                .and_then(JukeboxBlockEntity::value_input_long),
-            Some(0)
         );
     }
 }

--- a/steel-core/src/block_entity/entities/piston_moving.rs
+++ b/steel-core/src/block_entity/entities/piston_moving.rs
@@ -23,6 +23,7 @@ use crate::block_entity::{BlockEntity, BlockEntityBase, BlockEntityLifecycleExt 
 use crate::entity::Entity;
 use crate::physics::MoverType;
 use crate::world::{LevelReader, World};
+use steel_utils::nbt::NbtValueInput as _;
 
 const PUSH_OFFSET: f64 = 0.01;
 
@@ -609,12 +610,11 @@ impl BlockEntity for PistonMovingBlockEntity {
             .compound("blockState")
             .and_then(block_state_nbt::load)
             .unwrap_or_else(|| vanilla_blocks::AIR.default_state());
-        moving.direction =
-            PistonMovingState::direction_from_legacy_id(view.byte("facing").unwrap_or(0));
-        moving.progress = view.float("progress").unwrap_or(0.0);
+        moving.direction = PistonMovingState::direction_from_legacy_id(view.get_i8_or("facing", 0));
+        moving.progress = view.get_f32_or("progress", 0.0);
         moving.progress_o = moving.progress;
-        moving.extending = view.byte("extending").is_some_and(|value| value != 0);
-        moving.source_piston = view.byte("source").is_some_and(|value| value != 0);
+        moving.extending = view.get_bool_or("extending", false);
+        moving.source_piston = view.get_bool_or("source", false);
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {

--- a/steel-core/src/block_entity/entities/potent_sulfur.rs
+++ b/steel-core/src/block_entity/entities/potent_sulfur.rs
@@ -22,6 +22,7 @@ use crate::behavior::{BLOCK_BEHAVIORS, BlockCollisionContext};
 use crate::block_entity::{BlockEntity, BlockEntityBase, BlockEntityLifecycleExt as _};
 use crate::fluid::FluidStateExt as _;
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 const GEYSER_SALT: i64 = -904_011_478;
 const COUNTDOWN_FREQUENCY_TICKS: i64 = 20;
@@ -251,7 +252,7 @@ impl BlockEntity for PotentSulfurBlockEntity {
 
     fn load_additional(&self, nbt: &BorrowedNbtCompound<'_>) {
         let nbt: NbtCompoundView<'_, '_> = nbt.into();
-        if let Some(countdown) = nbt.int("countdown") {
+        if let Some(countdown) = nbt.get_i32("countdown") {
             self.sulfur.lock().waiting_countdown = countdown;
         }
     }

--- a/steel-core/src/block_entity/entities/sign.rs
+++ b/steel-core/src/block_entity/entities/sign.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 use crate::block_entity::{BlockEntity, BlockEntityBase};
 use crate::entity::Entity;
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 /// Maximum distance (in blocks) a player can be from a sign while editing.
 /// If they move further away, the edit lock is released.
@@ -102,8 +103,8 @@ impl SignText {
         }
 
         // Load glow
-        if let Some(glow) = nbt.byte("has_glowing_text") {
-            self.has_glowing_text = glow != 0;
+        if let Some(glow) = nbt.get_bool("has_glowing_text") {
+            self.has_glowing_text = glow;
         }
     }
 
@@ -281,8 +282,8 @@ impl BlockEntity for SignBlockEntity {
         }
 
         // Load waxed state
-        if let Some(waxed) = nbt_view.byte("is_waxed") {
-            sign.is_waxed = waxed != 0;
+        if let Some(waxed) = nbt_view.get_bool("is_waxed") {
+            sign.is_waxed = waxed;
         }
     }
 

--- a/steel-core/src/entity/ageable.rs
+++ b/steel-core/src/entity/ageable.rs
@@ -14,6 +14,7 @@ use crate::behavior::InteractionResult;
 use crate::entity::{AgeableMobGroupData, Entity, EntitySpawnReason, Mob, SpawnGroupData};
 use crate::player::Player;
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 const BABY_START_AGE: i32 = -24_000;
 const AGE_LOCK_COOLDOWN_TICKS: i32 = 40;
@@ -326,9 +327,9 @@ pub trait AgeableMob: Mob {
 
     /// Loads vanilla ageable mob fields.
     fn load_ageable_mob(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
-        self.set_age(nbt.int("Age").unwrap_or(0));
-        self.set_forced_age(nbt.int("ForcedAge").unwrap_or(0));
-        self.set_age_locked(nbt.byte("AgeLocked").is_some_and(|value| value != 0));
+        self.set_age(nbt.get_i32_or("Age", 0));
+        self.set_forced_age(nbt.get_i32_or("ForcedAge", 0));
+        self.set_age_locked(nbt.get_bool_or("AgeLocked", false));
     }
 }
 

--- a/steel-core/src/entity/animal.rs
+++ b/steel-core/src/entity/animal.rs
@@ -24,6 +24,7 @@ use crate::entity::{
 };
 use crate::player::Player;
 use crate::world::{LevelReader, World};
+use steel_utils::nbt::NbtValueInput as _;
 
 const PARENT_AGE_AFTER_BREEDING: i32 = 6000;
 const IN_LOVE_TIME: i32 = 600;
@@ -391,7 +392,7 @@ pub trait Animal: AgeableMob {
 
     /// Loads vanilla animal fields.
     fn load_animal(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
-        self.set_in_love_time(nbt.int("InLove").unwrap_or(0));
+        self.set_in_love_time(nbt.get_i32_or("InLove", 0));
         if let Some(love_cause) = nbt.int_array("LoveCause")
             && let Some(uuid) = Uuid::from_int_array(&love_cause)
         {

--- a/steel-core/src/entity/entities/mobs/hostile/endermite.rs
+++ b/steel-core/src/entity/entities/mobs/hostile/endermite.rs
@@ -24,6 +24,7 @@ use crate::entity::{
 };
 use crate::physics::MoveResult;
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 const DEFAULT_STEP_HEIGHT: f32 = 0.6;
 const MAX_LIFETIME: i32 = 2400;
@@ -189,8 +190,8 @@ impl Entity for EndermiteEntity {
 
     fn load_additional(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
         self.load_mob(nbt);
-        *self.lifetime.lock() = nbt.int("Lifetime").unwrap_or(0);
-        *self.player_spawned.lock() = nbt.byte("PlayerSpawned").is_some_and(|b| b != 0);
+        *self.lifetime.lock() = nbt.get_i32_or("Lifetime", 0);
+        *self.player_spawned.lock() = nbt.get_bool_or("PlayerSpawned", false);
     }
 }
 

--- a/steel-core/src/entity/entities/mobs/passive/chicken/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/chicken/mod.rs
@@ -42,6 +42,7 @@ use crate::entity::{
 use crate::physics::MoveResult;
 use crate::player::Player;
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 const CHICKEN_BABY_PASSENGER_ATTACHMENTS: [EntityAttachmentPoint; 1] =
     [EntityAttachmentPoint::new(0.0, 0.375, 0.0)];
@@ -464,8 +465,8 @@ impl Entity for ChickenEntity {
         self.load_ageable_mob(nbt);
         self.load_animal(nbt);
 
-        self.set_chicken_jockey(nbt.byte("IsChickenJockey").is_some_and(|value| value != 0));
-        if let Some(egg_time) = nbt.int("EggLayTime") {
+        self.set_chicken_jockey(nbt.get_bool_or("IsChickenJockey", false));
+        if let Some(egg_time) = nbt.get_i32("EggLayTime") {
             self.set_egg_time(egg_time);
         }
         if let Some(variant) = nbt.string("variant")

--- a/steel-core/src/entity/entities/mobs/passive/sheep/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/sheep/mod.rs
@@ -42,6 +42,7 @@ use crate::physics::MoveResult;
 use crate::player::Player;
 use crate::world::World;
 use crate::world::game_event::GameEventContext;
+use steel_utils::nbt::NbtValueInput as _;
 
 const SHEEP_BABY_PASSENGER_ATTACHMENTS: [EntityAttachmentPoint; 1] =
     [EntityAttachmentPoint::new(0.0, 0.5625, 0.0)];
@@ -401,8 +402,8 @@ impl Entity for SheepEntity {
         self.load_mob(nbt);
         self.load_ageable_mob(nbt);
         self.load_animal(nbt);
-        self.set_sheared(nbt.byte("Sheared").is_some_and(|value| value != 0));
-        self.set_color(DyeColor::by_id(i32::from(nbt.byte("Color").unwrap_or(0))));
+        self.set_sheared(nbt.get_bool_or("Sheared", false));
+        self.set_color(DyeColor::by_id(i32::from(nbt.get_i8_or("Color", 0))));
     }
 }
 

--- a/steel-core/src/entity/entities/mobs/passive/sheep/tests/persistence.rs
+++ b/steel-core/src/entity/entities/mobs/passive/sheep/tests/persistence.rs
@@ -34,3 +34,27 @@ fn sheep_loads_vanilla_wool_color_and_sheared_state() {
     assert_eq!(sheep.color(), DyeColor::Pink);
     assert!(sheep.is_sheared());
 }
+
+/// Vanilla reads these fields through `ValueInput.getNumericTag`, which accepts
+/// any numeric tag type and converts it with `NumericTag.byteValue()`.
+#[test]
+fn sheep_loads_wool_color_and_sheared_state_from_any_numeric_tag() {
+    init_vanilla_registry();
+
+    let mut nbt = NbtCompound::new();
+    nbt.insert("Color", DyeColor::Pink.id() as i16);
+    // 0.7 floors to byte 0, so this must be read as "not sheared".
+    nbt.insert("Sheared", 0.7_f64);
+
+    let mut bytes = Vec::new();
+    nbt.write(&mut bytes);
+    let borrowed = read_borrowed_compound(&mut Cursor::new(&bytes))
+        .unwrap_or_else(|error| panic!("test nbt should reborrow: {error}"));
+
+    let sheep = SheepEntity::new(&vanilla_entities::SHEEP, 1, DVec3::ZERO, Weak::new());
+    sheep.set_sheared(true);
+    sheep.load_additional((&borrowed).into());
+
+    assert_eq!(sheep.color(), DyeColor::Pink);
+    assert!(!sheep.is_sheared());
+}

--- a/steel-core/src/entity/entities/objects/display_ui/block_display.rs
+++ b/steel-core/src/entity/entities/objects/display_ui/block_display.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 
 use crate::entity::{Entity, EntityBase, EntityBaseLoad, EntitySyncedData};
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 /// A block display entity that renders a block state at its position.
 ///
@@ -119,7 +120,7 @@ impl Entity for BlockDisplayEntity {
 
     fn load_additional(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
         // Load block state ID
-        if let Some(state_id) = nbt.int("block_state") {
+        if let Some(state_id) = nbt.get_i32("block_state") {
             self.entity_data
                 .lock()
                 .block_state

--- a/steel-core/src/entity/entities/objects/display_ui/item_frame.rs
+++ b/steel-core/src/entity/entities/objects/display_ui/item_frame.rs
@@ -18,6 +18,7 @@ use crate::entity::{
     Entity, EntityBase, EntityBaseLoad, EntityBaseState, EntitySyncedData, ItemFrame,
 };
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 /// Item frame state needed by end-city structure markers.
 ///
@@ -283,7 +284,7 @@ impl Entity for ItemFrameEntity {
             self.set_item_with_update(item, false);
         }
 
-        if let Some(item_rotation) = nbt.byte("ItemRotation") {
+        if let Some(item_rotation) = nbt.get_i8("ItemRotation") {
             self.entity_data
                 .lock()
                 .rotation
@@ -291,9 +292,8 @@ impl Entity for ItemFrameEntity {
         }
 
         let facing = nbt
-            .byte("Facing")
-            .and_then(|value| direction_from_3d_data_value(i32::from(value)))
-            .or_else(|| nbt.int("Facing").and_then(direction_from_3d_data_value));
+            .get_i8("Facing")
+            .and_then(|value| direction_from_3d_data_value(i32::from(value)));
         if let Some(direction) = facing {
             self.set_direction(direction);
         }

--- a/steel-core/src/entity/entities/objects/explosives/end_crystal.rs
+++ b/steel-core/src/entity/entities/objects/explosives/end_crystal.rs
@@ -13,6 +13,7 @@ use steel_utils::{DowncastType, DowncastTypeKey};
 
 use crate::entity::{Entity, EntityBase, EntityBaseLoad, EntitySyncedData};
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 /// End Crystal entity state needed by worldgen and persistence.
 ///
@@ -139,8 +140,8 @@ impl Entity for EndCrystalEntity {
             self.set_beam_target(Some(BlockPos::new(target[0], target[1], target[2])));
         }
 
-        if let Some(show_bottom) = nbt.byte("ShowBottom") {
-            self.set_show_bottom(show_bottom != 0);
+        if let Some(show_bottom) = nbt.get_bool("ShowBottom") {
+            self.set_show_bottom(show_bottom);
         }
     }
 }

--- a/steel-core/src/entity/entities/objects/items/experience_orb.rs
+++ b/steel-core/src/entity/entities/objects/items/experience_orb.rs
@@ -24,6 +24,7 @@ use crate::fluid::get_fluid_state;
 use crate::physics::{MoverType, WorldCollisionProvider};
 use crate::player::Player;
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 const LIFETIME: i32 = 6000;
 const ENTITY_SCAN_PERIOD: i32 = 20;
@@ -513,16 +514,16 @@ impl Entity for ExperienceOrbEntity {
 
     fn load_additional(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
         let mut state = self.state.lock();
-        state.health = i32::from(nbt.short("Health").unwrap_or(DEFAULT_HEALTH as i16));
-        state.age = i32::from(nbt.short("Age").unwrap_or(0));
-        if let Some(count) = nbt.int("Count")
+        state.health = i32::from(nbt.get_i16_or("Health", DEFAULT_HEALTH as i16));
+        state.age = i32::from(nbt.get_i16_or("Age", 0));
+        if let Some(count) = nbt.get_i32("Count")
             && count > 0
         {
             state.count = count;
         }
         drop(state);
 
-        self.set_value(i32::from(nbt.short("Value").unwrap_or(0)));
+        self.set_value(i32::from(nbt.get_i16_or("Value", 0)));
     }
 }
 

--- a/steel-core/src/entity/entities/objects/items/falling_block.rs
+++ b/steel-core/src/entity/entities/objects/items/falling_block.rs
@@ -34,6 +34,7 @@ use crate::entity::{
 use crate::fluid::fluid_state_to_block;
 use crate::physics::MoverType;
 use crate::world::{ClipBlockShape, ClipFluid, World};
+use steel_utils::nbt::NbtValueInput as _;
 
 const DEFAULT_FALL_DAMAGE_PER_DISTANCE: f32 = 0.0;
 const DEFAULT_MAX_FALL_DAMAGE: i32 = 40;
@@ -539,18 +540,17 @@ impl Entity for FallingBlockEntity {
             .unwrap_or_else(|| vanilla_blocks::SAND.default_state());
         let mut state = self.state.lock();
         state.block_state = block_state;
-        state.time = nbt.int("Time").unwrap_or(0);
-        state.hurt_entities = nbt.byte("HurtEntities").map_or_else(
-            || block_state.get_block().has_tag(&BlockTag::ANVIL),
-            |value| value != 0,
+        state.time = nbt.get_i32_or("Time", 0);
+        state.hurt_entities = nbt.get_bool_or(
+            "HurtEntities",
+            block_state.get_block().has_tag(&BlockTag::ANVIL),
         );
-        state.fall_damage_per_distance = nbt
-            .float("FallHurtAmount")
-            .unwrap_or(DEFAULT_FALL_DAMAGE_PER_DISTANCE);
-        state.fall_damage_max = nbt.int("FallHurtMax").unwrap_or(DEFAULT_MAX_FALL_DAMAGE);
-        state.drop_item = nbt.byte("DropItem").is_none_or(|value| value != 0);
+        state.fall_damage_per_distance =
+            nbt.get_f32_or("FallHurtAmount", DEFAULT_FALL_DAMAGE_PER_DISTANCE);
+        state.fall_damage_max = nbt.get_i32_or("FallHurtMax", DEFAULT_MAX_FALL_DAMAGE);
+        state.drop_item = nbt.get_bool_or("DropItem", true);
         state.block_data = nbt.compound("TileEntityData").map(|data| data.to_owned());
-        state.cancel_drop = nbt.byte("CancelDrop").is_some_and(|value| value != 0);
+        state.cancel_drop = nbt.get_bool_or("CancelDrop", false);
     }
 }
 

--- a/steel-core/src/entity/entities/objects/items/item_entity.rs
+++ b/steel-core/src/entity/entities/objects/items/item_entity.rs
@@ -35,6 +35,7 @@ use steel_registry::blocks::block_state_ext::BlockStateExt;
 use steel_registry::stat::vanilla_stat_types;
 use steel_registry::vanilla_item_tags::ItemTag;
 use steel_utils::BlockPos;
+use steel_utils::nbt::NbtValueInput as _;
 
 /// Maximum age in ticks before despawn (5 minutes = 6000 ticks).
 const LIFETIME: i32 = 6000;
@@ -742,13 +743,13 @@ impl Entity for ItemEntity {
     fn load_additional(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
         // Match vanilla's ItemEntity.readAdditionalSaveData
         let mut state = self.item_state.lock();
-        if let Some(health) = nbt.short("Health") {
+        if let Some(health) = nbt.get_i16("Health") {
             state.health = i32::from(health);
         }
-        if let Some(age) = nbt.short("Age") {
+        if let Some(age) = nbt.get_i16("Age") {
             state.age = i32::from(age);
         }
-        if let Some(pickup_delay) = nbt.short("PickupDelay") {
+        if let Some(pickup_delay) = nbt.get_i16("PickupDelay") {
             state.pickup_delay = i32::from(pickup_delay);
         }
 

--- a/steel-core/src/entity/entities/objects/projectiles/firework_rocket.rs
+++ b/steel-core/src/entity/entities/objects/projectiles/firework_rocket.rs
@@ -31,6 +31,7 @@ use crate::entity::{
 use crate::physics::MoverType;
 use crate::world::game_event::GameEventContext;
 use crate::world::{ClipBlockShape, ClipFluid, ClipHitResult, World};
+use steel_utils::nbt::NbtValueInput as _;
 
 const INITIAL_VERTICAL_VELOCITY: f64 = 0.05;
 const INITIAL_HORIZONTAL_DEVIATION: f64 = 0.002_297;
@@ -425,15 +426,15 @@ impl Entity for FireworkRocketEntity {
         self.load_projectile(nbt);
         {
             let mut state = self.state.lock();
-            state.life = nbt.int("Life").unwrap_or(0);
-            state.lifetime = nbt.int("LifeTime").unwrap_or(0);
+            state.life = nbt.get_i32_or("Life", 0);
+            state.lifetime = nbt.get_i32_or("LifeTime", 0);
         }
         let item = nbt
             .compound("FireworksItem")
             .and_then(|item| ItemStack::from_borrowed_compound(&item))
             .unwrap_or_else(|| ItemStack::new(&vanilla_items::FIREWORK_ROCKET));
         self.set_item(item);
-        self.set_shot_at_angle(nbt.byte("ShotAtAngle").is_some_and(|value| value != 0));
+        self.set_shot_at_angle(nbt.get_bool_or("ShotAtAngle", false));
     }
 }
 

--- a/steel-core/src/entity/entities/objects/technical/interaction.rs
+++ b/steel-core/src/entity/entities/objects/technical/interaction.rs
@@ -15,6 +15,7 @@ use steel_registry::entity_data::EntityPose;
 use steel_registry::entity_type::{EntityDimensions, EntityTypeRef};
 use steel_registry::vanilla_entity_data::InteractionEntityData;
 use steel_utils::locks::SyncMutex;
+use steel_utils::nbt::NbtValueInput as _;
 use steel_utils::types::InteractionHand;
 use steel_utils::{DowncastType, DowncastTypeKey, UuidExt, WorldAabb};
 use uuid::Uuid;
@@ -236,15 +237,11 @@ impl Entity for InteractionEntity {
         let dimensions_changed = {
             let mut guard = self.entity_data.lock();
 
-            guard
-                .width
-                .set(nbt.float(TAG_WIDTH).unwrap_or(DEFAULT_WIDTH));
-            guard
-                .height
-                .set(nbt.float(TAG_HEIGHT).unwrap_or(DEFAULT_HEIGHT));
+            guard.width.set(nbt.get_f32_or(TAG_WIDTH, DEFAULT_WIDTH));
+            guard.height.set(nbt.get_f32_or(TAG_HEIGHT, DEFAULT_HEIGHT));
             guard
                 .response
-                .set(nbt.byte(TAG_RESPONSE).map_or(DEFAULT_RESPONSE, |b| b != 0));
+                .set(nbt.get_bool_or(TAG_RESPONSE, DEFAULT_RESPONSE));
 
             guard.width.is_dirty() || guard.height.is_dirty()
         };
@@ -294,7 +291,7 @@ impl FromNbtTag for PlayerAction {
         let compound = tag.compound()?;
         Some(Self {
             player: Uuid::from_int_array(&compound.int_array(TAG_PLAYER)?)?,
-            timestamp: compound.long(TAG_TIMESTAMP)?,
+            timestamp: compound.get_i64(TAG_TIMESTAMP)?,
         })
     }
 }
@@ -370,14 +367,14 @@ mod tests {
     use crate::entity::Entity;
     use crate::entity::entities::InteractionEntity;
     use crate::entity::entities::objects::technical::interaction::{
-        DEFAULT_HEIGHT, DEFAULT_WIDTH, PlayerAction, TAG_HEIGHT, TAG_WIDTH,
+        DEFAULT_HEIGHT, DEFAULT_WIDTH, PlayerAction, TAG_HEIGHT, TAG_RESPONSE, TAG_WIDTH,
     };
     use crate::test_support::{TestPlayerBuilder, fresh_test_world};
     use glam::DVec3;
     use simdnbt::borrow::read_compound;
     use simdnbt::owned::NbtCompound;
     use std::io::Cursor;
-    use std::sync::Arc;
+    use std::sync::{Arc, Weak};
     use steel_registry::vanilla_entities;
     use steel_utils::types::InteractionHand;
 
@@ -517,5 +514,33 @@ mod tests {
             .unwrap_or_else(|error| panic!("test nbt should reborrow: {error}"));
         interaction.load_additional((&borrowed).into());
         check_dimensions_and_bounding_box(2.0, DEFAULT_HEIGHT);
+    }
+
+    #[test]
+    fn loads_dimensions_and_response_from_any_numeric_tag() {
+        let interaction = InteractionEntity::new(
+            &vanilla_entities::INTERACTION,
+            0,
+            TEST_POSITION,
+            Weak::new(),
+        );
+        interaction.with_entity_data(|data| data.set_response(true));
+
+        let mut compound = NbtCompound::new();
+        compound.insert(TAG_WIDTH, 2_i16);
+        compound.insert(TAG_HEIGHT, 3_f64);
+        compound.insert(TAG_RESPONSE, 0.7_f64);
+        let mut bytes = Vec::new();
+        compound.write(&mut bytes);
+        let borrowed = read_compound(&mut Cursor::new(&bytes))
+            .unwrap_or_else(|error| panic!("test nbt should reborrow: {error}"));
+
+        interaction.load_additional((&borrowed).into());
+
+        interaction.with_entity_data(|data| {
+            assert_eq!(data.width(), 2.0);
+            assert_eq!(data.height(), 3.0);
+            assert!(!data.response());
+        });
     }
 }

--- a/steel-core/src/entity/entities/objects/vehicles/chest_minecart.rs
+++ b/steel-core/src/entity/entities/objects/vehicles/chest_minecart.rs
@@ -19,6 +19,7 @@ use crate::entity::{
 };
 use crate::portal::portal_shape::PortalShape;
 use crate::world::World;
+use steel_utils::nbt::NbtValueInput as _;
 
 /// Chest minecart entity state used by mineshaft generation.
 ///
@@ -139,11 +140,11 @@ impl Entity for ChestMinecartEntity {
             .string("LootTable")
             .and_then(|value| Identifier::from_str(&value.to_string()).ok());
         let mut state = self.state.lock();
-        if let Some(first_tick) = nbt.byte("HasTicked") {
-            state.first_tick = first_tick != 0;
+        if let Some(first_tick) = nbt.get_bool("HasTicked") {
+            state.first_tick = first_tick;
         }
         state.loot_table = loot_table;
-        state.loot_table_seed = nbt.long("LootTableSeed").unwrap_or(0);
+        state.loot_table_seed = nbt.get_i64_or("LootTableSeed", 0);
     }
 }
 

--- a/steel-core/src/entity/mob/mod.rs
+++ b/steel-core/src/entity/mob/mod.rs
@@ -49,6 +49,7 @@ use crate::inventory::equipment::EquipmentSlot;
 use crate::player::Player;
 use crate::world::game_event::GameEventContext;
 use crate::world::{LevelReader, World};
+use steel_utils::nbt::NbtValueInput as _;
 
 const MOB_FLAG_NO_AI: i8 = 1;
 const MOB_FLAG_LEFT_HANDED: i8 = 2;
@@ -86,7 +87,7 @@ impl DropChances {
     }
 
     fn set_equipment_chance(&mut self, slot: EquipmentSlot, chance: f32) -> bool {
-        if chance < 0.0 {
+        if !chance.is_finite() || chance < 0.0 {
             return false;
         }
 
@@ -122,7 +123,7 @@ impl DropChances {
 
         let mut loaded = Self::DEFAULT;
         for slot in EquipmentSlot::ALL {
-            let Some(chance) = drop_chances.float(slot.name()) else {
+            let Some(chance) = drop_chances.get_f32(slot.name()) else {
                 continue;
             };
             if !loaded.set_equipment_chance(slot, chance) {
@@ -661,13 +662,12 @@ pub trait Mob: LivingEntity + Leashable {
     }
 
     fn load_mob(&self, nbt: BorrowedNbtCompoundView<'_, '_>) {
-        self.set_can_pick_up_loot(nbt.byte("CanPickUpLoot").is_some_and(|value| value != 0));
-        *self.mob_base().persistence_required().lock() = nbt
-            .byte("PersistenceRequired")
-            .is_some_and(|value| value != 0);
+        self.set_can_pick_up_loot(nbt.get_bool_or("CanPickUpLoot", false));
+        *self.mob_base().persistence_required().lock() =
+            nbt.get_bool_or("PersistenceRequired", false);
         *self.mob_base().drop_chances().lock() = DropChances::load(nbt);
         *self.mob_base().leash_data().lock() = LeashData::load(nbt);
-        let home_radius = nbt.int("home_radius").unwrap_or(-1);
+        let home_radius = nbt.get_i32_or("home_radius", -1);
         if home_radius >= 0 {
             let home_position = nbt
                 .int_array("home_pos")
@@ -680,14 +680,13 @@ pub trait Mob: LivingEntity + Leashable {
             self.clear_home();
         }
 
-        self.set_left_handed(nbt.byte("LeftHanded").is_some_and(|value| value != 0));
+        self.set_left_handed(nbt.get_bool_or("LeftHanded", false));
         let death_loot_table = nbt
             .string("DeathLootTable")
             .and_then(|loot_table| loot_table.to_str().as_ref().parse().ok());
         *self.mob_base().death_loot_table().lock() = death_loot_table;
-        *self.mob_base().death_loot_table_seed().lock() =
-            nbt.long("DeathLootTableSeed").unwrap_or(0);
-        self.set_no_ai(nbt.byte("NoAI").is_some_and(|value| value != 0));
+        *self.mob_base().death_loot_table_seed().lock() = nbt.get_i64_or("DeathLootTableSeed", 0);
+        self.set_no_ai(nbt.get_bool_or("NoAI", false));
     }
 
     fn set_death_loot_table(&self, loot_table: Option<Identifier>) {

--- a/steel-core/src/entity/mob/tests.rs
+++ b/steel-core/src/entity/mob/tests.rs
@@ -1,6 +1,9 @@
+use std::io::Cursor;
 use std::sync::{Arc, Weak};
 
 use glam::DVec3;
+use simdnbt::borrow::read_compound as read_borrowed_compound;
+use simdnbt::owned::{NbtCompound, NbtTag};
 use steel_registry::entity_type::EntityTypeRef;
 use steel_registry::item_stack::ItemStack;
 use steel_registry::vanilla_entities;
@@ -12,7 +15,8 @@ use steel_utils::locks::SyncMutex;
 use steel_utils::{BlockPos, BlockStateId};
 
 use super::{
-    can_attempt_equipment_drop, find_ground_path_target_surface, path_end_node_can_reach_target,
+    DEFAULT_EQUIPMENT_DROP_CHANCE, DropChances, can_attempt_equipment_drop,
+    find_ground_path_target_surface, path_end_node_can_reach_target,
 };
 use crate::behavior::init_behaviors;
 use crate::entity::ai::control::{DEFAULT_LOOK_X_MAX_ROT_ANGLE, DEFAULT_LOOK_Y_MAX_ROT_SPEED};
@@ -25,6 +29,7 @@ use crate::entity::mob::{Mob, MobBase};
 use crate::entity::{
     Entity, EntityBase, LivingEntity, LivingEntityBase, PathfinderMob, SharedEntity,
 };
+use crate::inventory::equipment::EquipmentSlot;
 use crate::test_support::test_world;
 use crate::world::{LevelReader, World};
 
@@ -34,6 +39,30 @@ fn equipment_drop_attempt_gate_matches_vanilla_conditions() {
     assert!(!can_attempt_equipment_drop(0.085, false, false));
     assert!(can_attempt_equipment_drop(0.085, false, true));
     assert!(can_attempt_equipment_drop(2.0, true, false));
+}
+
+#[test]
+fn non_finite_loaded_drop_chance_falls_back_to_vanilla_defaults() {
+    let mut drop_chances = NbtCompound::new();
+    drop_chances.insert(EquipmentSlot::Head.name(), f64::MAX);
+    drop_chances.insert(EquipmentSlot::Saddle.name(), 2_i16);
+    let mut nbt = NbtCompound::new();
+    nbt.insert("drop_chances", NbtTag::Compound(drop_chances));
+    let mut bytes = Vec::new();
+    nbt.write(&mut bytes);
+    let borrowed = read_borrowed_compound(&mut Cursor::new(bytes.as_slice()))
+        .unwrap_or_else(|error| panic!("drop chance test NBT should reborrow: {error}"));
+
+    let loaded = DropChances::load((&borrowed).into());
+
+    assert_eq!(
+        loaded.by_equipment(EquipmentSlot::Head),
+        DEFAULT_EQUIPMENT_DROP_CHANCE
+    );
+    assert_eq!(
+        loaded.by_equipment(EquipmentSlot::Saddle),
+        DEFAULT_EQUIPMENT_DROP_CHANCE
+    );
 }
 
 struct SurfaceLevel {

--- a/steel-core/src/entity/projectile/mod.rs
+++ b/steel-core/src/entity/projectile/mod.rs
@@ -35,6 +35,7 @@ use crate::entity::{Entity, LivingEntity, SharedEntity};
 use crate::player::Player;
 use crate::world::game_event::GameEventContext;
 use crate::world::{ClipBlockShape, ClipFluid, ClipHitResult, World};
+use steel_utils::nbt::NbtValueInput as _;
 
 pub use throwable::ThrowableProjectile;
 pub use throwable_item::ThrowableItemProjectile;
@@ -644,8 +645,8 @@ pub trait Projectile: Entity + ProjectileEventSource {
         {
             state.owner = Some(uuid);
         }
-        state.left_owner = nbt.byte("LeftOwner").is_some_and(|value| value != 0);
-        state.has_been_shot = nbt.byte("HasBeenShot").is_some_and(|value| value != 0);
+        state.left_owner = nbt.get_bool_or("LeftOwner", false);
+        state.has_been_shot = nbt.get_bool_or("HasBeenShot", false);
     }
 }
 

--- a/steel-utils/src/nbt/mod.rs
+++ b/steel-utils/src/nbt/mod.rs
@@ -3,6 +3,7 @@
 mod codec;
 mod path;
 mod snbt;
+mod value_input;
 
 use rustc_hash::FxHashSet;
 use simdnbt::owned::{NbtCompound, NbtList, NbtTag};
@@ -16,6 +17,7 @@ pub use snbt::{
     SnbtError, SnbtErrorKind, SnbtNumberType, parse_snbt, parse_snbt_argument, parse_snbt_compound,
     parse_snbt_compound_argument, to_canonical_snbt,
 };
+pub use value_input::{NbtNumber, NbtNumericTag, NbtValueInput};
 
 /// Mirrors vanilla `NbtUtils.compareNbt`.
 #[must_use]

--- a/steel-utils/src/nbt/value_input.rs
+++ b/steel-utils/src/nbt/value_input.rs
@@ -1,0 +1,402 @@
+//! Lenient numeric field access mirroring vanilla's `ValueInput`.
+//!
+//! Vanilla reads numeric save fields through `TagValueInput.getNumericTag`,
+//! which accepts *any* numeric tag (byte, short, int, long, float, double) and
+//! converts it with the `NumericTag.byteValue()`/`intValue()`/... conversions.
+//! A `Color: 3s` short is therefore read as byte `3`, and `Sheared: 0.7d` as
+//! byte `0` (false). The raw `simdnbt` accessors only accept the exact tag type,
+//! so entity and block entity loaders should go through [`NbtValueInput`].
+
+use simdnbt::{
+    borrow::{NbtCompound as BorrowedNbtCompound, NbtTag as BorrowedNbtTag},
+    owned::{NbtCompound as OwnedNbtCompound, NbtTag as OwnedNbtTag},
+};
+
+/// Conversions performed by vanilla's `NumericTag` implementations.
+///
+/// Integer tags truncate to narrower integers (two's complement wraparound)
+/// and cast to floats. Float and double tags floor before converting to
+/// `byte`/`short`/`int`; `FloatTag.longValue()` truncates while
+/// `DoubleTag.longValue()` floors, exactly like vanilla.
+pub trait NbtNumericTag {
+    /// `NumericTag.byteValue() != 0`, which is how vanilla decodes booleans.
+    fn numeric_bool(&self) -> Option<bool> {
+        self.numeric_i8().map(|value| value != 0)
+    }
+
+    /// Mirrors `NumericTag.byteValue()`.
+    fn numeric_i8(&self) -> Option<i8>;
+
+    /// Mirrors `NumericTag.shortValue()`.
+    fn numeric_i16(&self) -> Option<i16>;
+
+    /// Mirrors `NumericTag.intValue()`.
+    fn numeric_i32(&self) -> Option<i32>;
+
+    /// Mirrors `NumericTag.longValue()`.
+    fn numeric_i64(&self) -> Option<i64>;
+
+    /// Mirrors `NumericTag.floatValue()`.
+    fn numeric_f32(&self) -> Option<f32>;
+
+    /// Mirrors `NumericTag.doubleValue()`.
+    fn numeric_f64(&self) -> Option<f64>;
+}
+
+/// A numeric NBT tag lifted out of either the owned or borrowed representation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NbtNumber {
+    /// `TAG_Byte`.
+    Byte(i8),
+    /// `TAG_Short`.
+    Short(i16),
+    /// `TAG_Int`.
+    Int(i32),
+    /// `TAG_Long`.
+    Long(i64),
+    /// `TAG_Float`.
+    Float(f32),
+    /// `TAG_Double`.
+    Double(f64),
+}
+
+impl NbtNumber {
+    /// Extracts the numeric payload of an owned tag, if it has one.
+    #[must_use]
+    pub const fn from_owned(tag: &OwnedNbtTag) -> Option<Self> {
+        match tag {
+            OwnedNbtTag::Byte(value) => Some(Self::Byte(*value)),
+            OwnedNbtTag::Short(value) => Some(Self::Short(*value)),
+            OwnedNbtTag::Int(value) => Some(Self::Int(*value)),
+            OwnedNbtTag::Long(value) => Some(Self::Long(*value)),
+            OwnedNbtTag::Float(value) => Some(Self::Float(*value)),
+            OwnedNbtTag::Double(value) => Some(Self::Double(*value)),
+            _ => None,
+        }
+    }
+
+    /// Extracts the numeric payload of a borrowed tag, if it has one.
+    #[must_use]
+    pub fn from_borrowed(tag: &BorrowedNbtTag<'_, '_>) -> Option<Self> {
+        tag.byte()
+            .map(Self::Byte)
+            .or_else(|| tag.short().map(Self::Short))
+            .or_else(|| tag.int().map(Self::Int))
+            .or_else(|| tag.long().map(Self::Long))
+            .or_else(|| tag.float().map(Self::Float))
+            .or_else(|| tag.double().map(Self::Double))
+    }
+}
+
+impl NbtNumericTag for NbtNumber {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "vanilla NumericTag conversions wrap/saturate"
+    )]
+    fn numeric_i8(&self) -> Option<i8> {
+        Some(match *self {
+            Self::Byte(value) => value,
+            Self::Short(value) => value as i8,
+            Self::Int(value) => value as i8,
+            Self::Long(value) => value as i8,
+            Self::Float(value) => (value.floor() as i32) as i8,
+            Self::Double(value) => (value.floor() as i32) as i8,
+        })
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "vanilla NumericTag conversions wrap/saturate"
+    )]
+    fn numeric_i16(&self) -> Option<i16> {
+        Some(match *self {
+            Self::Byte(value) => i16::from(value),
+            Self::Short(value) => value,
+            Self::Int(value) => value as i16,
+            Self::Long(value) => value as i16,
+            Self::Float(value) => (value.floor() as i32) as i16,
+            Self::Double(value) => (value.floor() as i32) as i16,
+        })
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "vanilla NumericTag conversions wrap/saturate"
+    )]
+    fn numeric_i32(&self) -> Option<i32> {
+        Some(match *self {
+            Self::Byte(value) => i32::from(value),
+            Self::Short(value) => i32::from(value),
+            Self::Int(value) => value,
+            Self::Long(value) => value as i32,
+            Self::Float(value) => value.floor() as i32,
+            Self::Double(value) => value.floor() as i32,
+        })
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "vanilla NumericTag conversions wrap/saturate"
+    )]
+    fn numeric_i64(&self) -> Option<i64> {
+        Some(match *self {
+            Self::Byte(value) => i64::from(value),
+            Self::Short(value) => i64::from(value),
+            Self::Int(value) => i64::from(value),
+            Self::Long(value) => value,
+            // `FloatTag.longValue()` is a plain `(long)` cast (truncation) ...
+            Self::Float(value) => value as i64,
+            // ... while `DoubleTag.longValue()` floors first.
+            Self::Double(value) => value.floor() as i64,
+        })
+    }
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        reason = "vanilla NumericTag conversions lose precision"
+    )]
+    fn numeric_f32(&self) -> Option<f32> {
+        Some(match *self {
+            Self::Byte(value) => f32::from(value),
+            Self::Short(value) => f32::from(value),
+            Self::Int(value) => value as f32,
+            Self::Long(value) => value as f32,
+            Self::Float(value) => value,
+            Self::Double(value) => value as f32,
+        })
+    }
+
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "vanilla NumericTag conversions lose precision"
+    )]
+    fn numeric_f64(&self) -> Option<f64> {
+        Some(match *self {
+            Self::Byte(value) => f64::from(value),
+            Self::Short(value) => f64::from(value),
+            Self::Int(value) => f64::from(value),
+            Self::Long(value) => value as f64,
+            Self::Float(value) => f64::from(value),
+            Self::Double(value) => value,
+        })
+    }
+}
+
+macro_rules! forward_numeric_tag {
+    ($ty:ty, |$tag:ident| $lift:expr) => {
+        impl NbtNumericTag for $ty {
+            fn numeric_i8(&self) -> Option<i8> {
+                let $tag = self;
+                $lift.and_then(|number| number.numeric_i8())
+            }
+            fn numeric_i16(&self) -> Option<i16> {
+                let $tag = self;
+                $lift.and_then(|number| number.numeric_i16())
+            }
+            fn numeric_i32(&self) -> Option<i32> {
+                let $tag = self;
+                $lift.and_then(|number| number.numeric_i32())
+            }
+            fn numeric_i64(&self) -> Option<i64> {
+                let $tag = self;
+                $lift.and_then(|number| number.numeric_i64())
+            }
+            fn numeric_f32(&self) -> Option<f32> {
+                let $tag = self;
+                $lift.and_then(|number| number.numeric_f32())
+            }
+            fn numeric_f64(&self) -> Option<f64> {
+                let $tag = self;
+                $lift.and_then(|number| number.numeric_f64())
+            }
+        }
+    };
+}
+
+forward_numeric_tag!(OwnedNbtTag, |tag| NbtNumber::from_owned(tag));
+forward_numeric_tag!(BorrowedNbtTag<'_, '_>, |tag| NbtNumber::from_borrowed(tag));
+
+/// Field accessors mirroring vanilla's `ValueInput.get*Or` family.
+///
+/// Every method accepts any numeric tag type and converts it like
+/// [`NbtNumericTag`]; non-numeric or missing tags yield `None` / the default.
+pub trait NbtValueInput {
+    /// Looks up `name` and returns its numeric payload, if it is a numeric tag.
+    fn get_number(&self, name: &str) -> Option<NbtNumber>;
+
+    /// Mirrors `ValueInput.getBoolean`.
+    fn get_bool(&self, name: &str) -> Option<bool> {
+        self.get_number(name)
+            .and_then(|number| number.numeric_bool())
+    }
+
+    /// Mirrors `ValueInput.getBooleanOr`.
+    fn get_bool_or(&self, name: &str, default: bool) -> bool {
+        self.get_bool(name).unwrap_or(default)
+    }
+
+    /// Mirrors `ValueInput.getByte`.
+    fn get_i8(&self, name: &str) -> Option<i8> {
+        self.get_number(name).and_then(|number| number.numeric_i8())
+    }
+
+    /// Mirrors `ValueInput.getByteOr`.
+    fn get_i8_or(&self, name: &str, default: i8) -> i8 {
+        self.get_i8(name).unwrap_or(default)
+    }
+
+    /// Mirrors `ValueInput.getShort`.
+    fn get_i16(&self, name: &str) -> Option<i16> {
+        self.get_number(name)
+            .and_then(|number| number.numeric_i16())
+    }
+
+    /// Mirrors `ValueInput.getShortOr`.
+    fn get_i16_or(&self, name: &str, default: i16) -> i16 {
+        self.get_i16(name).unwrap_or(default)
+    }
+
+    /// Mirrors `ValueInput.getInt`.
+    fn get_i32(&self, name: &str) -> Option<i32> {
+        self.get_number(name)
+            .and_then(|number| number.numeric_i32())
+    }
+
+    /// Mirrors `ValueInput.getIntOr`.
+    fn get_i32_or(&self, name: &str, default: i32) -> i32 {
+        self.get_i32(name).unwrap_or(default)
+    }
+
+    /// Mirrors `ValueInput.getLong`.
+    fn get_i64(&self, name: &str) -> Option<i64> {
+        self.get_number(name)
+            .and_then(|number| number.numeric_i64())
+    }
+
+    /// Mirrors `ValueInput.getLongOr`.
+    fn get_i64_or(&self, name: &str, default: i64) -> i64 {
+        self.get_i64(name).unwrap_or(default)
+    }
+
+    /// Mirrors `ValueInput.getFloat`.
+    fn get_f32(&self, name: &str) -> Option<f32> {
+        self.get_number(name)
+            .and_then(|number| number.numeric_f32())
+    }
+
+    /// Mirrors `ValueInput.getFloatOr`.
+    fn get_f32_or(&self, name: &str, default: f32) -> f32 {
+        self.get_f32(name).unwrap_or(default)
+    }
+
+    /// Mirrors `ValueInput.getDouble`.
+    fn get_f64(&self, name: &str) -> Option<f64> {
+        self.get_number(name)
+            .and_then(|number| number.numeric_f64())
+    }
+
+    /// Mirrors `ValueInput.getDoubleOr`.
+    fn get_f64_or(&self, name: &str, default: f64) -> f64 {
+        self.get_f64(name).unwrap_or(default)
+    }
+}
+
+impl NbtValueInput for OwnedNbtCompound {
+    fn get_number(&self, name: &str) -> Option<NbtNumber> {
+        self.get(name).and_then(NbtNumber::from_owned)
+    }
+}
+
+impl NbtValueInput for BorrowedNbtCompound<'_, '_> {
+    fn get_number(&self, name: &str) -> Option<NbtNumber> {
+        self.get(name)
+            .and_then(|tag| NbtNumber::from_borrowed(&tag))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use simdnbt::{
+        borrow::read as read_borrowed,
+        owned::{BaseNbt, NbtCompound, NbtTag},
+    };
+
+    use super::{NbtNumericTag, NbtValueInput};
+
+    fn compound() -> NbtCompound {
+        let mut nbt = NbtCompound::new();
+        nbt.insert("byte", 3_i8);
+        nbt.insert("short", 300_i16);
+        nbt.insert("int", 70_000_i32);
+        nbt.insert("long", i64::from(i32::MAX) + 1);
+        nbt.insert("float", 0.7_f32);
+        nbt.insert("double", -0.5_f64);
+        nbt.insert("string", "1");
+        nbt
+    }
+
+    #[test]
+    fn any_numeric_tag_is_accepted() {
+        let nbt = compound();
+        assert_eq!(nbt.get_i8("short"), Some(300_i16 as i8));
+        assert_eq!(nbt.get_i16("int"), Some(70_000_i32 as i16));
+        assert_eq!(nbt.get_i32("long"), Some(i32::MIN));
+        assert_eq!(nbt.get_i64("byte"), Some(3));
+        assert_eq!(nbt.get_f32("double"), Some(-0.5));
+        assert_eq!(nbt.get_f64("int"), Some(70_000.0));
+    }
+
+    #[test]
+    fn booleans_use_byte_value() {
+        let nbt = compound();
+        assert_eq!(nbt.get_bool("byte"), Some(true));
+        assert_eq!(nbt.get_bool("short"), Some(true));
+        // 0.7 floors to 0.
+        assert_eq!(nbt.get_bool("float"), Some(false));
+        // -0.5 floors to -1.
+        assert_eq!(nbt.get_bool("double"), Some(true));
+        // 256 truncates to 0 as a byte.
+        assert_eq!(NbtTag::Int(256).numeric_bool(), Some(false));
+        assert!(nbt.get_bool_or("missing", true));
+    }
+
+    #[test]
+    fn floating_conversions_match_vanilla() {
+        assert_eq!(NbtTag::Double(-0.5).numeric_i32(), Some(-1));
+        assert_eq!(NbtTag::Float(-0.5).numeric_i32(), Some(-1));
+        assert_eq!(NbtTag::Double(-0.5).numeric_i64(), Some(-1));
+        // FloatTag.longValue() truncates instead of flooring.
+        assert_eq!(NbtTag::Float(-0.5).numeric_i64(), Some(0));
+        assert_eq!(NbtTag::Double(1e10).numeric_i32(), Some(i32::MAX));
+        assert_eq!(NbtTag::Double(f64::NAN).numeric_i32(), Some(0));
+    }
+
+    #[test]
+    fn non_numeric_and_missing_tags_fall_back() {
+        let nbt = compound();
+        assert_eq!(nbt.get_i32("string"), None);
+        assert_eq!(nbt.get_i32("missing"), None);
+        assert_eq!(nbt.get_i32_or("string", 7), 7);
+        assert_eq!(nbt.get_f64_or("missing", 1.5), 1.5);
+    }
+
+    #[test]
+    fn borrowed_compounds_use_the_same_conversions() {
+        let nbt = BaseNbt::new("", compound());
+        let mut bytes = Vec::new();
+        nbt.write(&mut bytes);
+        let borrowed = read_borrowed(&mut Cursor::new(bytes.as_slice()))
+            .expect("owned test nbt should parse")
+            .unwrap();
+        let view = borrowed.as_compound();
+
+        assert_eq!(view.get_i8("short"), Some(300_i16 as i8));
+        assert_eq!(view.get_bool("float"), Some(false));
+        assert_eq!(view.get_i64("long"), Some(i64::from(i32::MAX) + 1));
+        assert_eq!(view.get_i32("string"), None);
+        assert_eq!(view.get_i16_or("missing", 9), 9);
+    }
+}


### PR DESCRIPTION
Fixes #559

## Summary
- Add shared lenient numeric NBT accessors matching vanilla `ValueInput` and `NumericTag` conversions for owned and borrowed compounds.
- Migrate entity and block-entity numeric load paths, including interaction entities, drop chances, chiseled bookshelves, and jukebox state.
- Preserve vanilla validation and fallback behavior for non-finite equipment drop chances.

## Testing
- `cargo fmt --all --check`
- `cargo test --verbose`
- `cargo clippy -r --all-targets --all-features`
- Focused numeric-tag, interaction-entity, jukebox, drop-chance, sheep, and server tests

`typos` was unavailable locally; CI runs it.