### PR TITLE
Disconnect clients when Login/Config packet decode fails

### DIFF
--- a/steel-login/src/tcp_client.rs
+++ b/steel-login/src/tcp_client.rs
@@ -523,7 +523,8 @@ impl JavaTcpClient {
                                 }
                             }
                             LoginOperationResult::Completed(Err(err)) => {
-                                log::warn!("Failed to get packet from client {id}: {err}");
+                                self_clone.reject_packet_decode_error(&err).await;
+                                break;
                             }
                             LoginOperationResult::Cancelled => break,
                             LoginOperationResult::TimedOut => {
@@ -794,6 +795,17 @@ impl JavaTcpClient {
         ))
         .await;
         ConnectionAction::none()
+    }
+
+    /// Fail-closed path for codec/decode errors while reading Login/Config packets.
+    ///
+    /// Vanilla disconnects on any unhandled pipeline exception; Steel previously only logged.
+    pub(crate) async fn reject_packet_decode_error(&self, error: &PacketError) {
+        log::warn!("Failed to get packet from client {}: {error}", self.id);
+        self.kick(TextComponent::translated(
+            translations::MULTIPLAYER_DISCONNECT_INVALID_PACKET.msg(),
+        ))
+        .await;
     }
 
     /// Kicks the client with a given reason.


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

Follow-up to #527 / the known-packs bound work.

Today if `process_packet` returns `PacketError` (decode blow-up, unexpected packet id in that state, etc.) we only `log::warn!` and keep reading. Client stays connected but stuck. Vanilla tears the connection down from `Connection.exceptionCaught`.

This kicks with `multiplayer.disconnect.invalid_packet` and breaks the incoming loop, same idea as `reject_unexpected_packet` for sequence mistakes.

Wrong packet *order* was already handled. This covers the Err path from reading the packet itself.

Closes #527

## How this was tested

- `cargo check -p steel-login`
- `cargo test -p steel-login --lib` (20 passed)
- Re-read `start_incoming_packet_task` / `handle_login` / `handle_config`: sequence failures still go through `reject_unexpected_packet`; this only changes the `PacketError` arm.

No live azalea repro on my side this time (the oversized known-packs case from #394). Happy to run that if you want it before merge.

## Screenshots / logs

N/A

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

N/A (login TCP path only)

## Additional notes

@JunkyDeveloper on packages: yes — this is not about datapacks/resources being “installed”. Known-pack *negotiation that decodes fine* is unchanged. What hits this path is `PacketError` from the codec / unexpected id (e.g. `SSelectKnownPacks` with >64 entries failing `read_packet`). Corrupt or oversize framing ends up here; a normal client with a valid packs list does not.