### PR TITLE
fix(chunk): let ticket revival win over an in-flight save preparation

### DIFF
--- a/steel-core/src/chunk/chunk_generation_task.rs
+++ b/steel-core/src/chunk/chunk_generation_task.rs
@@ -167,9 +167,12 @@ impl ChunkGenerationTask {
         let chunk_map_clone = chunk_map.clone();
         let mut cache = StaticCache2D::create(pos.0.x, pos.0.y, worst_case_radius, move |x, y| {
             chunk_map_clone
-                    .chunks
-                    .read_sync(&ChunkPos::new(x, y), |_, chunk_holder| chunk_holder.clone())
-                    .expect("The chunkholder should be created by distance manager before the generation task is scheduled. This occurring means there is a bug in the distance manager or you called this yourself.")
+                .chunks
+                .read_sync(&ChunkPos::new(x, y), |_, chunk_holder| chunk_holder.clone())
+                .expect(
+                    "update_chunk_level installs a holder for every position granted a \
+                     loading level before its neighbors can be scheduled",
+                )
         });
         cache.pin_holders_for_generation();
         let center_holder = Arc::clone(cache.get(pos.0.x, pos.0.y));

--- a/steel-core/src/chunk/chunk_holder.rs
+++ b/steel-core/src/chunk/chunk_holder.rs
@@ -219,22 +219,34 @@ impl Drop for ChunkSaveDependency {
     }
 }
 
+/// Reservation of a holder's save-preparation phase.
+///
+/// It excludes a second preparation but not a ticket revival; [`Self::finish`] hands the snapshot
+/// back only if the phase still owned the holder. One guard exists per holder: it keeps a strong
+/// reference, and `ChunkMap::process_unloads` only saves a holder whose strong count is 1.
 pub(crate) struct ChunkSavePreparationGuard {
     holder: Arc<ChunkHolder>,
+    /// Whether the lifecycle was already handed back, so `Drop` does not repeat it.
+    released: bool,
+}
+
+impl ChunkSavePreparationGuard {
+    /// Ends the phase, returning `value` only if no revival reclaimed the holder meanwhile.
+    #[must_use = "a snapshot prepared while losing a revival race must be discarded"]
+    pub(crate) fn finish<T>(mut self, value: T) -> Option<T> {
+        self.released = true;
+        self.holder.end_save_preparation().then_some(value)
+    }
 }
 
 impl Drop for ChunkSavePreparationGuard {
     fn drop(&mut self) {
-        let result = self.holder.save_lifecycle.compare_exchange(
-            SAVE_LIFECYCLE_PREPARING,
-            SAVE_LIFECYCLE_UNLOADING,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        );
-        assert!(
-            result.is_ok(),
-            "chunk save preparation ended outside the preparing lifecycle"
-        );
+        if self.released {
+            return;
+        }
+
+        // The preparation bailed before a snapshot existed, so nothing escaped.
+        let _ = self.holder.end_save_preparation();
     }
 }
 
@@ -711,19 +723,37 @@ impl ChunkHolder {
             .ok()
             .map(|_| ChunkSavePreparationGuard {
                 holder: Arc::clone(self),
+                released: false,
             })
     }
 
-    /// Attempts to reactivate an unloading holder without waiting for save preparation.
-    pub(crate) fn try_revive_from_unloading(&self) -> bool {
+    /// Leaves the preparing lifecycle, reporting whether the phase still owned the holder.
+    fn end_save_preparation(&self) -> bool {
         self.save_lifecycle
             .compare_exchange(
+                SAVE_LIFECYCLE_PREPARING,
                 SAVE_LIFECYCLE_UNLOADING,
-                SAVE_LIFECYCLE_ACTIVE,
                 Ordering::AcqRel,
                 Ordering::Acquire,
             )
             .is_ok()
+    }
+
+    /// Reactivates an unloading holder even while a save snapshot is in flight, as vanilla's
+    /// `ChunkMap.updateChunkScheduling` does via `pendingUnloads`. It cannot fail: a ticketed
+    /// position without a holder in `ChunkMap::chunks` breaks `ChunkGenerationTask::new`. A single
+    /// `try_update` covers both source states, since a finishing preparation moves `PREPARING` back
+    /// to `UNLOADING` between sequential CAS attempts.
+    pub(crate) fn revive_from_unloading(&self) {
+        let previous =
+            self.save_lifecycle
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |lifecycle| {
+                    (lifecycle != SAVE_LIFECYCLE_ACTIVE).then_some(SAVE_LIFECYCLE_ACTIVE)
+                });
+        debug_assert!(
+            previous.is_ok(),
+            "an already active chunk holder was revived from unloading"
+        );
     }
 
     /// Applies a step to the chunk.
