### PR TITLE
feat: add last_client_move_intent

### DIFF
--- a/steel-core/src/entity/mod.rs
+++ b/steel-core/src/entity/mod.rs
@@ -11,6 +11,7 @@ use rand::{SeedableRng as _, rngs::StdRng};
 use rustc_hash::FxHashSet;
 use simdnbt::borrow::NbtCompound as BorrowedNbtCompoundView;
 use simdnbt::owned::{NbtCompound, NbtList, NbtTag};
+use steel_math::trig;
 use steel_protocol::packets::game::{
     AnimateAction, AttributeSnapshot, CAnimate, CDamageEvent, CEntityEvent, CHurtAnimation,
     CTeleportEntity, EquipmentSlotItem, RelativeMovement, SoundSource,
@@ -419,13 +420,13 @@ pub(crate) fn get_input_vector(input: DVec3, speed: f32, yaw_degrees: f32) -> DV
     } else {
         input
     } * f64::from(speed);
-    let yaw = yaw_degrees.to_radians();
-    let sin = yaw.sin();
-    let cos = yaw.cos();
+    let yaw = f64::from(yaw_degrees.to_radians());
+    let sin = f64::from(trig::sin(yaw));
+    let cos = f64::from(trig::cos(yaw));
     DVec3::new(
-        movement.x * f64::from(cos) - movement.z * f64::from(sin),
+        movement.x * cos - movement.z * sin,
         movement.y,
-        movement.z * f64::from(cos) + movement.x * f64::from(sin),
+        movement.z * cos + movement.x * sin,
     )
 }
 

--- a/steel-core/src/player/movement/mod.rs
+++ b/steel-core/src/player/movement/mod.rs
@@ -25,6 +25,7 @@ use steel_utils::types::GameType;
 
 use crate::entity::{
     AcceptedClientMovement, AcceptedClientMovementOutcome, Entity, EntityMoveError, LivingEntity,
+    get_input_vector,
 };
 use crate::physics::{
     MOVEMENT_ERROR_THRESHOLD, MovementCollisionValidation, MoverType, WorldCollisionProvider,
@@ -889,6 +890,16 @@ impl Player {
     #[must_use]
     pub fn last_client_input(&self) -> PlayerInput {
         self.movement.lock().last_client_input()
+    }
+
+    /// Returns the latest client movement intent.
+    #[must_use]
+    pub fn last_client_move_intent(&self) -> DVec3 {
+        get_input_vector(
+            self.last_client_input().movement_input(),
+            1.0,
+            self.rotation().0,
+        )
     }
 
     /// Handles a player input packet (movement keys, sneaking, sprinting).

--- a/steel-core/src/player/tests.rs
+++ b/steel-core/src/player/tests.rs
@@ -1,3 +1,4 @@
+use std::f64::consts::FRAC_1_SQRT_2;
 use std::io::Cursor;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -7,7 +8,7 @@ use steel_protocol::packet_traits::{CompressionInfo, EncodedPacket};
 use steel_protocol::packets::common::{
     ChatVisibility, HumanoidArm, ParticleStatus, SClientInformation,
 };
-use steel_protocol::packets::game::EquipmentSlotItem;
+use steel_protocol::packets::game::{EquipmentSlotItem, SPlayerInput};
 use steel_registry::blocks::block_state_ext::BlockStateExt as _;
 use steel_registry::blocks::properties::{BlockStateProperties, Direction};
 use steel_registry::data_component_predicate::DataComponentMatchers;
@@ -234,6 +235,65 @@ fn test_player(world: Arc<World>) -> Arc<Player> {
     let player = TestPlayerBuilder::new(world, "TestPlayer", 1).build();
     player.set_client_loaded(true);
     player
+}
+
+#[test]
+fn last_client_move_intent_matches_vanilla_directional_inputs() {
+    const FORWARD: u8 = 0x01;
+    const BACKWARD: u8 = 0x02;
+    const LEFT: u8 = 0x04;
+    const RIGHT: u8 = 0x08;
+    const JUMP: u8 = 0x10;
+    const SHIFT: u8 = 0x20;
+    const SPRINT: u8 = 0x40;
+
+    let player = test_player(Arc::clone(test_world()));
+    let diagonal = FRAC_1_SQRT_2;
+
+    let cases = [
+        ("no input", 0, 0.0, DVec3::ZERO),
+        ("forward", FORWARD, 0.0, DVec3::new(0.0, 0.0, 1.0)),
+        ("backward", BACKWARD, 0.0, DVec3::new(0.0, 0.0, -1.0)),
+        ("left", LEFT, 0.0, DVec3::new(1.0, 0.0, 0.0)),
+        ("right", RIGHT, 0.0, DVec3::new(-1.0, 0.0, 0.0)),
+        (
+            "opposite forward inputs",
+            FORWARD | BACKWARD,
+            0.0,
+            DVec3::ZERO,
+        ),
+        ("opposite sideways inputs", LEFT | RIGHT, 0.0, DVec3::ZERO),
+        (
+            "forward-right diagonal",
+            FORWARD | RIGHT,
+            0.0,
+            DVec3::new(-diagonal, 0.0, diagonal),
+        ),
+        (
+            "forward rotated by yaw",
+            FORWARD,
+            90.0,
+            DVec3::new(-1.0, 0.0, 0.0),
+        ),
+        (
+            "non-movement inputs",
+            JUMP | SHIFT | SPRINT,
+            0.0,
+            DVec3::ZERO,
+        ),
+    ];
+
+    for (name, flags, yaw, expected) in cases {
+        player.set_rotation((yaw, 0.0));
+        player.handle_player_input(SPlayerInput { flags });
+
+        let actual = player.last_client_move_intent();
+
+        assert!(
+            (actual - expected).length_squared() < 1.0E-12,
+            "{name}: expected {expected:?}, got {actual:?}"
+        );
+    }
 }
 
 fn test_persistent_entity(


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [X] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description
This PR adds last_client_move_intent() to the Player, which matches ServerPlayer.getLastClientMoveIntent(). It also changes get_input_vector() to use steel's trig implementation which copies vanilla's own sin and cos implementation. Lastly, I added tests for last_client_move_intent().
<!-- What this PR does, why. -->

## How this was tested
It passes cargo fmt, cargo clippy, and cargo test.
<!-- Steps to reproduce/verify. Include env (MC version, OS) if relevant. -->
<!-- For commands please provide example commands -->
<!-- Also if possible link here flint tests, this will help us to review your PR quicker -->

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [X] Code builds w/o errors or warnings
- [X] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [X] No leftover debug code / comments

## Classes modified:

<!-- This is optional and you dont need to do it for commands, chors or foundation -->
<!-- The Classes need to be written the same as on the [tracker](https://steelmc.dev/tracker/) to appear in it. -->

## Additional notes

<!-- Anything else reviewers should know -->
