### PR TITLE
[BUGFIX] Active item use must not overwrite replaced hand stacks

### DIFF
--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -414,32 +414,62 @@ impl Player {
             return;
         };
         let hand = active.hand();
-        let item_matches = {
-            let inventory = self.inventory.lock();
-            inventory.get_item_in_hand(hand).item() == active.item()
-        };
-        if !item_matches {
-            self.stop_using_item();
-            return;
-        }
         let mut item = {
             let inventory = self.inventory.lock();
             let current = inventory.get_item_in_hand(hand);
+            if current.item() != active.item() {
+                drop(inventory);
+                self.stop_using_item();
+                return;
+            }
             current.copy_with_count(current.count())
         };
+        let item_before_tick = item.clone();
         let world = self.get_world();
         let behavior = ITEM_BEHAVIORS.get_behavior(item.item());
         behavior.on_use_tick(&world, self, &mut item, active.remaining_ticks());
 
         if self.active_item_use_hand() != Some(hand) {
-            self.inventory.lock().set_item_in_hand(hand, item);
+            // Active use ended during the callback. Write local mutations only when the
+            // hand still holds the pre-tick stack so #411's remainder path stays intact.
+            let mut inventory = self.inventory.lock();
+            if ItemStack::matches(inventory.get_item_in_hand(hand), &item_before_tick) {
+                inventory.set_item_in_hand(hand, item);
+            }
             return;
         }
+
+        {
+            let inventory = self.inventory.lock();
+            let current = inventory.get_item_in_hand(hand);
+            if !ItemStack::matches(current, &item_before_tick) {
+                // `on_use_tick` (or something it called) replaced the held stack.
+                // Keep that stack instead of overwriting it with the local copy.
+                if current.item() != active.item() {
+                    drop(inventory);
+                    self.stop_using_item();
+                }
+                return;
+            }
+        }
+
         let Some(active) = self.living_base.decrement_active_item_use() else {
             self.inventory.lock().set_item_in_hand(hand, item);
             return;
         };
         if active.remaining_ticks() <= 0 {
+            // Vanilla re-checks the full stack before finishUsingItem.
+            let still_same_stack = {
+                let inventory = self.inventory.lock();
+                ItemStack::is_same_item_same_components(
+                    inventory.get_item_in_hand(hand),
+                    &item_before_tick,
+                )
+            };
+            if !still_same_stack {
+                self.stop_using_item();
+                return;
+            }
             let stack_before_finish = item.clone();
             item = behavior.finish_using(&mut item, &world, self);
             self.apply_item_use_cooldown(&stack_before_finish);

--- a/steel-core/src/player/tests.rs
+++ b/steel-core/src/player/tests.rs
@@ -1472,6 +1472,43 @@ fn drinking_honey_bottle_from_full_inventory_drops_the_remainder_through_the_tic
 }
 
 #[test]
+fn active_item_use_does_not_overwrite_hand_replaced_during_tick() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("active_item_use_no_overwrite_replaced_hand");
+    insert_ready_full_chunk(&world, ChunkPos::new(0, 0));
+    let player = test_player(Arc::clone(&world));
+
+    player
+        .inventory
+        .lock()
+        .set_selected_item(ItemStack::with_count(&vanilla_items::HONEY_BOTTLE, 5));
+    player.start_using_item(InteractionHand::MainHand);
+
+    player.tick_active_item_use();
+    assert!(player.active_item_use_hand().is_some());
+
+    let replacement = ItemStack::new(&vanilla_items::DIAMOND);
+    player
+        .inventory
+        .lock()
+        .set_selected_item(replacement.clone());
+
+    player.tick_active_item_use();
+
+    let hand_item = player
+        .inventory
+        .lock()
+        .get_item_in_hand(InteractionHand::MainHand)
+        .clone();
+    assert!(
+        ItemStack::matches(&hand_item, &replacement),
+        "active-use tick must not restore the pre-replacement stack"
+    );
+    assert!(player.active_item_use_hand().is_none());
+}
+
+#[test]
 fn throttle_player_dropping_items_from_creative_menu() {
     const DROPS_ALLOWED_BEFORE_THROTTLE: i32 =
         DROP_SPAM_THROTTLER_THRESHOLD / DROP_SPAM_THROTTLER_INCREMENT_STEP;


### PR DESCRIPTION
## Summary
- After `on_use_tick`, keep a hand stack that no longer matches the pre-tick snapshot instead of overwriting it.
- Re-check same-item/same-components before `finish_using`.
- Preserve the #411 honey-bottle remainder path when active use ends during the callback and the hand is unchanged.

Closes Steel-Foundation/SteelMC#529

## Test plan
- [x] `cargo test -p steel-core --lib active_item_use_does_not_overwrite`
- [x] `cargo test -p steel-core --lib drinking_honey_bottle_from_full`