### PR TITLE
fix: defer chunk generation until dependency holders revive

### DIFF
--- a/steel-core/src/chunk/chunk_generation_task.rs
+++ b/steel-core/src/chunk/chunk_generation_task.rs
@@ -145,6 +145,14 @@ pub struct ChunkGenerationTask {
 }
 
 impl ChunkGenerationTask {
+    /// Radius of the holder neighborhood acquired before this target can be scheduled.
+    pub(crate) const fn dependency_radius(target_status: ChunkStatus) -> i32 {
+        GENERATION_PYRAMID
+            .get_step_to(target_status)
+            .accumulated_dependencies
+            .get_radius_of(ChunkStatus::Empty) as i32
+    }
+
     /// Creates a new generation task.
     #[must_use]
     #[inline]
@@ -159,10 +167,7 @@ impl ChunkGenerationTask {
         thread_pool: Arc<ThreadPool>,
         cancel_token: CancellationToken,
     ) -> Self {
-        let worst_case_radius = GENERATION_PYRAMID
-            .get_step_to(target_status)
-            .accumulated_dependencies
-            .get_radius_of(ChunkStatus::Empty) as i32;
+        let worst_case_radius = Self::dependency_radius(target_status);
 
         let chunk_map_clone = chunk_map.clone();
         let mut cache = StaticCache2D::create(pos.0.x, pos.0.y, worst_case_radius, move |x, y| {

--- a/steel-core/src/chunk/chunk_map/generation_readiness.rs
+++ b/steel-core/src/chunk/chunk_map/generation_readiness.rs
@@ -4,11 +4,45 @@ use super::{
     FullPublication, FxHashMap, FxHashSet, GENERATION_THREAD_MULTIPLE, GenerationTaskPriority,
     Instant, LoadLevelChange, Ordering, PackedChunkPos, PostProcessGenerationError,
     ReadinessReconcileResult, RunningGenerationTaskPermit, TickableChunk, TickingChunkSnapshot,
-    TickingReadiness, TickingReadinessCandidate, instrument, is_block_ticking, is_entity_ticking,
-    is_full,
+    TickingReadiness, TickingReadinessCandidate, generation_status, instrument, is_block_ticking,
+    is_entity_ticking, is_full,
 };
 
 impl ChunkMap {
+    pub(super) fn schedule_generation_for_holders(
+        self: &Arc<Self>,
+        holders: &[(Arc<ChunkHolder>, ChunkTicketLevel)],
+    ) -> (usize, FxHashSet<ChunkPos>) {
+        // Holder membership stays fixed during the chunk-source phase. Save completion
+        // only permits revival; the next chunk-source phase publishes it into `chunks`.
+        let revivals = self
+            .deferred_revivals
+            .lock()
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        let mut deferred = FxHashSet::default();
+        let mut scheduled = 0;
+        for (holder, level) in holders {
+            let Some(status) = generation_status(Some(*level)) else {
+                continue;
+            };
+            if holder.try_chunk(status).is_some() {
+                continue;
+            }
+            let center = holder.get_pos();
+            let radius = ChunkGenerationTask::dependency_radius(status) as u32;
+            if revivals.iter().any(|pos| {
+                center.0.x.abs_diff(pos.0.x) <= radius && center.0.y.abs_diff(pos.0.y) <= radius
+            }) {
+                deferred.insert(center);
+                continue;
+            }
+            scheduled += usize::from(holder.schedule_chunk_generation_task_b(status, self));
+        }
+        (scheduled, deferred)
+    }
+
     /// Schedules a new generation task.
     #[inline]
     #[instrument(level = "trace", skip(self), fields(chunk = ?pos, target = ?target_status))]

--- a/steel-core/src/chunk/chunk_map/mod.rs
+++ b/steel-core/src/chunk/chunk_map/mod.rs
@@ -228,6 +228,8 @@ pub struct ChunkMap {
     pub(crate) unloading_chunks: scc::HashMap<ChunkPos, Arc<ChunkHolder>, FxBuildHasher>,
     /// Ticket states waiting for an unloading holder's save preparation to finish.
     deferred_revivals: SyncMutex<FxHashMap<ChunkPos, DeferredChunkRevival>>,
+    /// Centers waiting for a dependency holder to finish save preparation and revive.
+    pub(crate) deferred_generation: SyncMutex<FxHashSet<ChunkPos>>,
     /// Queue of pending generation tasks.
     pub pending_generation_tasks: SyncMutex<Vec<Arc<ChunkGenerationTask>>>,
     /// Tracker for generation, save, and unload tasks.
@@ -383,6 +385,7 @@ impl ChunkMap {
             chunks: scc::HashMap::default(),
             unloading_chunks: scc::HashMap::default(),
             deferred_revivals: SyncMutex::new(FxHashMap::default()),
+            deferred_generation: SyncMutex::new(FxHashSet::default()),
             pending_generation_tasks: SyncMutex::new(Vec::new()),
             task_tracker: TaskTracker::new(),
             scheduling: ChunkSchedulingCoordinator::new(
@@ -1090,7 +1093,7 @@ impl ChunkMap {
             )
         };
 
-        let holders_to_schedule = {
+        let mut holders_to_schedule: Vec<_> = {
             let _span = tracing::trace_span!("lifecycle_commit").entered();
             let start = Instant::now();
             let holders: Vec<(Arc<ChunkHolder>, ChunkTicketLevel)> = batch
@@ -1104,6 +1107,26 @@ impl ChunkMap {
             timings.lifecycle_commit = start.elapsed();
             holders
         };
+
+        // The center's level need not change when its dependency revives. Retry against
+        // committed holders and levels so intervening unloads or demotions take effect.
+        let previously_deferred = mem::take(&mut *self.deferred_generation.lock());
+        if !previously_deferred.is_empty() {
+            let scheduled_positions: FxHashSet<ChunkPos> = holders_to_schedule
+                .iter()
+                .map(|(h, _)| h.get_pos())
+                .collect();
+            holders_to_schedule.extend(previously_deferred.into_iter().filter_map(|pos| {
+                if scheduled_positions.contains(&pos) {
+                    return None;
+                }
+                self.chunks
+                    .read_sync(&pos, |_, holder| {
+                        holder.load_level().map(|level| (Arc::clone(holder), level))
+                    })
+                    .flatten()
+            }));
+        }
 
         let lookup_cache_scope = GameplayChunkLookupCacheScope::enter(self);
         let readiness_result = {
@@ -1143,20 +1166,16 @@ impl ChunkMap {
             timings.ticking_snapshot_rebuild = start.elapsed();
         }
 
-        {
+        let deferred_generation = {
             let _span = tracing::trace_span!("schedule_generation").entered();
             let start = Instant::now();
-            timings.scheduled_count = holders_to_schedule
-                .iter()
-                .filter(|(holder, level)| {
-                    let Some(status) = generation_status(Some(*level)) else {
-                        return false;
-                    };
-                    holder.schedule_chunk_generation_task_b(status, self)
-                })
-                .count();
+            let (scheduled_count, deferred) =
+                self.schedule_generation_for_holders(&holders_to_schedule);
+            timings.scheduled_count = scheduled_count;
             timings.schedule_generation = start.elapsed();
-        }
+            deferred
+        };
+        *self.deferred_generation.lock() = deferred_generation;
 
         {
             let _span = tracing::trace_span!("run_generation").entered();

--- a/steel-core/src/chunk/chunk_map/tests/deferred_generation.rs
+++ b/steel-core/src/chunk/chunk_map/tests/deferred_generation.rs
@@ -1,0 +1,114 @@
+use super::*;
+use crate::chunk::chunk_ticket_manager::ticket_level_for_status;
+
+fn cancel_queued_tasks(map: &ChunkMap) {
+    for task in map.pending_generation_tasks.lock().drain(..) {
+        task.center_holder.cancel_generation_task();
+    }
+}
+
+#[test]
+fn deferred_dependency_retries_unchanged_center_without_blocking_other_chunks() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("generation_deferred_dependency");
+    let map = &world.chunk_map;
+    // Inspect task creation without workers consuming the queue.
+    map.stop_generation_refill_loop();
+    let center = ChunkPos::new(0, 0);
+    let neighbor_pos = ChunkPos::new(1, 0);
+    let unrelated = ChunkPos::new(100, 100);
+    let neighbor = insert_ready_full_chunk(&world, neighbor_pos);
+    map.update_chunk_level(neighbor_pos, None);
+    let preparation = neighbor
+        .try_begin_save_preparation()
+        .expect("unloading neighbor should reserve save preparation");
+    let level = ticket_level_for_status(ChunkStatus::Carvers);
+    let _center_lease = map
+        .acquire_chunk_request_leases(&[center], level)
+        .expect("center request lease should produce receipt");
+    let _unrelated_lease = map
+        .acquire_chunk_request_leases(&[unrelated], level)
+        .expect("unrelated request lease should produce receipt");
+    map.advance_scheduling();
+
+    assert!(map.deferred_generation.lock().contains(&center));
+    assert!(!map.deferred_generation.lock().contains(&unrelated));
+    assert!(!map.chunks.contains_sync(&neighbor_pos));
+    {
+        let tasks = map.pending_generation_tasks.lock();
+        assert!(
+            tasks
+                .iter()
+                .any(|task| task.center_holder.get_pos() == unrelated)
+        );
+        assert!(
+            !tasks
+                .iter()
+                .any(|task| task.center_holder.get_pos() == center)
+        );
+    }
+
+    drop(preparation);
+    map.advance_scheduling();
+    assert!(!map.deferred_generation.lock().contains(&center));
+    {
+        let tasks = map.pending_generation_tasks.lock();
+        let task = tasks
+            .iter()
+            .find(|task| task.center_holder.get_pos() == center)
+            .expect("unchanged center should retry after its neighbor revives");
+        assert_eq!(Some(task.target_status), generation_status(Some(level)));
+        assert!(Arc::ptr_eq(
+            task.cache.get(neighbor_pos.0.x, neighbor_pos.0.y),
+            &neighbor
+        ));
+    }
+    cancel_queued_tasks(map);
+    stop_chunk_tasks(&world);
+}
+
+#[test]
+fn deferred_generation_uses_current_ticket_after_removal_or_demotion() {
+    init_vanilla_registry();
+    init_behaviors();
+    for replacement in [
+        None,
+        Some(ticket_level_for_status(ChunkStatus::StructureStarts)),
+    ] {
+        let world = fresh_test_world("generation_deferred_ticket_change");
+        let map = &world.chunk_map;
+        map.stop_generation_refill_loop();
+        let center = ChunkPos::new(0, 0);
+        let neighbor_pos = ChunkPos::new(1, 0);
+        let neighbor = insert_ready_full_chunk(&world, neighbor_pos);
+        map.update_chunk_level(neighbor_pos, None);
+        let preparation = neighbor
+            .try_begin_save_preparation()
+            .expect("unloading neighbor should reserve save preparation");
+        let initial_level = ticket_level_for_status(ChunkStatus::Carvers);
+        let _initial_lease = map
+            .acquire_chunk_request_leases(&[center], initial_level)
+            .expect("request lease should produce receipt");
+        map.advance_scheduling();
+        assert!(map.deferred_generation.lock().contains(&center));
+
+        let _ = map.release_chunk_request_leases(&[center], initial_level);
+        if let Some(level) = replacement {
+            let _ = map.acquire_chunk_request_leases(&[center], level);
+        }
+        map.advance_scheduling();
+        assert!(!map.deferred_generation.lock().contains(&center));
+        {
+            let tasks = map.pending_generation_tasks.lock();
+            let target = tasks
+                .iter()
+                .find(|task| task.center_holder.get_pos() == center)
+                .map(|task| task.target_status);
+            assert_eq!(target, generation_status(replacement));
+        }
+        drop(preparation);
+        cancel_queued_tasks(map);
+        stop_chunk_tasks(&world);
+    }
+}

--- a/steel-core/src/chunk/chunk_map/tests/mod.rs
+++ b/steel-core/src/chunk/chunk_map/tests/mod.rs
@@ -284,6 +284,7 @@ fn unloaded_full_holder(pos: ChunkPos) -> Arc<ChunkHolder> {
     holder
 }
 
+mod deferred_generation;
 mod light_updates;
 mod persistence_unloads;
 mod player_tracking;


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

chunk generation can be scheduled while a required neighbor is still preparing its save. that holder stays in `unloading_chunks`, so `ChunkGenerationTask::new` panics when it looks in the active map.

this defers affected generation requests until their dependency holders can revive. retries use the current ticket levels, so removing or lowering a ticket while waiting still takes effect. unrelated chunks can keep generating.

related to #561.

## How this was tested

added two regression tests using actual ticket propagation and a held save preparation guard. they cover retrying an unchanged center after its neighbor revives, generation elsewhere, and ticket removal or demotion while waiting.

- `cargo test -p steel-core --lib chunk::` passed, 223 tests.
- `cargo clippy -r --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `typos`

tested on Linux with the repo's nightly toolchain and MC 26.2 data. checked the dependency radius against the local vanilla 26.2 source.

## Screenshots / logs

temporarily bypassing the new guard makes the regression test hit the original panic in the scheduling worker:

```text
The chunkholder should be created by distance manager before the generation task is scheduled. This occurring means there is a bug in the distance manager or you called this yourself.
```

with the guard restored:

```text
test result: ok. 223 passed; 0 failed; 0 ignored
```

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

n/a, chunk scheduling foundation.

## Additional notes

the test reproduces the save preparation path deterministically. i haven't rerun the intermittent live pregen or death repros.
