### PR TITLE
Enforce max_players when reserving player joins

### DIFF
--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -360,7 +360,9 @@ use permissions::validate_player_permission_group_update;
 mod player_admission;
 mod player_lifecycle;
 
-pub use player_admission::{DuplicatePlayerWaitError, PlayerJoinReservation};
+pub use player_admission::{
+    DuplicatePlayerWaitError, PlayerJoinReservation, PlayerJoinReserveError,
+};
 use player_admission::{PlayerAdmissionState, PlayerDisconnectQueue, PlayerJoinQueue};
 
 mod world_changes;

--- a/steel-core/src/server/player_admission.rs
+++ b/steel-core/src/server/player_admission.rs
@@ -39,10 +39,8 @@ pub enum DuplicatePlayerWaitError {
 /// Why [`Server::try_reserve_player_join`] refused a new join reservation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum PlayerJoinReserveError {
-    /// Another admission or online session already owns this UUID.
     #[error("player UUID is already joining or online")]
     Duplicate,
-    /// Online players plus in-flight join reservations already fill `max_players`.
     #[error("server is full")]
     ServerFull,
 }
@@ -347,8 +345,6 @@ impl Server {
     }
 
     /// True when online players plus in-flight `Joining` reservations fill `max_players`.
-    ///
-    /// Caller must hold `player_admissions`.
     fn join_slots_full(&self, admissions: &FxHashMap<Uuid, PlayerAdmissionState>) -> bool {
         let joining = admissions
             .values()

--- a/steel-core/src/server/player_admission.rs
+++ b/steel-core/src/server/player_admission.rs
@@ -36,6 +36,17 @@ pub enum DuplicatePlayerWaitError {
     TimedOut,
 }
 
+/// Why [`Server::try_reserve_player_join`] refused a new join reservation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum PlayerJoinReserveError {
+    /// Another admission or online session already owns this UUID.
+    #[error("player UUID is already joining or online")]
+    Duplicate,
+    /// Online players plus in-flight join reservations already fill `max_players`.
+    #[error("server is full")]
+    ServerFull,
+}
+
 /// Exclusive ownership of one UUID's pending join pipeline.
 ///
 /// Dropping an unconsumed reservation releases the UUID immediately.
