### PR TITLE
[BUGFIX] Prevent swords from breaking blocks in creative

### DIFF
--- a/steel-core/src/player/game_mode/block_breaking.rs
+++ b/steel-core/src/player/game_mode/block_breaking.rs
@@ -342,6 +342,20 @@ impl BlockBreakingManager {
     fn destroy_block(&self, player: &Player, world: &Arc<World>, pos: BlockPos) -> bool {
         let state = world.get_block_state(pos);
 
+        // Vanilla `Item.canDestroyBlockInCreative` — swords and similar tools must
+        // not remove blocks in Creative on a single click.
+        if player.game_mode() == GameType::Creative {
+            let can_destroy = {
+                let inventory = player.inventory.lock();
+                inventory
+                    .get_item_in_hand(InteractionHand::MainHand)
+                    .can_destroy_blocks_in_creative()
+            };
+            if !can_destroy {
+                return false;
+            }
+        }
+
         // Check if player's tool can destroy this block
         // TODO: Implement canDestroyBlock check for adventure mode
 
@@ -501,9 +515,15 @@ fn get_destroy_progress(player: &Player, block_state: BlockStateId) -> f32 {
 
     let destroy_time = block.config.destroy_time;
 
-    // Instant break for creative
+    // Instant break for creative when the held tool allows it
     if player.game_mode() == GameType::Creative {
-        return 1.0;
+        let can_destroy = {
+            let inventory = player.inventory.lock();
+            inventory
+                .get_item_in_hand(InteractionHand::MainHand)
+                .can_destroy_blocks_in_creative()
+        };
+        return if can_destroy { 1.0 } else { 0.0 };
     }
 
     // Unbreakable block

--- a/steel-core/src/player/tests.rs
+++ b/steel-core/src/player/tests.rs
@@ -1370,6 +1370,69 @@ fn block_action_restriction_precedes_redstone_ore_attack() {
 }
 
 #[test]
+fn creative_sword_does_not_break_blocks() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("creative_sword_no_break");
+    let pos = BlockPos::new(1, 64, 0);
+    insert_ready_full_chunk(&world, ChunkPos::from_block_pos(pos));
+    let stone = vanilla_blocks::STONE.default_state();
+    assert!(world.set_block(pos, stone, UpdateFlags::UPDATE_ALL));
+
+    let player = test_player(Arc::clone(&world));
+    player.base.set_position_local(DVec3::new(1.0, 64.0, 0.0));
+    player.restore_game_modes(GameType::Creative, None);
+    player.abilities.lock().update_for_game_mode(GameType::Creative);
+    player
+        .inventory
+        .lock()
+        .set_selected_item(ItemStack::new(&vanilla_items::WOODEN_SWORD));
+
+    player.block_breaking.lock().handle_block_break_action(
+        &player,
+        &world,
+        pos,
+        BlockBreakAction::Start,
+        Direction::Up,
+    );
+
+    assert_eq!(world.get_block_state(pos), stone);
+}
+
+#[test]
+fn creative_pickaxe_still_breaks_blocks() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("creative_pickaxe_breaks");
+    let pos = BlockPos::new(1, 64, 0);
+    insert_ready_full_chunk(&world, ChunkPos::from_block_pos(pos));
+    assert!(world.set_block(
+        pos,
+        vanilla_blocks::STONE.default_state(),
+        UpdateFlags::UPDATE_ALL,
+    ));
+
+    let player = test_player(Arc::clone(&world));
+    player.base.set_position_local(DVec3::new(1.0, 64.0, 0.0));
+    player.restore_game_modes(GameType::Creative, None);
+    player.abilities.lock().update_for_game_mode(GameType::Creative);
+    player
+        .inventory
+        .lock()
+        .set_selected_item(ItemStack::new(&vanilla_items::DIAMOND_PICKAXE));
+
+    player.block_breaking.lock().handle_block_break_action(
+        &player,
+        &world,
+        pos,
+        BlockBreakAction::Start,
+        Direction::Up,
+    );
+
+    assert!(world.get_block_state(pos).is_air());
+}
+
+#[test]
 fn extra_items_created_on_use_fill_inventory_when_there_is_room() {
     init_vanilla_registry();
     let world = fresh_test_world("extra_items_created_on_use_has_room");


### PR DESCRIPTION
## Summary
- Creative destroy now checks `can_destroy_blocks_in_creative` on the main-hand stack before removing the block.
- Creative destroy progress returns 0 when the held tool forbids breaking.
- Regression tests for wooden sword (no break) and diamond pickaxe (still breaks).

Closes Steel-Foundation/SteelMC#534

## Test plan
- [x] `cargo test -p steel-core --lib creative_sword_does_not_break_blocks`
- [x] `cargo test -p steel-core --lib creative_pickaxe_still_breaks_blocks`