@@ -1710,27 +1740,44 @@ mod tests {
     }
 
     #[test]
-    fn save_preparation_defers_revival_only_until_the_snapshot_is_built() {
+    fn revival_wins_over_an_in_flight_save_preparation() {
         let holder = test_holder();
         holder.begin_unloading();
         let preparation = holder
             .try_begin_save_preparation()
             .expect("an unloading holder should begin save preparation");
 
-        assert!(!holder.try_revive_from_unloading());
+        holder.revive_from_unloading();
 
-        drop(preparation);
-
-        assert!(holder.try_revive_from_unloading());
+        assert!(
+            preparation.finish(()).is_none(),
+            "a preparation that lost the revival race must discard its snapshot"
+        );
         assert!(holder.try_begin_save_preparation().is_none());
     }
 
     #[test]
-    fn revival_winning_the_lifecycle_race_cancels_save_preparation() {
+    fn an_uncontested_save_preparation_keeps_its_snapshot() {
+        let holder = test_holder();
+        holder.begin_unloading();
+        let preparation = holder
+            .try_begin_save_preparation()
+            .expect("an unloading holder should begin save preparation");
+
+        assert_eq!(preparation.finish(7), Some(7));
+        assert!(
+            holder.try_begin_save_preparation().is_some(),
+            "finishing an uncontested phase must return the holder to the unloading lifecycle"
+        );
+    }
+
+    #[test]
+    fn a_revived_holder_refuses_a_new_save_preparation() {
         let holder = test_holder();
         holder.begin_unloading();
 
-        assert!(holder.try_revive_from_unloading());
+        holder.revive_from_unloading();
+
         assert!(holder.try_begin_save_preparation().is_none());
     }
 }

--- a/steel-core/src/chunk/chunk_map/generation_readiness.rs
+++ b/steel-core/src/chunk/chunk_map/generation_readiness.rs
@@ -1,11 +1,10 @@
 use super::{
     Arc, ChunkGenerationTask, ChunkHolder, ChunkMap, ChunkPos, ChunkStatus, ChunkTicketLevel,
-    DeferredChunkRevival, FullNeighborhoodCounts, FullNeighborhoodError, FullNeighborhoodIndex,
-    FullPublication, FxHashMap, FxHashSet, GENERATION_THREAD_MULTIPLE, GenerationTaskPriority,
-    Instant, LoadLevelChange, Ordering, PackedChunkPos, PostProcessGenerationError,
-    ReadinessReconcileResult, RunningGenerationTaskPermit, TickableChunk, TickingChunkSnapshot,
-    TickingReadiness, TickingReadinessCandidate, instrument, is_block_ticking, is_entity_ticking,
-    is_full,
+    FullNeighborhoodCounts, FullNeighborhoodError, FullNeighborhoodIndex, FullPublication,
+    FxHashMap, GENERATION_THREAD_MULTIPLE, GenerationTaskPriority, Instant, LoadLevelChange,
+    Ordering, PackedChunkPos, PostProcessGenerationError, ReadinessReconcileResult,
+    RunningGenerationTaskPermit, TickableChunk, TickingChunkSnapshot, TickingReadiness,
+    TickingReadinessCandidate, instrument, is_block_ticking, is_entity_ticking, is_full,
 };
 
 impl ChunkMap {
@@ -100,17 +99,15 @@ impl ChunkMap {
     }
 
     /// Updates scheduling for a chunk based on its new level.
-    /// Returns the chunk holder if it is active.
+    ///
+    /// Returns the holder for every loaded level and `None` only when unloading, so every
+    /// position granted a level owns a live holder before `ChunkGenerationTask::new` reads it.
     #[inline]
     pub(super) fn update_chunk_level(
         self: &Arc<Self>,
         pos: ChunkPos,
         new_level: Option<ChunkTicketLevel>,
     ) -> Option<Arc<ChunkHolder>> {
-        if new_level.is_none() {
-            self.deferred_revivals.lock().remove(&pos);
-        }
-
         // Recover from unloading if possible, else create new holder.
         let (chunk_holder, initialize_simulation) =
             if let Some(holder) = self.chunks.read_sync(&pos, |_, holder| holder.clone()) {
@@ -120,13 +117,7 @@ impl ChunkMap {
 
                 if let Some(entry) = self.unloading_chunks.remove_sync(&pos) {
                     let holder = entry.1;
-                    if !holder.try_revive_from_unloading() {
-                        let _ = self.unloading_chunks.insert_sync(pos, Arc::clone(&holder));
-                        self.deferred_revivals
-                            .lock()
-                            .insert(pos, DeferredChunkRevival { load_level: level });
-                        return None;
-                    }
+                    holder.revive_from_unloading();
                     let _ = self.chunks.insert_sync(pos, Arc::clone(&holder));
                     (holder, true)
                 } else {
@@ -143,69 +134,57 @@ impl ChunkMap {
                 }
             };
 
-        if let Some(level) = new_level {
-            let old = chunk_holder.swap_load_level(level);
-            if initialize_simulation {
-                chunk_holder.set_simulation_level(self.scheduling.simulation_level(pos));
-            }
-            if old != Some(level) {
-                chunk_holder.update_highest_allowed_status(Some(level));
-            }
-            if chunk_holder.try_chunk(ChunkStatus::Empty).is_some() {
-                let world = self.world_gen_context.world();
-                world.on_entity_chunk_loaded(pos);
-                world.update_entity_chunk_visibility(pos, chunk_holder.entity_visibility());
-            }
-            if is_full(level)
-                && !old.is_some_and(is_full)
-                && chunk_holder.is_full_status_initialized()
-                && chunk_holder.published_status() == Some(ChunkStatus::Full)
-                && chunk_holder.try_chunk(ChunkStatus::Full).is_some()
-            {
-                self.full_publications.publish(&chunk_holder);
-            }
-            Some(chunk_holder)
-        } else {
-            //log::info!("Unloading chunk at {pos:?}");
-            chunk_holder.begin_unloading();
-            chunk_holder.cancel_generation_task();
-            chunk_holder.clear_load_level();
-            chunk_holder.set_simulation_level(None);
-            chunk_holder.update_highest_allowed_status(None);
-            // Wake any await_chunk futures so generation tasks holding refs to
-            // this chunk can detect the status is disallowed and exit.
-            chunk_holder.wake_all_watchers();
+        let Some(level) = new_level else {
+            self.begin_chunk_unload(pos, &chunk_holder);
+            return None;
+        };
 
-            // Clean up POI data for this chunk column
-            let world = self.world_gen_context.world();
-            world.on_entity_chunk_unload_start(pos);
-            world.poi_storage.lock().remove_chunk(pos);
-
-            if let Some(chunk) = chunk_holder.try_full_chunk() {
-                chunk.suspend_block_entities(&chunk_holder);
-            }
-
-            // Move to unloading_chunks for deferred unload
-            if let Some((_, holder)) = self.chunks.remove_sync(&pos) {
-                let _ = self.unloading_chunks.insert_sync(pos, holder);
-            }
-            None
+        let old = chunk_holder.swap_load_level(level);
+        if initialize_simulation {
+            chunk_holder.set_simulation_level(self.scheduling.simulation_level(pos));
         }
+        if old != Some(level) {
+            chunk_holder.update_highest_allowed_status(Some(level));
+        }
+        if chunk_holder.try_chunk(ChunkStatus::Empty).is_some() {
+            let world = self.world_gen_context.world();
+            world.on_entity_chunk_loaded(pos);
+            world.update_entity_chunk_visibility(pos, chunk_holder.entity_visibility());
+        }
+        if is_full(level)
+            && !old.is_some_and(is_full)
+            && chunk_holder.is_full_status_initialized()
+            && chunk_holder.published_status() == Some(ChunkStatus::Full)
+            && chunk_holder.try_chunk(ChunkStatus::Full).is_some()
+        {
+            self.full_publications.publish(&chunk_holder);
+        }
+        Some(chunk_holder)
     }
 
-    pub(super) fn merge_deferred_revivals(&self, changes: &mut Vec<LoadLevelChange>) {
-        let changed_positions = changes
-            .iter()
-            .map(|change| change.pos)
-            .collect::<FxHashSet<_>>();
-        let mut deferred = self.deferred_revivals.lock();
-        for pos in &changed_positions {
-            deferred.remove(pos);
+    /// Tears an active holder down and moves it to `unloading_chunks` for deferred unload.
+    fn begin_chunk_unload(&self, pos: ChunkPos, chunk_holder: &Arc<ChunkHolder>) {
+        chunk_holder.begin_unloading();
+        chunk_holder.cancel_generation_task();
+        chunk_holder.clear_load_level();
+        chunk_holder.set_simulation_level(None);
+        chunk_holder.update_highest_allowed_status(None);
+        // Wake any await_chunk futures so generation tasks holding refs to
+        // this chunk can detect the status is disallowed and exit.
+        chunk_holder.wake_all_watchers();
+
+        // Clean up POI data for this chunk column
+        let world = self.world_gen_context.world();
+        world.on_entity_chunk_unload_start(pos);
+        world.poi_storage.lock().remove_chunk(pos);
+
+        if let Some(chunk) = chunk_holder.try_full_chunk() {
+            chunk.suspend_block_entities(chunk_holder);
         }
-        changes.extend(deferred.drain().map(|(pos, revival)| LoadLevelChange {
-            pos,
-            new_level: Some(revival.load_level),
-        }));
+
+        if let Some((_, holder)) = self.chunks.remove_sync(&pos) {
+            let _ = self.unloading_chunks.insert_sync(pos, holder);
+        }
     }
 
     pub(super) fn prepare_ticking_readiness_demotions(

--- a/steel-core/src/chunk/chunk_map/mod.rs
+++ b/steel-core/src/chunk/chunk_map/mod.rs
@@ -206,11 +206,6 @@ struct TickingReadinessCandidate {
     target: TickingReadiness,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct DeferredChunkRevival {
-    load_level: ChunkTicketLevel,
-}
-
 #[derive(Default)]
 struct ReadinessReconcileResult {
     snapshot_changed: bool,
@@ -226,8 +221,6 @@ pub struct ChunkMap {
     pub(crate) chunks: scc::HashMap<ChunkPos, Arc<ChunkHolder>, FxBuildHasher>,
     /// Map of chunks currently being unloaded.
     pub(crate) unloading_chunks: scc::HashMap<ChunkPos, Arc<ChunkHolder>, FxBuildHasher>,
-    /// Ticket states waiting for an unloading holder's save preparation to finish.
-    deferred_revivals: SyncMutex<FxHashMap<ChunkPos, DeferredChunkRevival>>,
     /// Queue of pending generation tasks.
     pub pending_generation_tasks: SyncMutex<Vec<Arc<ChunkGenerationTask>>>,
     /// Tracker for generation, save, and unload tasks.
@@ -382,7 +375,6 @@ impl ChunkMap {
         Self {
             chunks: scc::HashMap::default(),
             unloading_chunks: scc::HashMap::default(),
-            deferred_revivals: SyncMutex::new(FxHashMap::default()),
             pending_generation_tasks: SyncMutex::new(Vec::new()),
             task_tracker: TaskTracker::new(),
             scheduling: ChunkSchedulingCoordinator::new(
@@ -969,7 +961,7 @@ impl ChunkMap {
         {
             let _span = tracing::trace_span!("process_unloads").entered();
             let start = Instant::now();
-            self.process_pending_unloads();
+            self.process_unloads();
             timings.scheduling.process_unloads = start.elapsed();
         }
 
@@ -987,7 +979,7 @@ impl ChunkMap {
         let _source_phase_guard = self.source_phase_guard.lock();
         let mut timings = self.run_chunk_source_updates();
         let start = Instant::now();
-        self.process_pending_unloads();
+        self.process_unloads();
         timings.process_unloads = start.elapsed();
         timings
     }
@@ -1042,8 +1034,6 @@ impl ChunkMap {
             timings.ticket_updates = start.elapsed();
             batch
         };
-
-        self.merge_deferred_revivals(&mut batch.load_changes);
 
         {
             let _span = tracing::trace_span!("block_entity_unloads").entered();
@@ -1165,24 +1155,9 @@ impl ChunkMap {
             timings.run_generation = start.elapsed();
         }
 
-        let through_receipt = batch.through_receipt;
-        // A staged revival has not published the ticket's holder state yet. A later
-        // phase returns the same watermark and commits it after every revival lands.
-        if self.deferred_revivals.lock().is_empty() {
-            self.scheduling.publish_committed(through_receipt);
-        }
+        self.scheduling.publish_committed(batch.through_receipt);
         self.scheduling.recycle_update_batch(batch);
         timings
-    }
-
-    fn process_pending_unloads(self: &Arc<Self>) {
-        let staged_revivals = self
-            .deferred_revivals
-            .lock()
-            .keys()
-            .copied()
-            .collect::<FxHashSet<_>>();
-        self.process_unloads(&staged_revivals);
     }
 
     /// Returns full chunks whose simulation level currently allows entity ticks.

--- a/steel-core/src/chunk/chunk_map/persistence.rs
+++ b/steel-core/src/chunk/chunk_map/persistence.rs
@@ -1,5 +1,5 @@
 use super::{
-    Arc, Chunk, ChunkHolder, ChunkMap, ChunkPos, ChunkSaveDependency, ChunkStatus, ChunkStorage,
+    Arc, Chunk, ChunkHolder, ChunkMap, ChunkSaveDependency, ChunkStatus, ChunkStorage,
     ClearedBlockEntities, FinalizedBlockEntityUnload, FxHashSet, instrument, io, mem,
 };
 use crate::chunk_saver::PreparedChunkSave;
@@ -45,12 +45,12 @@ impl ChunkMap {
                     None
                 };
 
+                let prepared = save_preparation.finish(prepared).flatten();
+
                 if prepared.is_none() && dirty {
                     chunk_guard.mark_dirty();
                 }
 
-                // Revival need not wait for encoding or disk I/O once this owned input exists.
-                drop(save_preparation);
                 prepared
             };
 
@@ -120,22 +120,16 @@ impl ChunkMap {
     /// Processes chunks that are pending unload.
     ///
     /// Iterates over `unloading_chunks`. For each chunk with `strong_count == 1`:
-    /// - If staged to revive at the next lifecycle boundary: keep
     /// - If dirty: spawn save task (keep until saved and clean)
     /// - If not dirty: release region handle and remove
-    #[instrument(level = "trace", skip(self, staged_revivals))]
-    pub(super) fn process_unloads(self: &Arc<Self>, staged_revivals: &FxHashSet<ChunkPos>) {
+    #[instrument(level = "trace", skip(self))]
+    pub(super) fn process_unloads(self: &Arc<Self>) {
         self.propagate_queued_light_changes();
 
         let mut finalized = Vec::new();
         {
             let light_updates = self.light_updates.lock();
             self.unloading_chunks.retain_sync(|pos, holder| {
-                // Prepared ticket changes publish only at the next lifecycle boundary.
-                if staged_revivals.contains(pos) {
-                    return true;
-                }
-
                 if light_updates.touches_chunk(*pos) {
                     return true;
                 }

--- a/steel-core/src/chunk/chunk_map/tests/persistence_unloads.rs
+++ b/steel-core/src/chunk/chunk_map/tests/persistence_unloads.rs
@@ -1,6 +1,35 @@
 use super::*;
+use crate::chunk::chunk_holder::ChunkSavePreparationGuard;
+use crate::chunk::chunk_pyramid::GENERATION_PYRAMID;
 use crate::chunk::chunk_request::{ChunkRequest, ChunkTicketKind};
 use std::thread;
+
+/// Unloads a ready Full holder at `pos` and reserves its save preparation.
+fn unloading_holder_with_save_preparation(
+    world: &Arc<World>,
+    pos: ChunkPos,
+) -> (Arc<ChunkHolder>, ChunkSavePreparationGuard) {
+    let holder = insert_ready_full_chunk(world, pos);
+    world.chunk_map.update_chunk_level(pos, None);
+    let preparation = holder
+        .try_begin_save_preparation()
+        .expect("the unloading holder should reserve save preparation");
+    (holder, preparation)
+}
+
+fn revive_at_full(world: &Arc<World>, pos: ChunkPos) -> Arc<ChunkHolder> {
+    world
+        .chunk_map
+        .update_chunk_level(pos, Some(ChunkTicketLevel::FULL_CHUNK))
+        .expect("revival must win the race against an in-flight save preparation")
+}
+
+fn assert_snapshot_discarded(preparation: ChunkSavePreparationGuard) {
+    assert!(
+        preparation.finish(()).is_none(),
+        "the preparation that lost the race must discard its snapshot"
+    );
+}
 
 #[test]
 fn world_tick_spawns_dirty_unload_save_on_the_chunk_runtime() {
@@ -46,66 +75,31 @@ fn save_retry_marks_same_unloading_holder_dirty() {
 }
 
 #[test]
-fn revival_during_save_preparation_is_retried_at_the_next_lifecycle_boundary() {
+fn revival_during_save_preparation_activates_the_holder_immediately() {
     init_vanilla_registry();
     init_behaviors();
     let world = fresh_test_world("save_preparation_revival");
     let chunk_pos = ChunkPos::new(0, 0);
-    let original = insert_ready_full_chunk(&world, chunk_pos);
+    let (original, preparation) = unloading_holder_with_save_preparation(&world, chunk_pos);
 
-    world.chunk_map.update_chunk_level(chunk_pos, None);
-    let preparation = original
-        .try_begin_save_preparation()
-        .expect("the unloading holder should reserve save preparation");
-
-    assert!(
-        world
-            .chunk_map
-            .update_chunk_level(chunk_pos, Some(ChunkTicketLevel::FULL_CHUNK))
-            .is_none(),
-        "revival must be staged instead of blocking the lifecycle thread"
-    );
-    assert!(world.chunk_map.unloading_chunks.contains_sync(&chunk_pos));
-    assert!(!world.chunk_map.chunks.contains_sync(&chunk_pos));
-
-    drop(preparation);
-
-    let mut changes = Vec::new();
-    world.chunk_map.merge_deferred_revivals(&mut changes);
-    assert_eq!(changes.len(), 1);
-    let change = changes[0];
-    let Some(revived) = world
-        .chunk_map
-        .update_chunk_level(change.pos, change.new_level)
-    else {
-        panic!("revival should retry after save preparation releases the holder");
-    };
+    let revived = revive_at_full(&world, chunk_pos);
 
     assert!(Arc::ptr_eq(&original, &revived));
     assert!(world.chunk_map.chunks.contains_sync(&chunk_pos));
     assert!(!world.chunk_map.unloading_chunks.contains_sync(&chunk_pos));
+    assert_snapshot_discarded(preparation);
 }
 
 #[test]
-fn ticket_receipt_waits_for_deferred_holder_revival() {
-    let world = fresh_test_world("deferred_revival_receipt");
+fn ticket_receipt_commits_while_the_holder_is_still_preparing_a_save() {
+    let world = fresh_test_world("save_preparation_receipt");
     let pos = ChunkPos::new(0, 0);
-    let holder = insert_ready_full_chunk(&world, pos);
-    world.chunk_map.update_chunk_level(pos, None);
-    let preparation = holder
-        .try_begin_save_preparation()
-        .expect("the unloading holder should reserve save preparation");
+    let (holder, preparation) = unloading_holder_with_save_preparation(&world, pos);
 
     let receipt = world
         .chunk_map
         .acquire_chunk_request_leases(&[pos], ChunkTicketLevel::MAX)
         .expect("one request lease should produce a receipt");
-    world.chunk_map.advance_scheduling();
-
-    assert!(!world.chunk_map.is_ticket_receipt_committed(receipt));
-    assert!(!world.chunk_map.chunks.contains_sync(&pos));
-
-    drop(preparation);
     world.chunk_map.advance_scheduling();
 
     assert!(world.chunk_map.is_ticket_receipt_committed(receipt));
@@ -115,41 +109,50 @@ fn ticket_receipt_waits_for_deferred_holder_revival() {
             .chunks
             .read_sync(&pos, |_, active| Arc::ptr_eq(active, &holder))
             .unwrap_or(false),
-        "the receipt should publish only after the original holder revives"
+        "the original holder must be active again without waiting for the save"
     );
+    assert_snapshot_discarded(preparation);
 
     stop_chunk_tasks(&world);
 }
 
 #[test]
-fn newer_ticket_change_replaces_a_deferred_revival() {
+fn revival_during_save_preparation_keeps_the_generation_neighborhood_complete() {
     init_vanilla_registry();
     init_behaviors();
-    let world = fresh_test_world("save_preparation_revival_override");
-    let chunk_pos = ChunkPos::new(0, 0);
-    let holder = insert_ready_full_chunk(&world, chunk_pos);
+    let world = fresh_test_world("save_preparation_revival_neighborhood");
+    let pinned = ChunkPos::new(0, 0);
+    let neighbor = ChunkPos::new(1, 0);
+    let target_status = ChunkStatus::Biomes;
+    let radius = GENERATION_PYRAMID
+        .get_step_to(target_status)
+        .accumulated_dependencies
+        .get_radius_of(ChunkStatus::Empty) as i32;
 
-    world.chunk_map.update_chunk_level(chunk_pos, None);
-    let preparation = holder
-        .try_begin_save_preparation()
-        .expect("the unloading holder should reserve save preparation");
-    assert!(
-        world
-            .chunk_map
-            .update_chunk_level(chunk_pos, Some(ChunkTicketLevel::FULL_CHUNK))
-            .is_none()
-    );
-    drop(preparation);
+    // Every position in the neighbor's dependency square needs a live holder.
+    for x in (neighbor.0.x - radius)..=(neighbor.0.x + radius) {
+        for z in (neighbor.0.y - radius)..=(neighbor.0.y + radius) {
+            let pos = ChunkPos::new(x, z);
+            if pos != pinned {
+                world
+                    .chunk_map
+                    .update_chunk_level(pos, Some(ChunkTicketLevel::MAX));
+            }
+        }
+    }
 
-    let removal = LoadLevelChange {
-        pos: chunk_pos,
-        new_level: None,
-    };
-    let mut changes = vec![removal];
-    world.chunk_map.merge_deferred_revivals(&mut changes);
+    let (holder, preparation) = unloading_holder_with_save_preparation(&world, pinned);
+    let revived = revive_at_full(&world, pinned);
+    assert!(Arc::ptr_eq(&holder, &revived));
 
-    assert_eq!(changes, vec![removal]);
-    assert!(world.chunk_map.unloading_chunks.contains_sync(&chunk_pos));
+    // Before the fix the pinned position was a hole in `chunks` and this panicked.
+    let task = world
+        .chunk_map
+        .schedule_generation_task_b(target_status, neighbor);
+    assert!(Arc::ptr_eq(task.cache.get(pinned.0.x, pinned.0.y), &holder));
+
+    task.cancel();
+    assert_snapshot_discarded(preparation);
 }
 
 #[test]
@@ -182,7 +185,7 @@ fn final_full_chunk_unload_finalizes_chunk_owned_tick_queues() {
     world.chunk_map.rebuild_ticking_chunk_snapshot();
     drop(holder);
     let _runtime_guard = world.chunk_map.chunk_runtime.enter();
-    world.chunk_map.process_unloads(&FxHashSet::default());
+    world.chunk_map.process_unloads();
 
     assert!(!world.chunk_map.unloading_chunks.contains_sync(&chunk_pos));
     assert!(!world.has_registered_full_chunk_ticks(chunk_pos));

--- a/steel-core/src/chunk_saver/storage/chunk.rs
+++ b/steel-core/src/chunk_saver/storage/chunk.rs
@@ -263,11 +263,17 @@ impl ChunkStorage {
     }
 
     /// Converts a runtime section to persistent format.
+    ///
+    /// `Building` sections are finalized under the same write guard that serializes them, since
+    /// worldgen re-enters `Building` on every column write.
     pub(super) fn section_to_persistent(
         section: &SectionHolder,
         builder: &mut ChunkBuilder,
     ) -> PersistentSection {
-        let section = section.read();
+        let mut section = section.write();
+        if matches!(&section.states, PalettedContainer::Building(_)) {
+            section.recalculate_counts();
+        }
         let biomes = Self::biomes_to_persistent(&section.biomes, builder);
 
         match &section.states {
@@ -311,9 +317,8 @@ impl ChunkStorage {
                     biomes,
                 }
             }
-            PalettedContainer::Building(_) => panic!(
-                "section_to_persistent called on a section still in worldgen Building mode; \
-                 finalize_building must be called before serialization"
+            PalettedContainer::Building(_) => unreachable!(
+                "recalculate_counts finalizes Building sections under this same write guard"
             ),
         }
     }

--- a/steel-core/src/chunk_saver/storage/mod.rs
+++ b/steel-core/src/chunk_saver/storage/mod.rs
@@ -553,9 +553,12 @@ impl ChunkStorage {
     /// Call this during the holder's snapshot-preparation phase, then pass the result to
     /// `save_chunk_data` after ending that phase.
     ///
+    /// Returns `None` when there is nothing to write, or when a revival promoted the chunk after
+    /// `status` was captured; callers then leave the chunk dirty for a later save.
+    ///
     /// # Panics
     ///
-    /// Panics if `status` does not match whether Full runtime state is initialized.
+    /// Panics if `status` is Full but the chunk has no Full runtime state.
     #[must_use]
     #[expect(
         clippy::similar_names,
@@ -571,25 +574,21 @@ impl ChunkStorage {
         runtime_entities: &[SharedEntity],
         force: bool,
     ) -> Option<PreparedChunkSave> {
-        assert_eq!(
-            status == ChunkStatus::Full,
-            chunk.full_runtime().is_some(),
-            "persisted chunk status must match its Full runtime state"
+        let has_full_runtime = chunk.full_runtime().is_some();
+        assert!(
+            status != ChunkStatus::Full || has_full_runtime,
+            "a chunk persisted as Full must have its Full runtime state initialized"
         );
-        if !force && !chunk.is_dirty() {
+        if status != ChunkStatus::Full && has_full_runtime {
+            tracing::debug!(
+                chunk = ?chunk.pos(),
+                ?status,
+                "Abandoning chunk save preparation: the chunk was promoted while it was snapshotted"
+            );
             return None;
         }
-
-        // Finalize any sections still in worldgen Building mode. Proto chunks
-        // can be saved before being upgraded by `Chunk::promote_to_full`
-        // (which is where `recalculate_counts` normally runs and implicitly
-        // finalizes). Without this, `section_to_persistent` would panic on
-        // the Building variant.
-        for section_holder in &chunk.sections().sections {
-            let mut guard = section_holder.write();
-            if matches!(&guard.states, PalettedContainer::Building(_)) {
-                guard.recalculate_counts();
-            }
+        if !force && !chunk.is_dirty() {
+            return None;
         }
 
         let pos = chunk.pos();
@@ -653,7 +652,13 @@ impl ChunkStorage {
             // Proto ticks are pending, so Vanilla ignores the current game
             // time when serializing their already-relative delays.
             let Some(snapshot) = chunk.scheduled_ticks.snapshot(0) else {
-                panic!("Proto chunk scheduled-tick container was finalized before saving");
+                // Promotion to Full closes the proto container.
+                tracing::debug!(
+                    chunk = ?pos,
+                    "Abandoning chunk save preparation: the proto scheduled-tick container was \
+                     finalized while the chunk was snapshotted"
+                );
+                return None;
             };
             let bt = Self::block_ticks_to_persistent(snapshot.block, pos);
             let ft = Self::fluid_ticks_to_persistent(snapshot.fluid, pos);

--- a/steel-core/src/chunk_saver/storage/tests/chunks_sections.rs
+++ b/steel-core/src/chunk_saver/storage/tests/chunks_sections.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-#[should_panic(expected = "persisted chunk status must match its Full runtime state")]
+#[should_panic(expected = "a chunk persisted as Full must have its Full runtime state initialized")]
 fn chunk_save_rejects_full_status_for_proto_data() {
     init_vanilla_registry();
 
@@ -13,6 +13,25 @@ fn chunk_save_rejects_full_status_for_proto_data() {
         Weak::new(),
     );
     let _ = ChunkStorage::prepare_chunk_save(&chunk, ChunkStatus::Full, &[], true);
+}
+
+#[test]
+fn chunk_save_abandons_a_proto_status_snapshot_of_a_promoted_chunk() {
+    init_vanilla_registry();
+
+    let chunk = Chunk::new(
+        single_empty_section(),
+        ChunkPos::new(0, 0),
+        0,
+        16,
+        Weak::new(),
+    );
+    let _ = chunk.promote_to_full();
+
+    assert!(
+        ChunkStorage::prepare_chunk_save(&chunk, ChunkStatus::Biomes, &[], true).is_none(),
+        "a proto-status snapshot of a promoted chunk must be abandoned"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

Fixes #561 

fixes the fatal `chunk-worker` panic players hit, introduced by #307

`ChunkGenerationTask::new` needs a holder in `ChunkMap::chunks` for every position in its dependency radius. reviving an unloading holder used a CAS that only accepted `SAVE_LIFECYCLE_UNLOADING`, so it failed while a save snapshot held `SAVE_LIFECYCLE_PREPARING`. the revival got parked in `deferred_revivals`, leaving a position with a ticket level and no holder for a full epoch. neighbours revived in the same commit were scheduled against that hole

dying is a wide net for the race: `Player::tick_death` drops the whole player-view ticket 20 ticks after death, those chunks are freshly dirty from the item drops, so a save spawns for each one just before the ticket returns

the fix is vanilla's: revival always wins, and the in-flight save discovers it lost. `revive_from_unloading` is infallible now, `ChunkSavePreparationGuard::finish` hands the snapshot back only if the phase still owned the holder, and `deferred_revivals` is deleted. since revival can now win, `prepare_chunk_save` treats "promoted underneath the snapshot" as an abandon rather than a panic

## How this was tested

- `cargo test`: full workspace green, 0 failures
- `cargo clippy -r --all-targets --all-features` and `cargo fmt --all --check`: clean
- the regression test is falsified. `revival_during_save_preparation_keeps_the_generation_neighborhood_complete` pins a holder in `PREPARING`, revives it, then schedules a generation task over its neighbourhood. i temporarily reinstated the old deferral and it reproduced the exact panic at `chunk_generation_task.rs:157`. reverted, re-ran green
- three more tests cover the lifecycle and the new abandon path: `revival_wins_over_an_in_flight_save_preparation`, `an_uncontested_save_preparation_keeps_its_snapshot`, `chunk_save_abandons_a_proto_status_snapshot_of_a_promoted_chunk`

i died 20+ times without `keepInventory` in loaded terrain and no `chunk-worker` panic

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

`ChunkHolder`, `ChunkGenerationTask`, `ChunkMap`, `ChunkStorage`

## Additional notes

two pre-existing things found along the way, both left alone

1. `Arc::strong_count` is the wrong unload gate. `process_unloads` skips the save and unload whenever `Arc::strong_count(holder) != 1`. that means "nobody anywhere holds an Arc", not "generation depends on this". the gameplay lookup cache, light workset and ticking snapshot all clone holder Arcs, so any of them lingering delays an unload for unrelated reasons. vanilla uses an explicit `generationRefCount` registered as a save dependency. steel already has that in `ChunkSaveDependency` / `active_save_dependencies`, `process_unloads` just doesn't consult it. worth its own PR. note `ChunkSavePreparationGuard`'s doc currently leans on the strong-count gate to rule out a stale guard releasing a second phase, so that changes with it
2. POI data is dropped before the save reads it. `begin_chunk_unload` calls `poi_storage.remove_chunk(pos)` before the save runs, so `pois_to_persistent` always writes an empty POI list on unload and loses `free_tickets`. vanilla's `ChunkMap.save` calls `poiManager.flush(pos)` first