@@ -195,9 +206,16 @@ impl Server {
         if player.connection.closed() {
             return;
         }
-        let Some(reservation) = self.try_reserve_player_join(player.gameprofile.id) else {
-            player.disconnect(translations::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN.msg());
-            return;
+        let reservation = match self.try_reserve_player_join(player.gameprofile.id) {
+            Ok(reservation) => reservation,
+            Err(PlayerJoinReserveError::Duplicate) => {
+                player.disconnect(translations::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN.msg());
+                return;
+            }
+            Err(PlayerJoinReserveError::ServerFull) => {
+                player.disconnect(translations::MULTIPLAYER_DISCONNECT_SERVER_FULL.msg());
+                return;
+            }
         };
 
         reservation.queue_player_join(player);
@@ -301,17 +319,34 @@ impl Server {
     }
 
     /// Atomically reserves a UUID after configuration's duplicate-session recheck.
-    pub fn try_reserve_player_join(self: &Arc<Self>, uuid: Uuid) -> Option<PlayerJoinReservation> {
+    ///
+    /// Slot accounting holds the admissions lock and counts online players plus
+    /// in-flight [`PlayerAdmissionState::Joining`] reservations. Operators may
+    /// bypass the `max_players` cap (vanilla `canBypassPlayerLimit`).
+    pub fn try_reserve_player_join(
+        self: &Arc<Self>,
+        uuid: Uuid,
+    ) -> Result<PlayerJoinReservation, PlayerJoinReserveError> {
         let mut admissions = self.player_admissions.lock();
         if admissions.contains_key(&uuid) {
-            return None;
+            return Err(PlayerJoinReserveError::Duplicate);
         }
         if self.online_players.get_by_uuid(&uuid).is_some() {
-            return None;
+            return Err(PlayerJoinReserveError::Duplicate);
+        }
+        if !self.is_operator(uuid) {
+            let joining = admissions
+                .values()
+                .filter(|state| **state == PlayerAdmissionState::Joining)
+                .count();
+            let occupied = self.online_players.len().saturating_add(joining);
+            if occupied >= self.config.max_players as usize {
+                return Err(PlayerJoinReserveError::ServerFull);
+            }
         }
         let previous = admissions.insert(uuid, PlayerAdmissionState::Joining);
         debug_assert!(previous.is_none());
-        Some(PlayerJoinReservation {
+        Ok(PlayerJoinReservation {
             server: Arc::clone(self),
             uuid,
             queued: false,
@@ -324,6 +359,16 @@ impl Server {
         let mut admissions = self.player_admissions.lock();
         if admissions.contains_key(&uuid) || self.online_players.get_by_uuid(&uuid).is_some() {
             return false;
+        }
+        if !self.is_operator(uuid) {
+            let joining = admissions
+                .values()
+                .filter(|state| **state == PlayerAdmissionState::Joining)
+                .count();
+            let occupied = self.online_players.len().saturating_add(joining);
+            if occupied >= self.config.max_players as usize {
+                return false;
+            }
         }
         admissions
             .insert(uuid, PlayerAdmissionState::Joining)

--- a/steel-core/src/server/player_admission.rs
+++ b/steel-core/src/server/player_admission.rs
@@ -354,10 +354,7 @@ impl Server {
             .values()
             .filter(|state| **state == PlayerAdmissionState::Joining)
             .count();
-        self.online_players
-            .len()
-            .saturating_add(joining)
-            >= self.config.max_players as usize
+        self.online_players.len().saturating_add(joining) >= self.config.max_players as usize
     }
 
     #[cfg(test)]

--- a/steel-core/src/server/player_admission.rs
+++ b/steel-core/src/server/player_admission.rs
@@ -2,7 +2,7 @@ use steel_utils::translations;
 
 use super::{
     Arc, CPlayerInfoUpdate, CRemovePlayerInfo, CancellationToken, ClientPacket, ConnectionProtocol,
-    DomainPlayerState, EncodedPacket, Entity, GlobalPlayerData, Instant, JoinSet,
+    DomainPlayerState, EncodedPacket, Entity, FxHashMap, GlobalPlayerData, Instant, JoinSet,
     NetworkConnection, PendingWorldChangeToken, PersistentPlayerData, Player, ResetReason,
     SegQueue, Server, SyncMutex, Uuid, mpsc,
 };
@@ -318,11 +318,11 @@ impl Server {
         }
     }
 
-    /// Atomically reserves a UUID after configuration's duplicate-session recheck.
+    /// Reserves a UUID for join after the config-phase duplicate recheck.
     ///
-    /// Slot accounting holds the admissions lock and counts online players plus
-    /// in-flight [`PlayerAdmissionState::Joining`] reservations. Operators may
-    /// bypass the `max_players` cap (vanilla `canBypassPlayerLimit`).
+    /// Under the admissions lock: reject if the UUID is busy; otherwise count
+    /// online players + `Joining` slots against `max_players`. Ops bypass the cap
+    /// (`canBypassPlayerLimit`).
     pub fn try_reserve_player_join(
         self: &Arc<Self>,
         uuid: Uuid,
@@ -334,15 +334,8 @@ impl Server {
         if self.online_players.get_by_uuid(&uuid).is_some() {
             return Err(PlayerJoinReserveError::Duplicate);
         }
-        if !self.is_operator(uuid) {
-            let joining = admissions
-                .values()
-                .filter(|state| **state == PlayerAdmissionState::Joining)
-                .count();
-            let occupied = self.online_players.len().saturating_add(joining);
-            if occupied >= self.config.max_players as usize {
-                return Err(PlayerJoinReserveError::ServerFull);
-            }
+        if !self.is_operator(uuid) && self.join_slots_full(&admissions) {
+            return Err(PlayerJoinReserveError::ServerFull);
         }
         let previous = admissions.insert(uuid, PlayerAdmissionState::Joining);
         debug_assert!(previous.is_none());
@@ -353,6 +346,20 @@ impl Server {
         })
     }
 
+    /// True when online players plus in-flight `Joining` reservations fill `max_players`.
+    ///
+    /// Caller must hold `player_admissions`.
+    fn join_slots_full(&self, admissions: &FxHashMap<Uuid, PlayerAdmissionState>) -> bool {
+        let joining = admissions
+            .values()
+            .filter(|state| **state == PlayerAdmissionState::Joining)
+            .count();
+        self.online_players
+            .len()
+            .saturating_add(joining)
+            >= self.config.max_players as usize
+    }
+
     #[cfg(test)]
     pub(super) fn reserve_player_join(&self, player: &Player) -> bool {
         let uuid = player.gameprofile.id;
@@ -360,15 +367,8 @@ impl Server {
         if admissions.contains_key(&uuid) || self.online_players.get_by_uuid(&uuid).is_some() {
             return false;
         }
-        if !self.is_operator(uuid) {
-            let joining = admissions
-                .values()
-                .filter(|state| **state == PlayerAdmissionState::Joining)
-                .count();
-            let occupied = self.online_players.len().saturating_add(joining);
-            if occupied >= self.config.max_players as usize {
-                return false;
-            }
+        if !self.is_operator(uuid) && self.join_slots_full(&admissions) {
+            return false;
         }
         admissions
             .insert(uuid, PlayerAdmissionState::Joining)

--- a/steel-core/src/server/player_admission.rs
+++ b/steel-core/src/server/player_admission.rs
@@ -39,8 +39,10 @@ pub enum DuplicatePlayerWaitError {
 /// Why [`Server::try_reserve_player_join`] refused a new join reservation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum PlayerJoinReserveError {
+    /// UUID already has a join admission or an online session.
     #[error("player UUID is already joining or online")]
     Duplicate,
+    /// Online + in-flight `Joining` reservations already fill `max_players`.
     #[error("server is full")]
     ServerFull,
 }

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -143,8 +143,12 @@ impl NetworkConnection for RecordingConnection {
 }
 
 fn test_runtime_config() -> Arc<RuntimeConfig> {
+    test_runtime_config_with_max_players(20)
+}
+
+fn test_runtime_config_with_max_players(max_players: u32) -> Arc<RuntimeConfig> {
     Arc::new(RuntimeConfig {
-        max_players: 1,
+        max_players,
         view_distance: 2,
         simulation_distance: 2,
         max_chained_neighbor_updates: 1_000_000,
@@ -195,12 +199,53 @@ async fn test_server(
     .await
 }
 
+async fn test_server_with_max_players(
+    world: Arc<World>,
+    player_permission_states: PermissionSubjectIndex,
+    storage_root: &Path,
+    max_players: u32,
+) -> Result<Arc<Server>, String> {
+    let domain = ResolvedDomainConfig {
+        name: world.domain().to_owned(),
+        default_world: world.key.clone(),
+        worlds: vec![world.key.clone()],
+    };
+    test_server_with_worlds_config(
+        domain.name.clone(),
+        slice::from_ref(&domain),
+        slice::from_ref(&world),
+        player_permission_states,
+        storage_root,
+        test_runtime_config_with_max_players(max_players),
+    )
+    .await
+}
+
 async fn test_server_with_worlds(
     default_domain: String,
     domains: &[ResolvedDomainConfig],
     loaded_worlds: &[Arc<World>],
     player_permission_states: PermissionSubjectIndex,
     storage_root: &Path,
+) -> Result<Arc<Server>, String> {
+    test_server_with_worlds_config(
+        default_domain,
+        domains,
+        loaded_worlds,
+        player_permission_states,
+        storage_root,
+        test_runtime_config(),
+    )
+    .await
+}
+
+async fn test_server_with_worlds_config(
+    default_domain: String,
+    domains: &[ResolvedDomainConfig],
+    loaded_worlds: &[Arc<World>],
+    player_permission_states: PermissionSubjectIndex,
+    storage_root: &Path,
+    config: Arc<RuntimeConfig>,
 ) -> Result<Arc<Server>, String> {
     let mut worlds = WorldMap::new(default_domain, domains, &[]);
     for world in loaded_worlds {
@@ -227,7 +272,6 @@ async fn test_server_with_worlds(
         .collect();
     let permission_groups = PermissionGroupManager::transient(PermissionGroupsConfig::default())
         .map_err(|error| format!("test permission groups should resolve: {error}"))?;
-    let config = test_runtime_config();
     let registry_cache = RegistryCache::new(config.compression);
 
     Ok(Arc::new(Server {

--- a/steel-core/src/server/tests/connection_lifecycle.rs
+++ b/steel-core/src/server/tests/connection_lifecycle.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use crate::{
     player::connection::{JavaConnection, JavaNetworkWriter, NetworkConnection, OutboundPacket},
     player::{ClientInformation, GameProfile, Player, PlayerConnection},
-    server::DuplicatePlayerWaitError,
+    server::{DuplicatePlayerWaitError, PlayerJoinReserveError},
     world::World,
 };
 
@@ -28,7 +28,6 @@ use super::{
     test_storage_root,
 };
 use crate::permission::{OP_GROUP, PermissionSet, PermissionSubjectIndex, PermissionSubjectState};
-use crate::server::PlayerJoinReserveError;
 
 fn java_test_player(
     server: &Arc<Server>,
@@ -257,7 +256,7 @@ fn duplicate_login_evicts_relocating_player_and_waits_for_disconnect_admission_r
         };
         assert!(matches!(
             server.try_reserve_player_join(uuid),
-            Err(crate::server::PlayerJoinReserveError::Duplicate)
+            Err(PlayerJoinReserveError::Duplicate)
         ));
         drop(first_reservation);
         let second_reservation = server.try_reserve_player_join(uuid);

--- a/steel-core/src/server/tests/connection_lifecycle.rs
+++ b/steel-core/src/server/tests/connection_lifecycle.rs
@@ -23,7 +23,12 @@ use crate::{
     world::World,
 };
 
-use super::{PlayerAdmissionState, Server, fresh_test_world, test_server, test_storage_root};
+use super::{
+    PlayerAdmissionState, Server, fresh_test_world, test_server, test_server_with_max_players,
+    test_storage_root,
+};
+use crate::permission::{OP_GROUP, PermissionSet, PermissionSubjectIndex, PermissionSubjectState};
+use crate::server::PlayerJoinReserveError;
 
 fn java_test_player(
     server: &Arc<Server>,
@@ -247,13 +252,16 @@ fn duplicate_login_evicts_relocating_player_and_waits_for_disconnect_admission_r
         };
 
         let first_reservation = server.try_reserve_player_join(uuid);
-        let Some(first_reservation) = first_reservation else {
+        let Ok(first_reservation) = first_reservation else {
             panic!("configuration should reserve the released UUID");
         };
-        assert!(server.try_reserve_player_join(uuid).is_none());
+        assert!(matches!(
+            server.try_reserve_player_join(uuid),
+            Err(crate::server::PlayerJoinReserveError::Duplicate)
+        ));
         drop(first_reservation);
         let second_reservation = server.try_reserve_player_join(uuid);
-        assert!(second_reservation.is_some());
+        assert!(second_reservation.is_ok());
         drop(second_reservation);
 
         drop(pending);
@@ -341,6 +349,120 @@ fn duplicate_login_wait_matches_vanillas_deadline_ordering() {
             ));
         }
 
+        drop(server);
+        if let Err(error) = fs::remove_dir_all(&storage_root).await {
+            panic!("test storage should be removed: {error}");
+        }
+    });
+}
+
+#[test]
+fn max_players_rejects_join_when_online_slots_are_full() {
+    let world = fresh_test_world("max_players_online_full");
+    let runtime = Builder::new_current_thread().enable_all().build();
+    let Ok(runtime) = runtime else {
+        panic!("test runtime should initialize");
+    };
+
+    runtime.block_on(async {
+        let storage_root = test_storage_root("max-players-online-full");
+        let server = test_server_with_max_players(
+            Arc::clone(&world),
+            PermissionSubjectIndex::new(),
+            &storage_root,
+            1,
+        )
+        .await;
+        let Ok(server) = server else {
+            panic!("test server should initialize");
+        };
+
+        let (online, _, _) = java_test_player(&server, Arc::clone(&world), Uuid::from_u128(1));
+        assert!(server.online_players.insert(Arc::clone(&online)));
+
+        assert!(matches!(
+            server.try_reserve_player_join(Uuid::from_u128(2)),
+            Err(PlayerJoinReserveError::ServerFull)
+        ));
+
+        drop(online);
+        drop(server);
+        if let Err(error) = fs::remove_dir_all(&storage_root).await {
+            panic!("test storage should be removed: {error}");
+        }
+    });
+}
+
+#[test]
+fn max_players_counts_joining_reservations_as_occupied_slots() {
+    let world = fresh_test_world("max_players_joining_slot");
+    let runtime = Builder::new_current_thread().enable_all().build();
+    let Ok(runtime) = runtime else {
+        panic!("test runtime should initialize");
+    };
+
+    runtime.block_on(async {
+        let storage_root = test_storage_root("max-players-joining-slot");
+        let server = test_server_with_max_players(
+            Arc::clone(&world),
+            PermissionSubjectIndex::new(),
+            &storage_root,
+            1,
+        )
+        .await;
+        let Ok(server) = server else {
+            panic!("test server should initialize");
+        };
+
+        let reservation = server
+            .try_reserve_player_join(Uuid::from_u128(1))
+            .expect("first join should reserve the only slot");
+        assert!(matches!(
+            server.try_reserve_player_join(Uuid::from_u128(2)),
+            Err(PlayerJoinReserveError::ServerFull)
+        ));
+        drop(reservation);
+        assert!(server.try_reserve_player_join(Uuid::from_u128(2)).is_ok());
+
+        drop(server);
+        if let Err(error) = fs::remove_dir_all(&storage_root).await {
+            panic!("test storage should be removed: {error}");
+        }
+    });
+}
+
+#[test]
+fn max_players_allows_operator_bypass() {
+    let world = fresh_test_world("max_players_op_bypass");
+    let runtime = Builder::new_current_thread().enable_all().build();
+    let Ok(runtime) = runtime else {
+        panic!("test runtime should initialize");
+    };
+
+    runtime.block_on(async {
+        let storage_root = test_storage_root("max-players-op-bypass");
+        let op_uuid = Uuid::from_u128(99);
+        let mut permissions = PermissionSubjectIndex::new();
+        permissions.set(
+            op_uuid,
+            PermissionSubjectState::new(vec![OP_GROUP.to_owned()], PermissionSet::new()),
+        );
+        let server =
+            test_server_with_max_players(Arc::clone(&world), permissions, &storage_root, 1).await;
+        let Ok(server) = server else {
+            panic!("test server should initialize");
+        };
+
+        let (online, _, _) = java_test_player(&server, Arc::clone(&world), Uuid::from_u128(1));
+        assert!(server.online_players.insert(Arc::clone(&online)));
+
+        assert!(matches!(
+            server.try_reserve_player_join(Uuid::from_u128(2)),
+            Err(PlayerJoinReserveError::ServerFull)
+        ));
+        assert!(server.try_reserve_player_join(op_uuid).is_ok());
+
+        drop(online);
         drop(server);
         if let Err(error) = fs::remove_dir_all(&storage_root).await {
             panic!("test storage should be removed: {error}");

--- a/steel-login/src/handlers/config.rs
+++ b/steel-login/src/handlers/config.rs
@@ -6,6 +6,7 @@ use steel_core::entity::next_entity_id;
 use steel_core::player::PlayerConnection;
 use steel_core::player::connection::JavaConnection;
 use steel_core::player::{ClientInformation, Player};
+use steel_core::server::PlayerJoinReserveError;
 use steel_protocol::packets::common::CCustomPayload;
 use steel_protocol::packets::common::{SClientInformation, SCustomPayload};
 use steel_protocol::packets::config::CFinishConfiguration;
@@ -101,12 +102,22 @@ impl JavaTcpClient {
             Ok(gameprofile) => gameprofile,
             Err(error) => return self.reject_unexpected_packet(error).await,
         };
-        let Some(reservation) = self.server.try_reserve_player_join(gameprofile.id) else {
-            self.kick(TextComponent::translated(
-                translations::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN.msg(),
-            ))
-            .await;
-            return ConnectionAction::none();
+        let reservation = match self.server.try_reserve_player_join(gameprofile.id) {
+            Ok(reservation) => reservation,
+            Err(PlayerJoinReserveError::Duplicate) => {
+                self.kick(TextComponent::translated(
+                    translations::MULTIPLAYER_DISCONNECT_DUPLICATE_LOGIN.msg(),
+                ))
+                .await;
+                return ConnectionAction::none();
+            }
+            Err(PlayerJoinReserveError::ServerFull) => {
+                self.kick(TextComponent::translated(
+                    translations::MULTIPLAYER_DISCONNECT_SERVER_FULL.msg(),
+                ))
+                .await;
+                return ConnectionAction::none();
+            }
         };
         self.protocol.store(ConnectionProtocol::Play);
 


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

`max_players` was only used for status/login display. Join reservation never checked it, so extra UUIDs could still get in.

`try_reserve_player_join` now counts online players plus in-flight `Joining` admissions under the same lock (so two config tasks can't race past the cap). Full server → `multiplayer.disconnect.server_full`. Duplicate UUID still gets the duplicate-login kick. Ops bypass via `is_operator` (vanilla `canBypassPlayerLimit`).

Closes #631

## How this was tested

- `cargo test -p steel-core --lib max_players_` (reject at cap, joining slot held/released, op bypass)
- `cargo test -p steel-core --lib duplicate_login_`
- `cargo check -p steel-login`

## Screenshots / logs

N/A

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

N/A

## Additional notes

Replaces closed #639 with the project PR template. Bypass is the op group in `player_permission_states`, same as elsewhere — say if you want a separate permission later.