### PR TITLE
fix: /setblock failing after block_state parser change

### DIFF
--- a/steel-core/src/command/builtins/fill.rs
+++ b/steel-core/src/command/builtins/fill.rs
@@ -6,14 +6,14 @@ use steel_registry::{
     blocks::block_state_ext::BlockStateExt as _, vanilla_blocks,
     vanilla_game_rules::MAX_BLOCK_MODIFICATIONS,
 };
-use steel_utils::{BlockPos, BoundingBox, Identifier, translations, types::UpdateFlags};
+use steel_utils::{BlockPos, BoundingBox, Identifier, translations};
 use text_components::TextComponent;
 
 use super::super::{
     brigadier::{CommandNodeBuilder, CommandSyntaxError},
     execution::{
         BlockInput, BlockPredicate, CommandSource, SteelArgumentType, SteelCommandContext,
-        SteelCommandRuntime, argument, literal,
+        SteelCommandRuntime, argument, literal, placement_flags,
     },
     registration::CommandRegistration,
 };
@@ -175,11 +175,7 @@ fn fill_blocks(
                     continue;
                 };
 
-                let placed = input.place(world, pos, flags).map_err(|error| {
-                    CommandSyntaxError::dynamic(format!(
-                        "Failed to apply block entity NBT at {pos:?}: {error}"
-                    ))
-                })?;
+                let placed = input.place(world, pos, flags)?;
                 if !placed {
                     if affected {
                         count += 1;
@@ -229,16 +225,6 @@ const fn input_at<'input>(
     }
 }
 
