### PR TITLE
refactor: move some functions from `Animal` to `AgeableMob`

### DIFF
--- a/steel-core/src/behavior/items/spawn_egg.rs
+++ b/steel-core/src/behavior/items/spawn_egg.rs
@@ -101,8 +101,8 @@ impl SpawnEggItem {
         }
 
         let world = parent.level()?;
-        let offspring = if let Some(animal) = parent.as_animal() {
-            animal.get_breed_offspring(&world, animal)?
+        let offspring = if let Some(ageable) = parent.as_ageable_mob() {
+            ageable.get_breed_offspring(&world, ageable)?
         } else {
             match create_entity_instance(&world, entity_type, parent.position()) {
                 Ok(offspring) => offspring,

--- a/steel-core/src/entity/ageable.rs
+++ b/steel-core/src/entity/ageable.rs
@@ -7,11 +7,15 @@ use simdnbt::owned::NbtCompound;
 use steel_protocol::packets::game::SoundSource;
 use steel_registry::vanilla_entity_type_tags::EntityTypeTag;
 use steel_registry::{REGISTRY, TaggedRegistryExt, sound_events, vanilla_items};
+use steel_utils::Identifier;
 use steel_utils::locks::SyncMutex;
 use steel_utils::types::InteractionHand;
 
 use crate::behavior::InteractionResult;
-use crate::entity::{AgeableMobGroupData, Entity, EntitySpawnReason, Mob, SpawnGroupData};
+use crate::entity::{
+    AgeableMobGroupData, ENTITIES, Entity, EntitySpawnReason, Mob, SharedEntity, SpawnGroupData,
+    next_entity_id,
+};
 use crate::player::Player;
 use crate::world::World;
 
@@ -298,6 +302,48 @@ pub trait AgeableMob: Mob {
 
         InteractionResult::Success
     }
+
+    /// Creates a same-type offspring using the registered entity factory.
+    fn create_breed_offspring(&self, world: &Arc<World>) -> Option<SharedEntity> {
+        ENTITIES.create(
+            self.entity_type(),
+            next_entity_id(),
+            self.position(),
+            Arc::downgrade(world),
+        )
+    }
+
+    /// Creates this animal's vanilla breeding offspring.
+    fn get_breed_offspring(
+        &self,
+        world: &Arc<World>,
+        partner: &dyn AgeableMob,
+    ) -> Option<SharedEntity> {
+        let offspring = self.create_breed_offspring(world)?;
+        let Some(offspring_animal) = offspring.as_ageable_mob() else {
+            log::error!(
+                "breeding entity type {} created non-ageable offspring",
+                self.entity_type().key
+            );
+            return None;
+        };
+
+        self.initialize_breed_offspring(partner, offspring_animal);
+        Some(offspring)
+    }
+
+    /// Returns this animal's breedable variant key when offspring inherit it.
+    fn breed_variant_key(&self) -> Option<&Identifier> {
+        None
+    }
+
+    /// Applies a breedable variant key to offspring that inherit one.
+    fn set_breed_variant_key(&self, _key: &Identifier) -> bool {
+        false
+    }
+
+    /// Applies entity-specific state to freshly created breeding offspring.
+    fn initialize_breed_offspring(&self, _partner: &dyn AgeableMob, _offspring: &dyn AgeableMob) {}
 
     /// Ticks vanilla age progression.
     fn tick_ageable_mob(&self) {

--- a/steel-core/src/entity/animal.rs
+++ b/steel-core/src/entity/animal.rs
@@ -12,16 +12,13 @@ use steel_registry::vanilla_game_rules::MOB_DROPS;
 use steel_utils::entity_events::EntityStatus;
 use steel_utils::locks::SyncMutex;
 use steel_utils::types::InteractionHand;
-use steel_utils::{BlockPos, Identifier, UuidExt};
+use steel_utils::{BlockPos, UuidExt};
 use uuid::Uuid;
 
 use crate::behavior::InteractionResult;
 use crate::entity::ai::path::PathType;
 use crate::entity::entities::ExperienceOrbEntity;
-use crate::entity::{
-    AgeableMob, AgeableMobBase, ENTITIES, EntitySpawnReason, Mob, MobBase, SharedEntity,
-    next_entity_id,
-};
+use crate::entity::{AgeableMob, AgeableMobBase, EntitySpawnReason, Mob, MobBase};
 use crate::player::Player;
 use crate::world::{LevelReader, World};
 
@@ -247,48 +244,6 @@ pub trait Animal: AgeableMob {
         }
 
         self.mob_interact_ageable(player, hand)
-    }
-
-    /// Creates a same-type offspring using the registered entity factory.
-    fn create_breed_offspring(&self, world: &Arc<World>) -> Option<SharedEntity> {
-        ENTITIES.create(
-            self.entity_type(),
-            next_entity_id(),
-            self.position(),
-            Arc::downgrade(world),
-        )
-    }
-
-    /// Returns this animal's breedable variant key when offspring inherit it.
-    fn breed_variant_key(&self) -> Option<&Identifier> {
-        None
-    }
-
-    /// Applies a breedable variant key to offspring that inherit one.
-    fn set_breed_variant_key(&self, _key: &Identifier) -> bool {
-        false
-    }
-
-    /// Applies entity-specific state to freshly created breeding offspring.
-    fn initialize_breed_offspring(&self, _partner: &dyn Animal, _offspring: &dyn Animal) {}
-
-    /// Creates this animal's vanilla breeding offspring.
-    fn get_breed_offspring(
-        &self,
-        world: &Arc<World>,
-        partner: &dyn Animal,
-    ) -> Option<SharedEntity> {
-        let offspring = self.create_breed_offspring(world)?;
-        let Some(offspring_animal) = offspring.as_animal() else {
-            log::error!(
-                "breeding entity type {} created non-animal offspring",
-                self.entity_type().key
-            );
-            return None;
-        };
-
-        self.initialize_breed_offspring(partner, offspring_animal);
-        Some(offspring)
     }
 
     /// Creates, initializes, and inserts vanilla breeding offspring.

--- a/steel-core/src/entity/entities/mobs/passive/chicken/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/chicken/mod.rs
@@ -569,16 +569,6 @@ impl AgeableMob for ChickenEntity {
     fn age_boundary_changed(&self, _baby: bool) {
         self.refresh_dimensions();
     }
-}
-
-impl Animal for ChickenEntity {
-    fn animal_base(&self) -> &AnimalBase {
-        &self.animal_base
-    }
-
-    fn is_food(&self, item_stack: &ItemStack) -> bool {
-        ChickenEntity::is_food(item_stack)
-    }
 
     fn breed_variant_key(&self) -> Option<&Identifier> {
         Some(&self.variant().key)
@@ -588,7 +578,7 @@ impl Animal for ChickenEntity {
         self.set_variant_by_key(key)
     }
 
-    fn initialize_breed_offspring(&self, partner: &dyn Animal, offspring: &dyn Animal) {
+    fn initialize_breed_offspring(&self, partner: &dyn AgeableMob, offspring: &dyn AgeableMob) {
         let use_self_variant = rand::random::<bool>();
         let variant_key = if use_self_variant {
             self.breed_variant_key()
@@ -602,6 +592,16 @@ impl Animal for ChickenEntity {
         if !offspring.set_breed_variant_key(variant_key) {
             log::error!("chicken offspring could not inherit breeding variant {variant_key}");
         }
+    }
+}
+
+impl Animal for ChickenEntity {
+    fn animal_base(&self) -> &AnimalBase {
+        &self.animal_base
+    }
+
+    fn is_food(&self, item_stack: &ItemStack) -> bool {
+        ChickenEntity::is_food(item_stack)
     }
 }
 

--- a/steel-core/src/entity/entities/mobs/passive/chicken/tests/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/chicken/tests/mod.rs
@@ -9,7 +9,7 @@ use steel_registry::{
 };
 
 use crate::entity::damage::DamageSource;
-use crate::entity::{Animal, Entity, LivingEntity, Mob};
+use crate::entity::{Entity, LivingEntity, Mob};
 use crate::test_support::fresh_test_world;
 
 use super::*;

--- a/steel-core/src/entity/entities/mobs/passive/cow/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/cow/mod.rs
@@ -389,16 +389,6 @@ impl AgeableMob for CowEntity {
     fn age_boundary_changed(&self, _baby: bool) {
         self.refresh_dimensions();
     }
-}
-
-impl Animal for CowEntity {
-    fn animal_base(&self) -> &AnimalBase {
-        &self.animal_base
-    }
-
-    fn is_food(&self, item_stack: &ItemStack) -> bool {
-        CowEntity::is_food(item_stack)
-    }
 
     fn breed_variant_key(&self) -> Option<&Identifier> {
         Some(&self.variant().key)
@@ -408,7 +398,7 @@ impl Animal for CowEntity {
         self.set_variant_by_key(key)
     }
 
-    fn initialize_breed_offspring(&self, partner: &dyn Animal, offspring: &dyn Animal) {
+    fn initialize_breed_offspring(&self, partner: &dyn AgeableMob, offspring: &dyn AgeableMob) {
         let use_self_variant = rand::random::<bool>();
         let variant_key = if use_self_variant {
             self.breed_variant_key()
@@ -422,6 +412,16 @@ impl Animal for CowEntity {
         if !offspring.set_breed_variant_key(variant_key) {
             log::error!("cow offspring could not inherit breeding variant {variant_key}");
         }
+    }
+}
+
+impl Animal for CowEntity {
+    fn animal_base(&self) -> &AnimalBase {
+        &self.animal_base
+    }
+
+    fn is_food(&self, item_stack: &ItemStack) -> bool {
+        CowEntity::is_food(item_stack)
     }
 }
 

--- a/steel-core/src/entity/entities/mobs/passive/cow/tests/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/cow/tests/mod.rs
@@ -10,7 +10,7 @@ use steel_registry::{
 use steel_utils::types::InteractionHand;
 
 use crate::entity::damage::DamageSource;
-use crate::entity::{Animal, Entity, LivingEntity, Mob};
+use crate::entity::{Entity, LivingEntity, Mob};
 use crate::test_support::{TestPlayerBuilder, fresh_test_world};
 
 use super::*;

--- a/steel-core/src/entity/entities/mobs/passive/pig/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/pig/mod.rs
@@ -408,20 +408,6 @@ impl AgeableMob for PigEntity {
     fn set_synced_baby(&self, baby: bool) {
         self.entity_data.lock().ageable_mob_mut().baby.set(baby);
     }
-}
-
-impl Animal for PigEntity {
-    fn animal_base(&self) -> &AnimalBase {
-        &self.animal_base
-    }
-
-    fn is_food(&self, item_stack: &ItemStack) -> bool {
-        PigEntity::is_food(item_stack)
-    }
-
-    fn play_eating_sound(&self) {
-        self.play_sound(self.current_sound_set().eat_sound, 1.0, 1.0);
-    }
 
     fn breed_variant_key(&self) -> Option<&Identifier> {
         Some(&self.variant().key)
@@ -431,7 +417,7 @@ impl Animal for PigEntity {
         self.set_variant_by_key(key)
     }
 
-    fn initialize_breed_offspring(&self, partner: &dyn Animal, offspring: &dyn Animal) {
+    fn initialize_breed_offspring(&self, partner: &dyn AgeableMob, offspring: &dyn AgeableMob) {
         let use_self_variant = rand::random::<bool>();
         let variant_key = if use_self_variant {
             self.breed_variant_key()
@@ -445,6 +431,20 @@ impl Animal for PigEntity {
         if !offspring.set_breed_variant_key(variant_key) {
             log::error!("pig offspring could not inherit breeding variant {variant_key}");
         }
+    }
+}
+
+impl Animal for PigEntity {
+    fn animal_base(&self) -> &AnimalBase {
+        &self.animal_base
+    }
+
+    fn is_food(&self, item_stack: &ItemStack) -> bool {
+        PigEntity::is_food(item_stack)
+    }
+
+    fn play_eating_sound(&self) {
+        self.play_sound(self.current_sound_set().eat_sound, 1.0, 1.0);
     }
 }
 

--- a/steel-core/src/entity/entities/mobs/passive/sheep/mod.rs
+++ b/steel-core/src/entity/entities/mobs/passive/sheep/mod.rs
@@ -492,6 +492,17 @@ impl AgeableMob for SheepEntity {
     fn age_boundary_changed(&self, _baby: bool) {
         self.refresh_dimensions();
     }
+
+    fn initialize_breed_offspring(&self, partner: &dyn AgeableMob, offspring: &dyn AgeableMob) {
+        let parent1_color = self.color();
+        let parent2_color = partner
+            .downcast_ref::<SheepEntity>()
+            .map_or(parent1_color, SheepEntity::color);
+        let mixed_color = SheepEntity::get_mixed_color(parent1_color, parent2_color);
+        if let Some(offspring) = offspring.downcast_ref::<SheepEntity>() {
+            offspring.set_color(mixed_color);
+        }
+    }
 }
 
 impl Animal for SheepEntity {
@@ -501,17 +512,6 @@ impl Animal for SheepEntity {
 
     fn is_food(&self, item_stack: &ItemStack) -> bool {
         SheepEntity::is_food(item_stack)
-    }
-
-    fn initialize_breed_offspring(&self, partner: &dyn Animal, offspring: &dyn Animal) {
-        let parent1_color = self.color();
-        let parent2_color = partner
-            .downcast_ref::<SheepEntity>()
-            .map_or(parent1_color, SheepEntity::color);
-        let mixed_color = SheepEntity::get_mixed_color(parent1_color, parent2_color);
-        if let Some(offspring) = offspring.downcast_ref::<SheepEntity>() {
-            offspring.set_color(mixed_color);
-        }
     }
 }
 

--- a/steel-core/src/entity/entities/mobs/passive/sheep/tests/core.rs
+++ b/steel-core/src/entity/entities/mobs/passive/sheep/tests/core.rs
@@ -210,7 +210,7 @@ fn sheep_breeding_mixes_parent_colors_through_dye_recipes() {
             .expect("shared entity should be a sheep");
         sheep.set_color(parent_color);
 
-        let offspring = Animal::get_breed_offspring(sheep, &world, partner)
+        let offspring = AgeableMob::get_breed_offspring(sheep, &world, partner)
             .expect("sheep breeding should create an offspring");
         let offspring = offspring
             .downcast_ref::<SheepEntity>()
@@ -240,7 +240,7 @@ fn sheep_breeding_falls_back_to_a_parent_color_without_a_mix_recipe() {
     sheep.set_color(DyeColor::Green);
 
     for _ in 0..COLOR_FALLBACK_TRIALS {
-        let offspring = Animal::get_breed_offspring(sheep, &world, partner)
+        let offspring = AgeableMob::get_breed_offspring(sheep, &world, partner)
             .expect("sheep breeding should create an offspring");
         let offspring = offspring
             .downcast_ref::<SheepEntity>()


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [x] Refactor / code cleanup

## Description

Closes #630

Moves some functions from the `Animal` trait to `AgeableMob` that are there in Vanilla, so that it is now possible for spawn eggs to use `AgeableMob` instead of `Animal`.

## How this was tested

Try testing spawn eggs on an entity, and see that the behavior remains unchanged. Cannot test this on villagers as they haven't been implemented yet.

## Screenshots / logs

N/A

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

- Cow
- Sheep
- Chicken
- Pig
- SpawnEggItem

## Additional notes

<!-- Anything else reviewers should know -->
