### PR TITLE
refactor: route fixed translation keys through generated translations

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -33,8 +33,8 @@ disallowed-types = [
 disallowed-methods = [
     # Prevent people from taking ownership of the Arc inside the ArcSwap Guard
     { path = "arc_swap::Guard::into_inner", reason = "Holding a strong reference to a Chunk leads to stale data. Use the Guard directly for transient access." },
-    # const_translate should only be use in generated code
-    { path = "text_components::translation::TranslatedMessage::new", reason = "New TranslatedMessages should only be use in generated code. Use steel_utils::translations::GeneratedTranslation::msg().into() instead." },
+    # Fixed vanilla translation keys must go through the generated `steel_utils::translations` API.
+    { path = "text_components::translation::TranslatedMessage::new", reason = "Use `steel_utils::translations::SOME_KEY.msg()` (or `.message([args])`) for fixed vanilla keys. Only genuinely dynamic keys build a TranslatedMessage directly." },
 ]
 
 avoid-breaking-exported-api = false

--- a/prek.toml
+++ b/prek.toml
@@ -36,6 +36,16 @@ hooks = [
         priority = 10
     },
     {
+        id = "forbid-literal-translation-keys",
+        name = "Fixed translation keys must use steel_utils::translations, not a raw TranslatedMessage",
+        language = "system",
+        entry = "bash -c '! grep -n -A3 -E \"TranslatedMessage[[:space:]]*\\{\" \"$@\" | grep -qE \"key:[[:space:]]*\\\"\"' --",
+        types = ["rust"],
+        pass_filenames = true,
+        require_serial = true,
+        priority = 10
+    },
+    {
         id = "typos",
         name = "Spell Check (typos)",
         language = "system",

--- a/steel-core/src/behavior/blocks/building/bed_block.rs
+++ b/steel-core/src/behavior/blocks/building/bed_block.rs
@@ -17,9 +17,7 @@ use steel_registry::blocks::{
     BlockRef, block_state_ext::BlockStateExt, properties::BlockStateProperties,
 };
 use steel_registry::vanilla_blocks;
-use steel_utils::{BlockPos, BlockStateId, Direction, types::UpdateFlags};
-use text_components::TextComponent;
-use text_components::translation::TranslatedMessage;
+use steel_utils::{BlockPos, BlockStateId, Direction, translations, types::UpdateFlags};
 
 const BED_BOUNCE_SCALE: f64 = 0.660_000_026_226_043_7;
 const BED_PART: &EnumProperty<BedPart> = &BlockStateProperties::BED_PART;
@@ -367,11 +365,9 @@ impl BlockBehavior for BedBlock {
             // TODO: Mirror vanilla `kickVillagerOutOfBed`: find a sleeping
             // villager in this bed AABB and call `stopSleeping` once villager
             // sleeping exists.
-            player.send_overlay_message(&TextComponent::translated(TranslatedMessage {
-                key: "block.minecraft.bed.occupied".into(),
-                fallback: None,
-                args: None,
-            }));
+            player.send_overlay_message(
+                &translations::BLOCK_MINECRAFT_BED_OCCUPIED.msg().component(),
+            );
             return InteractionResult::SuccessServer;
         }
 

--- a/steel-core/src/behavior/items/compass.rs
+++ b/steel-core/src/behavior/items/compass.rs
@@ -4,11 +4,12 @@ use steel_macros::item_behavior;
 use steel_registry::{
     data_components::vanilla_components::LODESTONE_TRACKER, item_stack::ItemStack,
 };
+use steel_utils::translations;
 use text_components::TextComponent;
 
 use crate::behavior::ItemBehavior;
 
-use super::dynamic_name::{default_name, translated};
+use super::dynamic_name::default_name;
 
 /// Compass behavior providing the lodestone-specific name.
 // TODO: Implement lodestone binding and tracked-target invalidation when item
@@ -19,7 +20,11 @@ pub struct CompassItem;
 impl ItemBehavior for CompassItem {
     fn get_name<'a>(&self, stack: &'a ItemStack) -> Cow<'a, TextComponent> {
         if stack.has(LODESTONE_TRACKER) {
-            translated("item.minecraft.lodestone_compass".to_owned(), None)
+            Cow::Owned(
+                translations::ITEM_MINECRAFT_LODESTONE_COMPASS
+                    .msg()
+                    .component(),
+            )
         } else {
             default_name(stack)
         }

--- a/steel-core/src/player/game_mode/entity_interaction.rs
+++ b/steel-core/src/player/game_mode/entity_interaction.rs
@@ -3,14 +3,15 @@ use super::{
     DamageType, ENTITY_INTERACTION_RANGE_BUFFER, EnchantmentDamageContext,
     EnchantmentPostAttackContext, Entity, EntityTypeRef, GameType, ITEM_BEHAVIORS, InteractionHand,
     InteractionResult, InventoryAccess, ItemStack, LivingEntity, PiercingWeapon, Player, SAttack,
-    SInteract, SharedEntity, SoundEventHolder, SoundEventRef, TextComponent, TranslatedMessage,
-    World, WorldAabb, enchantment_helper, piercing_ray_hit_t, vanilla_attributes,
-    vanilla_damage_types, vanilla_entities,
+    SInteract, SharedEntity, SoundEventHolder, SoundEventRef, TextComponent, World, WorldAabb,
+    enchantment_helper, piercing_ray_hit_t, vanilla_attributes, vanilla_damage_types,
+    vanilla_entities,
 };
 use crate::player::food_data::food_constants;
 use std::ops::Add;
 use steel_registry::particle_type::ParticleData;
 use steel_registry::{vanilla_custom_stats, vanilla_particle_types};
+use steel_utils::translations;
 
 const fn sound_holder_ref(holder: &SoundEventHolder) -> Option<SoundEventRef> {
     match holder {
@@ -23,12 +24,9 @@ const fn sound_holder_ref(holder: &SoundEventHolder) -> Option<SoundEventRef> {
 }
 impl Player {
     fn invalid_entity_attacked_message() -> TextComponent {
-        TranslatedMessage {
-            key: "multiplayer.disconnect.invalid_entity_attacked".into(),
-            fallback: None,
-            args: None,
-        }
-        .component()
+        translations::MULTIPLAYER_DISCONNECT_INVALID_ENTITY_ATTACKED
+            .msg()
+            .component()
     }
 
     fn eye_position(&self) -> DVec3 {

--- a/steel-core/src/player/game_mode/mod.rs
+++ b/steel-core/src/player/game_mode/mod.rs
@@ -25,7 +25,6 @@ use steel_registry::{REGISTRY, vanilla_attributes, vanilla_damage_types, vanilla
 use steel_utils::types::{Difficulty, GameType, InteractionHand};
 use steel_utils::{BlockPos, Downcast as _, Identifier, WorldAabb};
 use text_components::TextComponent;
-use text_components::translation::TranslatedMessage;
 
 use crate::behavior::{
     BLOCK_BEHAVIORS, BlockCollisionContext, BlockHitResult, ITEM_BEHAVIORS, InteractionResult,

--- a/steel-core/src/player/sleep.rs
+++ b/steel-core/src/player/sleep.rs
@@ -5,7 +5,7 @@ use steel_registry::{
     dimension_type::BedRuleValue,
     vanilla_custom_stats,
 };
-use steel_utils::{BlockPos, Direction};
+use steel_utils::{BlockPos, Direction, translations};
 use text_components::{TextComponent, translation::TranslatedMessage};
 
 use super::sleep_state::SLEEP_DURATION;
@@ -55,6 +55,8 @@ impl Player {
             .error_message_key
             .as_ref()
             .map(|key| {
+                // dynamic translation key: dimension bed-rule error keys come
+                // from the dimension type registry, not a fixed vanilla key.
                 TranslatedMessage {
                     key: (*key).into(),
                     fallback: None,
@@ -151,22 +153,16 @@ impl Player {
         }
         if !self.bed_in_range(pos, direction) {
             return Err(BedSleepingProblem::Message(Box::new(
-                TranslatedMessage {
-                    key: "block.minecraft.bed.too_far_away".into(),
-                    fallback: None,
-                    args: None,
-                }
-                .component(),
+                translations::BLOCK_MINECRAFT_BED_TOO_FAR_AWAY
+                    .msg()
+                    .component(),
             )));
         }
         if self.bed_blocked(pos, direction) {
             return Err(BedSleepingProblem::Message(Box::new(
-                TranslatedMessage {
-                    key: "block.minecraft.bed.obstructed".into(),
-                    fallback: None,
-                    args: None,
-                }
-                .component(),
+                translations::BLOCK_MINECRAFT_BED_OBSTRUCTED
+                    .msg()
+                    .component(),
             )));
         }
 
@@ -193,14 +189,7 @@ impl Player {
         self.award_custom_stat(&vanilla_custom_stats::SLEEP_IN_BED);
         // TODO: trigger CriteriaTriggers.SLEPT_IN_BED once the foundation for advancements exist.
         if !world.can_sleep_through_nights() {
-            self.send_overlay_message(
-                &TranslatedMessage {
-                    key: "sleep.not_possible".into(),
-                    fallback: None,
-                    args: None,
-                }
-                .component(),
-            );
+            self.send_overlay_message(&translations::SLEEP_NOT_POSSIBLE.msg().component());
         }
         world.update_sleeping_player_list();
         Ok(())
@@ -224,14 +213,7 @@ impl Player {
                 .as_ref()
                 .is_some_and(|config| !config.is_same_position(current.as_ref()))
         {
-            self.send_message(
-                &TranslatedMessage {
-                    key: "block.minecraft.set_spawn".into(),
-                    fallback: None,
-                    args: None,
-                }
-                .component(),
-            );
+            self.send_message(&translations::BLOCK_MINECRAFT_SET_SPAWN.msg().component());
         }
         *current = respawn_config;
     }

--- a/steel-core/src/world/sleep.rs
+++ b/steel-core/src/world/sleep.rs
@@ -2,8 +2,8 @@ use steel_protocol::packets::game::CSystemChat;
 use steel_registry::vanilla_game_rules::{
     ADVANCE_TIME, ADVANCE_WEATHER, PLAYERS_SLEEPING_PERCENTAGE,
 };
-use steel_utils::Identifier;
-use text_components::{TextComponent, translation::TranslatedMessage};
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
 
 use super::{World, sleep_status::SleepStatus};
 use crate::entity::LivingEntity as _;
@@ -47,25 +47,14 @@ impl World {
 
         let percentage = self.players_sleeping_percentage();
         let message = if sleep_status.are_enough_sleeping(percentage) {
-            TranslatedMessage {
-                key: "sleep.skipping_night".into(),
-                fallback: None,
-                args: None,
-            }
-            .component()
+            translations::SLEEP_SKIPPING_NIGHT.msg().component()
         } else {
-            TranslatedMessage {
-                key: "sleep.players_sleeping".into(),
-                fallback: None,
-                args: Some(
-                    vec![
-                        TextComponent::from(sleep_status.amount_sleeping().to_string()),
-                        TextComponent::from(sleep_status.sleepers_needed(percentage).to_string()),
-                    ]
-                    .into(),
-                ),
-            }
-            .component()
+            translations::SLEEP_PLAYERS_SLEEPING
+                .message([
+                    TextComponent::from(sleep_status.amount_sleeping().to_string()),
+                    TextComponent::from(sleep_status.sleepers_needed(percentage).to_string()),
+                ])
+                .component()
         };
 
         self.broadcast_to_all_with(|player| CSystemChat::new(&message, true, player));


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

Fixes #339. Several fixed vanilla translation keys were built with raw `TranslatedMessage`
struct literals instead of the generated `steel_utils::translations` API, which made known
keys stringly typed and, for `sleep.players_sleeping`, lost the compile-time check that it
receives exactly two arguments.

- Replaced the fixed-key literals with `translations::KEY.msg()` / `.message([...])`:
  `player/sleep.rs` (bed too-far / obstructed / `sleep.not_possible` / `set_spawn`),
  `world/sleep.rs` (`sleep.skipping_night`, `sleep.players_sleeping`), `bed_block.rs`
  (`bed.occupied`), `game_mode/entity_interaction.rs`
  (`multiplayer.disconnect.invalid_entity_attacked`), and the lodestone compass name in
  `behavior/items/compass.rs`.
- `sleep.players_sleeping` now uses
  `translations::SLEEP_PLAYERS_SLEEPING.message([sleeping, needed])` (`Translation<2>`), so
  the two-argument shape is enforced at compile time.
- Left genuinely dynamic keys as `TranslatedMessage` literals, as the issue asks: the
  dimension bed-rule error key in `player/sleep.rs` (now with a `// dynamic translation
  key` note), plus registry / damage keys elsewhere (enchant command, entity names, death
  messages, `dynamic_name::translated`).
- Fixed the `clippy.toml` `disallowed-methods` reason for `TranslatedMessage::new`: it
  pointed at a non-existent `GeneratedTranslation` API. It now names the real
  `translations::KEY.msg()` / `.message([args])` API.
- Added a `prek` local hook, `forbid-literal-translation-keys`, that fails when a
  `TranslatedMessage` struct literal is built with a string-literal `key:`. The
  `TranslatedMessage::new` clippy rule is evaded by struct-literal construction; this hook
  closes that gap while leaving variable-key (dynamic) paths untouched. It follows the
  style of the existing `forbid-multiple-hyphens-equals` local hook.

## How this was tested

- `cargo test` (sleep / bed / compass / `dynamic_name` suites plus the full workspace run),
  `cargo clippy -r --all-targets --all-features`, `cargo fmt --all --check`, `typos`,
  `prek run --all-files` all pass.
- Verified the new hook fails on a probe file containing a literal-key `TranslatedMessage`
  and passes on the tree.
- No translation keys changed, so existing key-assertion tests (e.g.
  `every_mc26_dynamic_item_name_override_uses_stack_components` for the lodestone compass)
  still pass.

## Screenshots / logs

<!-- n/a -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

<!-- refactor only; no vanilla class newly implemented -->

## Additional notes

- Out of scope per the issue: dimension bed-rule error keys, entity / damage names,
  enchantment names and levels, and dynamic item names.