-fn placement_flags(strict: bool) -> UpdateFlags {
-    let mut flags = UpdateFlags::UPDATE_CLIENTS | UpdateFlags::UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS;
-    if strict {
-        flags |= UpdateFlags::UPDATE_KNOWN_SHAPE
-            | UpdateFlags::UPDATE_SUPPRESS_DROPS
-            | UpdateFlags::UPDATE_SKIP_ON_PLACE;
-    }
-    flags
-}
-
 fn block_region_volume(region: BoundingBox) -> i64 {
     let x_span = i64::from(region.max_x()) - i64::from(region.min_x()) + 1;
     let y_span = i64::from(region.max_y()) - i64::from(region.min_y()) + 1;
@@ -259,7 +245,7 @@ fn area_too_large(limit: i32, area: i64) -> CommandSyntaxError {
 #[cfg(test)]
 mod tests {
     use steel_registry::{init_vanilla_registry, vanilla_game_rules};
-    use steel_utils::{ChunkPos, Downcast as _, WorldAabb};
+    use steel_utils::{ChunkPos, Downcast as _, WorldAabb, types::UpdateFlags};
 
     use super::super::create_dispatcher;
     use super::*;

--- a/steel-core/src/command/builtins/setblock.rs
+++ b/steel-core/src/command/builtins/setblock.rs
@@ -9,7 +9,6 @@ use super::super::{
     registration::CommandRegistration,
 };
 use super::execute::loaded_block_position;
-use crate::world::tick_scheduler::TickPriority;
 use steel_registry::blocks::block_state_ext::BlockStateExt;
 use steel_utils::Identifier;
 use steel_utils::translations::{COMMANDS_SETBLOCK_FAILED, COMMANDS_SETBLOCK_SUCCESS};
@@ -74,15 +73,6 @@ fn set_block(
 
     if !strict {
         level.update_neighbors_on_block_set(block_pos, old_state);
-        let placed_state = level.get_block_state(block_pos);
-        if placed_state.has_fluid() {
-            level.schedule_fluid_tick(
-                block_pos,
-                placed_state.get_fluid_state().fluid_id,
-                0,
-                TickPriority::ExtremelyHigh,
-            );
-        }
     }
 
     context.source().send_success(

--- a/steel-core/src/command/builtins/setblock.rs
+++ b/steel-core/src/command/builtins/setblock.rs
@@ -4,19 +4,15 @@ use super::super::{
     brigadier::{CommandNodeBuilder, CommandSyntaxError},
     execution::{
         CommandSource, SteelArgumentType, SteelCommandContext, SteelCommandRuntime, argument,
-        literal,
+        literal, placement_flags,
     },
     registration::CommandRegistration,
 };
-use crate::command::execution::BlockPredicate;
+use super::execute::loaded_block_position;
 use crate::world::tick_scheduler::TickPriority;
-use simdnbt::borrow::read_compound;
-use std::io::Cursor;
-use steel_registry::REGISTRY;
 use steel_registry::blocks::block_state_ext::BlockStateExt;
 use steel_utils::Identifier;
 use steel_utils::translations::{COMMANDS_SETBLOCK_FAILED, COMMANDS_SETBLOCK_SUCCESS};
-use steel_utils::types::UpdateFlags;
 use text_components::TextComponent;
 
 /// How the block should be placed
@@ -53,44 +49,10 @@ fn set_block(
     context: &SteelCommandContext<CommandSource>,
     mode: SetBlockMode,
 ) -> Result<i32, CommandSyntaxError> {
-    // Block pos
-    let coordinates = context.coordinates("pos")?;
-    let block_pos = coordinates.block_pos(context.source());
-
-    // Block predicate into block state
-    let block_predicate = context.block_predicate("block")?;
-
-    let (block_state, nbt) = match block_predicate {
-        BlockPredicate::Block {
-            block,
-            properties,
-            nbt,
-        } => {
-            // Adapt properties for the next function
-            let properties_vec: Vec<(&str, &str)> = properties
-                .iter()
-                .map(|(name, value)| (name.as_ref(), value.as_ref()))
-                .collect();
-
-            // Get the block state id
-            let Some(block_state_id) = REGISTRY
-                .blocks
-                .state_id_from_block_properties(block, &properties_vec)
-            else {
-                return Err(CommandSyntaxError::dynamic(
-                    "This Block is not registered or a property name/value is invalid.",
-                ));
-            };
-
-            (block_state_id, nbt)
-        }
-        BlockPredicate::Tag { .. } => unreachable!(),
-    };
-
-    // World the player is in
+    let block_pos = loaded_block_position(context, "pos")?;
+    let block = context.block_input("block")?;
     let level = context.source().world();
 
-    // Keep mode only places into air; fail if the target is occupied
     if matches!(mode, SetBlockMode::Keep) && !level.get_block_state(block_pos).is_air() {
         return Ok(set_block_failed(context.source()));
     }
@@ -98,50 +60,25 @@ fn set_block(
     let place_needed = if matches!(mode, SetBlockMode::Destroy) {
         level.destroy_block(block_pos, true);
 
-        !block_state.is_air() || !level.get_block_state(block_pos).is_air()
+        !block.state().is_air() || !level.get_block_state(block_pos).is_air()
     } else {
         true
     };
 
-    let update_bits = if matches!(mode, SetBlockMode::Strict) {
-        816
-    } else {
-        256
-    };
-
-    // Save the old state to update the neighbors later
+    let strict = matches!(mode, SetBlockMode::Strict);
     let old_state = level.get_block_state(block_pos);
 
-    // Place the block and update with the right flag
-    if place_needed
-        && !level.set_block(
-            block_pos,
-            block_state,
-            UpdateFlags::from_bits_truncate(2 | update_bits),
-        )
-    {
+    if place_needed && !block.place(level, block_pos, placement_flags(strict))? {
         return Ok(set_block_failed(context.source()));
     }
 
-    // Load the NBT data into the block entity if it exists
-    if let Some(block_entity) = level.get_block_entity(block_pos)
-        && let Some(nbt) = nbt
-    {
-        let mut bytes = Vec::new();
-        nbt.write(&mut bytes);
-        let borrowed = read_compound(&mut Cursor::new(bytes.as_slice())).map_err(|_| {
-            CommandSyntaxError::dynamic("Failed to transpose owned compound into borrowed ")
-        })?;
-        block_entity.load_additional(&borrowed);
-        block_entity.set_changed();
-    }
-
-    if !matches!(mode, SetBlockMode::Strict) {
-        level.update_neighbour_on_block_set(block_pos, old_state);
-        if block_state.has_fluid() {
+    if !strict {
+        level.update_neighbors_on_block_set(block_pos, old_state);
+        let placed_state = level.get_block_state(block_pos);
+        if placed_state.has_fluid() {
             level.schedule_fluid_tick(
                 block_pos,
-                block_state.get_fluid_state().fluid_id,
+                placed_state.get_fluid_state().fluid_id,
                 0,
                 TickPriority::ExtremelyHigh,
             );
@@ -165,6 +102,5 @@ fn set_block(
 fn set_block_failed(source: &CommandSource) -> i32 {
     source.send_failure(COMMANDS_SETBLOCK_FAILED.msg().component());
 
-    // No block placed or replaced
     0
 }

--- a/steel-core/src/command/execution/block.rs
+++ b/steel-core/src/command/execution/block.rs
@@ -42,7 +42,6 @@ impl BlockInput {
         }
     }
 
-    #[cfg(test)]
     pub(crate) const fn state(&self) -> BlockStateId {
         self.state
     }
@@ -58,7 +57,7 @@ impl BlockInput {
         world: &Arc<World>,
         pos: BlockPos,
         flags: UpdateFlags,
-    ) -> Result<bool, simdnbt::Error> {
+    ) -> Result<bool, CommandSyntaxError> {
         let mut state = if flags.contains(UpdateFlags::UPDATE_KNOWN_SHAPE) {
             self.state
         } else {
@@ -79,7 +78,13 @@ impl BlockInput {
             && let Some(block_entity) = world.get_block_entity(pos)
         {
             let before = block_entity.save_without_metadata();
-            block_entity.load_with_owned_components(nbt)?;
+            block_entity
+                .load_with_owned_components(nbt)
+                .map_err(|error| {
+                    CommandSyntaxError::dynamic(format!(
+                        "Failed to apply block entity NBT at {pos:?}: {error}"
+                    ))
+                })?;
             let after = block_entity.save_without_metadata();
             if !nbt_compounds_equal(&before, &after) {
                 affected = true;
@@ -89,6 +94,17 @@ impl BlockInput {
         }
         Ok(affected)
     }
+}
+
+/// Block-update flags for command placement, vanilla's `2 | (strict ? 816 : 256)`.
+pub(crate) fn placement_flags(strict: bool) -> UpdateFlags {
+    let mut flags = UpdateFlags::UPDATE_CLIENTS | UpdateFlags::UPDATE_SKIP_BLOCK_ENTITY_SIDEEFFECTS;
+    if strict {
+        flags |= UpdateFlags::UPDATE_KNOWN_SHAPE
+            | UpdateFlags::UPDATE_SUPPRESS_DROPS
+            | UpdateFlags::UPDATE_SKIP_ON_PLACE;
+    }
+    flags
 }
 
 /// A concrete block or block tag with optional state and block-entity constraints.

--- a/steel-core/src/command/execution/mod.rs
+++ b/steel-core/src/command/execution/mod.rs
@@ -21,7 +21,7 @@ mod world;
 pub(crate) use argument::SteelArgumentType;
 pub(crate) use argument::{SteelArgumentParser, SteelArgumentSuggestionContext};
 pub(crate) use biome::BiomeOrTag;
-pub(crate) use block::{BlockInput, BlockPredicate};
+pub(crate) use block::{BlockInput, BlockPredicate, placement_flags};
 pub(crate) use coordinates::Coordinates;
 pub(crate) use item_predicate::ItemPredicate;
 pub(crate) use permission::PermissionGroupName;

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -3278,3 +3278,68 @@ fn title_command_delivers_vanilla_packets_to_recorded_connections() {
         }
     });
 }
+
+#[test]
+fn setblock_command_places_blocks_and_keep_mode_skips_occupied_positions() {
+    use crate::block_entity::init_block_entities;
+    use steel_registry::blocks::block_state_ext::BlockStateExt as _;
+    use steel_registry::init_vanilla_registry;
+
+    init_vanilla_registry();
+    init_behaviors();
+    init_block_entities();
+    let world = fresh_test_world("setblock-command");
+    insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+    let storage_root = test_storage_root("setblock-command");
+    let runtime = Builder::new_current_thread().enable_all().build();
+    let Ok(runtime) = runtime else {
+        panic!("test runtime should initialize");
+    };
+    runtime.block_on(async {
+        let server = test_server(
+            Arc::clone(&world),
+            PermissionSubjectIndex::new(),
+            &storage_root,
+        )
+        .await;
+        let Ok(server) = server else {
+            panic!("test server should initialize");
+        };
+
+        let run = |command: &str| {
+            let source = CommandSource::new(CommandSender::Console, Arc::clone(&server));
+            let chain = {
+                let dispatcher = server.command_dispatcher.read();
+                let parse = dispatcher.parse(command, source.clone());
+                dispatcher.context_chain(parse)
+            };
+            let chain = match chain {
+                Ok(chain) => chain,
+                Err(error) => panic!("{command} should parse: {error}"),
+            };
+            let mut execution = CommandExecutionContext::for_source(&source);
+            execution.queue_initial_command(chain, source, CommandResultCallback::empty());
+            assert!(matches!(execution.run(), ExecutionStop::Completed));
+        };
+
+        let pos = BlockPos::new(8, 64, 8);
+        run("setblock 8 64 8 minecraft:stone");
+        assert_eq!(
+            world.get_block_state(pos).get_block(),
+            &vanilla_blocks::STONE,
+            "setblock must place the requested block"
+        );
+
+        run("setblock 8 64 8 minecraft:dirt keep");
+        assert_eq!(
+            world.get_block_state(pos).get_block(),
+            &vanilla_blocks::STONE,
+            "keep mode must not replace an occupied position"
+        );
+
+        drop(server);
+        if let Err(error) = fs::remove_dir_all(&storage_root).await {
+            panic!("test storage should be removed: {error}");
+        }
+    });
+}

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -2105,6 +2105,22 @@ fn decode_system_chat(packet: &EncodedPacket) -> TextComponent {
     component
 }
 
+/// Parses `command` for `source` and runs it to completion on `server`.
+fn run_command(server: &Server, source: CommandSource, command: &str) {
+    let chain = {
+        let dispatcher = server.command_dispatcher.read();
+        let parse = dispatcher.parse(command, source.clone());
+        dispatcher.context_chain(parse)
+    };
+    let chain = match chain {
+        Ok(chain) => chain,
+        Err(error) => panic!("{command} should parse: {error}"),
+    };
+    let mut execution = CommandExecutionContext::for_source(&source);
+    execution.queue_initial_command(chain, source, CommandResultCallback::empty());
+    assert!(matches!(execution.run(), ExecutionStop::Completed));
+}
+
 fn packet_id(packet: &EncodedPacket) -> i32 {
     let mut cursor = Cursor::new(packet.encoded_data.as_slice());
     assert!(
@@ -3127,20 +3143,11 @@ fn damage_command_records_by_entity_as_the_responsible_player() {
         attacker.set_client_loaded(true);
 
         let source = CommandSource::new(CommandSender::Console, Arc::clone(&server));
-        let command = "damage Victim 1 minecraft:player_attack by Attacker";
-        let chain = {
-            let dispatcher = server.command_dispatcher.read();
-            let parse = dispatcher.parse(command, source.clone());
-            dispatcher.context_chain(parse)
-        };
-        let chain = match chain {
-            Ok(chain) => chain,
-            Err(error) => panic!("damage command should parse: {error}"),
-        };
-
-        let mut execution = CommandExecutionContext::for_source(&source);
-        execution.queue_initial_command(chain, source, CommandResultCallback::empty());
-        assert!(matches!(execution.run(), ExecutionStop::Completed));
+        run_command(
+            &server,
+            source,
+            "damage Victim 1 minecraft:player_attack by Attacker",
+        );
 
         assert_eq!(
             target.last_hurt_by_player_uuid(),
@@ -3149,7 +3156,6 @@ fn damage_command_records_by_entity_as_the_responsible_player() {
         );
 
         drop((target, attacker));
-        drop(execution);
         drop(server);
         if let Err(error) = fs::remove_dir_all(&storage_root).await {
             panic!("test storage should be removed: {error}");
@@ -3158,10 +3164,6 @@ fn damage_command_records_by_entity_as_the_responsible_player() {
 }
 
 #[test]
-#[expect(
-    clippy::too_many_lines,
-    reason = "one integration test covers all title branches and issuer-scoped resolution"
-)]
 fn title_command_delivers_vanilla_packets_to_recorded_connections() {
     let world = fresh_test_world("title-command");
     let storage_root = test_storage_root("title-command");
@@ -3203,19 +3205,7 @@ fn title_command_delivers_vanilla_packets_to_recorded_connections() {
             if let Some(source_entity) = source_entity {
                 source = source.with_entity(source_entity);
             }
-            let source = source.with_callback(callback);
-            let chain = {
-                let dispatcher = server.command_dispatcher.read();
-                let parse = dispatcher.parse(command, source.clone());
-                dispatcher.context_chain(parse)
-            };
-            let Ok(chain) = chain else {
-                panic!("title command should parse: {command}");
-            };
-
-            let mut execution = CommandExecutionContext::for_source(&source);
-            execution.queue_initial_command(chain, source, CommandResultCallback::empty());
-            assert!(matches!(execution.run(), ExecutionStop::Completed));
+            run_command(&server, source.with_callback(callback), command);
 
             let Some(result) = *result.lock() else {
                 panic!("title command should report a result");
@@ -3308,18 +3298,7 @@ fn setblock_command_places_blocks_and_keep_mode_skips_occupied_positions() {
 
         let run = |command: &str| {
             let source = CommandSource::new(CommandSender::Console, Arc::clone(&server));
-            let chain = {
-                let dispatcher = server.command_dispatcher.read();
-                let parse = dispatcher.parse(command, source.clone());
-                dispatcher.context_chain(parse)
-            };
-            let chain = match chain {
-                Ok(chain) => chain,
-                Err(error) => panic!("{command} should parse: {error}"),
-            };
-            let mut execution = CommandExecutionContext::for_source(&source);
-            execution.queue_initial_command(chain, source, CommandResultCallback::empty());
-            assert!(matches!(execution.run(), ExecutionStop::Completed));
+            run_command(&server, source, command);
         };
 
         let pos = BlockPos::new(8, 64, 8);

--- a/steel-core/src/world/block_updates/mod.rs
+++ b/steel-core/src/world/block_updates/mod.rs
@@ -617,29 +617,6 @@ impl World {
         }
     }
 
-    /// Called when a block changed with a command (setblock, fill, ...)
-    ///
-    /// This is the Rust equivalent of vanilla's `ServerLevel.updateNeighborsOnBlockSet()`.
-    pub(crate) fn update_neighbour_on_block_set(
-        self: &Arc<Self>,
-        pos: BlockPos,
-        old_state: BlockStateId,
-    ) {
-        let block_state = self.get_block_state(pos);
-        // For block behaviors
-        let behavior = BLOCK_BEHAVIORS.get_behavior(old_state.get_block());
-
-        if old_state != block_state {
-            behavior.affect_neighbors_after_removal(old_state, self, pos, false);
-        }
-
-        self.update_neighbors_at(pos, block_state.get_block());
-
-        if behavior.has_analog_output_signal(block_state) {
-            self.update_neighbor_for_output_signal(pos, block_state.get_block());
-        }
-    }
-
     /// Notifies a block that one of its neighbors changed.
     ///
     /// This is the Rust equivalent of vanilla's `Level.neighborChanged()`.


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description
#443 changed `BlockStateParser` to produce `BlockInput`, but `/setblock` still read the argument as `BlockPredicate`, so every invocation failed. Now uses `block_input()` + `BlockInput::place` like `/fill`, requires a loaded position like vanilla, shares `placement_flags` with `/fill`, and removes the unused `update_neighbour_on_block_set`. Includes an end-to-end regression test.

## How this was tested

new regression test runs the command through the real dispatcher and asserts
the resulting block states, e.g.:
`setblock 8 64 8 minecraft:stone` places stone
`setblock 8 64 8 minecraft:dirt keep` fails, stone kept
`setblock 8 65 8 minecraft:end_rod[facing=east]` resolves to vanilla state id 14637

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments
