### PR TITLE
refactor(server): make the shutdown save sequence callable from a library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,7 +2682,6 @@ dependencies = [
  "serde_json",
  "steel-core",
  "steel-login",
- "steel-registry",
  "steel-utils",
  "strip-ansi-escapes",
  "text_components",

--- a/steel-core/src/server/player_admission.rs
+++ b/steel-core/src/server/player_admission.rs
@@ -344,7 +344,7 @@ impl Server {
         admitted
     }
 
-    fn reserve_player_disconnect(&self, player: &Arc<Player>) -> bool {
+    pub(super) fn reserve_player_disconnect(&self, player: &Arc<Player>) -> bool {
         let uuid = player.gameprofile.id;
         let mut admissions = self.player_admissions.lock();
         if admissions.contains_key(&uuid) {

--- a/steel-core/src/server/run_loop.rs
+++ b/steel-core/src/server/run_loop.rs
@@ -4,11 +4,13 @@ use super::{
     COMMAND_REQUESTS_PER_TICK, COMMAND_RESUMPTIONS_PER_TICK, CancellationToken, ChunkPos,
     ChunkSender, CommandExecutionContext, CommandExecutionOwner, CommandRequest,
     CommandResultCallback, CommandSender, CommandSource, Duration, EncodedChunk,
-    ExecutionCommandSource, ExecutionStop, GameTickTaskGuard, Instant, JoinSet, NetworkConnection,
-    PendingCommandExecutionQueue, Player, SEND_PLAYER_INFO_INTERVAL, SLOW_CHUNK_TICK_THRESHOLD,
-    Server, StringReader, SuggestionError, Suggestions, TAB_LIST_UPDATE_INTERVAL, TabListTickStats,
-    ThreadPool, World, command_suggestions_packet, sleep, spawn_blocking,
+    ExecutionCommandSource, ExecutionStop, GameTickTaskGuard, GlobalPlayerData, Instant, JoinSet,
+    MenuRemovalStatus, NetworkConnection, PendingCommandExecutionQueue, PersistentPlayerData,
+    Player, SEND_PLAYER_INFO_INTERVAL, SLOW_CHUNK_TICK_THRESHOLD, Server, StringReader,
+    SuggestionError, Suggestions, TAB_LIST_UPDATE_INTERVAL, TabListTickStats, ThreadPool, World,
+    command_suggestions_packet, sleep, spawn_blocking,
 };
+use steel_registry::vanilla_custom_stats;
 use steel_utils::threading::{available_worker_threads, worker_threads_for_available};
 
 impl Server {
@@ -73,6 +75,91 @@ impl Server {
                 log::error!("{task} task failed: {error}");
             }
         }
+    }
+
+    /// Saves everything and tears the worlds down, in the order shutdown requires.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a player's menus cannot be removed, which means packets are still being
+    /// processed. Callers must stop packet processing before calling this; the standalone
+    /// server does so by closing its task tracker and awaiting the drain.
+    pub async fn save_and_shutdown(&self) {
+        if let Err(error) = self.flush_known_players().await {
+            log::error!("Failed to flush known player cache during shutdown: {error}");
+        }
+
+        let players = self.get_players();
+        for player in &players {
+            player.close_connection();
+            assert_eq!(
+                player.remove_all_menus(),
+                MenuRemovalStatus::Complete,
+                "shutdown menu removal must run after packet processing stops"
+            );
+        }
+
+        for world in self.worlds.values() {
+            world.chunk_map.stop_generation_refill_loop();
+            world.chunk_map.task_tracker.close();
+            world.chunk_map.task_tracker.wait().await;
+        }
+
+        let mut players_to_save = Vec::new();
+        for player in players {
+            let domain = player.get_world().domain().to_owned();
+            player.award_custom_stat(&vanilla_custom_stats::LEAVE_GAME);
+            let data = PersistentPlayerData::from_player(&player);
+            player.store_ender_pearls_with_player();
+            players_to_save.push((player, domain, data));
+        }
+
+        log::info!("Saving world data...");
+        let command_data = self.save_command_data().await;
+        match command_data.scoreboards {
+            Ok(saved) => log::info!("Saved {saved} domain scoreboards"),
+            Err(error) => log::error!("Failed to save domain scoreboards: {error}"),
+        }
+        match command_data.storage {
+            Ok(saved) => log::info!("Saved {saved} domain command storages"),
+            Err(error) => log::error!("Failed to save domain command storage: {error}"),
+        }
+        let mut total_saved = 0;
+        for world in self.worlds.values() {
+            world.cleanup(&mut total_saved).await;
+        }
+        log::info!("Saved {total_saved} chunks");
+
+        log::info!("Saving player data...");
+        let mut saved = 0;
+        for (player, domain, data) in players_to_save {
+            let uuid = player.gameprofile.id;
+            match self
+                .player_data_storage
+                .save_domain_data(&domain, uuid, &data)
+                .await
+            {
+                Ok(()) => {
+                    saved += 1;
+                }
+                Err(e) => {
+                    log::error!("Failed to save player {uuid} domain data during shutdown: {e}");
+                }
+            }
+            if let Err(e) = self
+                .player_data_storage
+                .save_global(
+                    uuid,
+                    &GlobalPlayerData {
+                        last_active_domain: domain,
+                    },
+                )
+                .await
+            {
+                log::error!("Failed to save player {uuid} global data during shutdown: {e}");
+            }
+        }
+        log::info!("Saved {saved} players");
     }
 
     /// The main game tick loop (20 TPS, governed by tick rate manager).

--- a/steel-core/src/server/run_loop.rs
+++ b/steel-core/src/server/run_loop.rs
@@ -12,6 +12,7 @@ use super::{
 };
 use steel_registry::vanilla_custom_stats;
 use steel_utils::threading::{available_worker_threads, worker_threads_for_available};
+use steel_utils::translations;
 
 impl Server {
     pub(super) fn advance_server_tick(&self) -> (u64, bool) {
@@ -91,7 +92,10 @@ impl Server {
 
         let players = self.get_players();
         for player in &players {
-            player.close_connection();
+            // Claim the removal first so a later tick cannot run the ordinary disconnect
+            // path for the same player and award the leave-game stat twice.
+            let _ = self.reserve_player_disconnect(player);
+            player.disconnect(translations::MULTIPLAYER_DISCONNECT_SERVER_SHUTDOWN.msg());
             assert_eq!(
                 player.remove_all_menus(),
                 MenuRemovalStatus::Complete,

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -29,7 +29,7 @@ use steel_registry::{
     init_vanilla_registry, stat::vanilla_stat_types, vanilla_blocks, vanilla_custom_stats,
     vanilla_dimension_types, vanilla_entities, vanilla_game_rules::RESPAWN_RADIUS, vanilla_items,
 };
-use steel_utils::{BlockPos, ChunkPos, UuidExt as _, types::UpdateFlags};
+use steel_utils::{BlockPos, ChunkPos, UuidExt as _, translations, types::UpdateFlags};
 use steel_utils::{codec::VarInt, serial::ReadFrom, text::DisplayResolutor};
 use text_components::TextComponent;
 use tokio::{
@@ -90,6 +90,7 @@ use super::{
 struct TestConnection {
     sent_packets: Arc<SyncMutex<Vec<EncodedPacket>>>,
     closed: AtomicBool,
+    disconnect_reason: Arc<SyncMutex<Option<TextComponent>>>,
 }
 
 impl NetworkConnection for TestConnection {
@@ -105,7 +106,10 @@ impl NetworkConnection for TestConnection {
         self.sent_packets.lock().extend(packets);
     }
 
-    fn disconnect_with_reason(&self, _reason: TextComponent) {}
+    fn disconnect_with_reason(&self, reason: TextComponent) {
+        *self.disconnect_reason.lock() = Some(reason);
+        self.close();
+    }
 
     fn tick(&self) {}
 
@@ -2368,17 +2372,38 @@ fn test_player_with_connection(
         .build()
 }
 
+struct TestConnectionHandles {
+    connection: Arc<PlayerConnection>,
+    sent_packets: Arc<SyncMutex<Vec<EncodedPacket>>>,
+    disconnect_reason: Arc<SyncMutex<Option<TextComponent>>>,
+}
+
+fn test_connection() -> TestConnectionHandles {
+    let sent_packets = Arc::new(SyncMutex::new(Vec::new()));
+    let disconnect_reason = Arc::new(SyncMutex::new(None));
+    let connection = Arc::new(PlayerConnection::Other(Box::new(TestConnection {
+        sent_packets: Arc::clone(&sent_packets),
+        closed: AtomicBool::new(false),
+        disconnect_reason: Arc::clone(&disconnect_reason),
+    })));
+    TestConnectionHandles {
+        connection,
+        sent_packets,
+        disconnect_reason,
+    }
+}
+
 fn test_player_with_packets(
     server: &Arc<Server>,
     world: Arc<World>,
     name: &str,
     entity_id: i32,
 ) -> (Arc<Player>, Arc<SyncMutex<Vec<EncodedPacket>>>) {
-    let sent_packets = Arc::new(SyncMutex::new(Vec::new()));
-    let connection = Arc::new(PlayerConnection::Other(Box::new(TestConnection {
-        sent_packets: Arc::clone(&sent_packets),
-        closed: AtomicBool::new(false),
-    })));
+    let TestConnectionHandles {
+        connection,
+        sent_packets,
+        ..
+    } = test_connection();
     let player = test_player_with_connection(server, world, name, entity_id, connection);
     (player, sent_packets)
 }
@@ -2390,11 +2415,11 @@ fn test_player_with_uuid_and_packets(
     name: &str,
     entity_id: i32,
 ) -> (Arc<Player>, Arc<SyncMutex<Vec<EncodedPacket>>>) {
-    let sent_packets = Arc::new(SyncMutex::new(Vec::new()));
-    let connection = Arc::new(PlayerConnection::Other(Box::new(TestConnection {
-        sent_packets: Arc::clone(&sent_packets),
-        closed: AtomicBool::new(false),
-    })));
+    let TestConnectionHandles {
+        connection,
+        sent_packets,
+        ..
+    } = test_connection();
     let player = TestPlayerBuilder::new(world, name, entity_id)
         .uuid(uuid)
         .connection(connection)
@@ -3987,5 +4012,73 @@ fn offline_startup_still_requests_the_services_keys() {
 
             shutdown_server(&server, &save_root).await;
         });
+    });
+}
+
+#[test]
+fn save_and_shutdown_writes_player_and_world_data() {
+    with_server_runtime(|runtime| {
+        runtime.block_on(async {
+            let save_root = test_storage_root("save-and-shutdown");
+            let server = offline_server(runtime, &save_root, UNROUTABLE_SERVICES)
+                .await
+                .expect("an offline server should start");
+
+            server.save_and_shutdown().await;
+
+            assert!(save_root.join("global/known_players.dat").is_file());
+            assert!(
+                save_root
+                    .join("minecraft/worlds/overworld/level.toml")
+                    .is_file()
+            );
+
+            shutdown_server(&server, &save_root).await;
+        });
+    });
+}
+
+#[test]
+fn save_and_shutdown_disconnects_players_and_claims_their_removal() {
+    let world = fresh_test_world_in_domain("survival", "shutdown-disconnect");
+    let runtime = Builder::new_current_thread().enable_all().build();
+    let Ok(runtime) = runtime else {
+        panic!("test runtime should initialize");
+    };
+    runtime.block_on(async {
+        let storage_root = test_storage_root("shutdown-disconnect");
+        let server = test_server(
+            Arc::clone(&world),
+            PermissionSubjectIndex::new(),
+            &storage_root,
+        )
+        .await;
+        let Ok(server) = server else {
+            panic!("test server should initialize");
+        };
+        let TestConnectionHandles {
+            connection,
+            disconnect_reason,
+            ..
+        } = test_connection();
+        let player =
+            test_player_with_connection(&server, Arc::clone(&world), "TestPlayer", 1, connection);
+        assert!(server.online_players.insert(Arc::clone(&player)));
+        assert!(world.add_player(Arc::clone(&player), ResetReason::InitialJoin));
+
+        server.save_and_shutdown().await;
+
+        assert_eq!(
+            disconnect_reason.lock().clone(),
+            Some(TextComponent::from(
+                translations::MULTIPLAYER_DISCONNECT_SERVER_SHUTDOWN.msg()
+            ))
+        );
+        assert!(
+            server.process_player_disconnects().is_empty(),
+            "shutdown should claim the removal so a later tick does not repeat it"
+        );
+
+        shutdown_server(&server, &storage_root).await;
     });
 }

--- a/steel/Cargo.toml
+++ b/steel/Cargo.toml
@@ -10,7 +10,6 @@ authors.workspace = true
 steel-core.workspace = true
 steel-login.workspace = true
 steel-utils.workspace = true
-steel-registry.workspace = true
 
 # Async runtime
 tokio.workspace = true

--- a/steel/src/main.rs
+++ b/steel/src/main.rs
@@ -13,11 +13,6 @@ use futures::FutureExt;
 use steel::config::{self, LogConfig};
 use steel::logger::CommandLogger;
 use steel::{SERVER, SteelServer, logger::LoggerLayer};
-use steel_core::player::player_data::PersistentPlayerData;
-use steel_core::player::player_data_storage::GlobalPlayerData;
-use steel_core::player::player_inventory::MenuRemovalStatus;
-use steel_core::server::Server;
-use steel_registry::vanilla_custom_stats;
 use steel_utils::text::DisplayResolutor;
 #[cfg(all(windows, debug_assertions))]
 use steel_utils::threading::DEBUG_STACK_SIZE;
@@ -325,7 +320,7 @@ async fn run_server(
     let server = steel.server.clone();
 
     if !server.prepare_spawn_area().await {
-        shutdown_worlds(&server).await;
+        server.save_and_shutdown().await;
         return Ok(());
     }
 
@@ -340,88 +335,8 @@ async fn run_server(
     task_tracker.close();
     task_tracker.wait().await;
 
-    shutdown_worlds(&server).await;
+    server.save_and_shutdown().await;
 
     log::info!("Server stopped");
     Ok(())
-}
-
-async fn shutdown_worlds(server: &Arc<Server>) {
-    if let Err(error) = server.flush_known_players().await {
-        log::error!("Failed to flush known player cache during shutdown: {error}");
-    }
-
-    let players = server.get_players();
-    for player in &players {
-        player.close_connection();
-        assert_eq!(
-            player.remove_all_menus(),
-            MenuRemovalStatus::Complete,
-            "shutdown menu removal must run after packet processing stops"
-        );
-    }
-
-    for world in server.worlds.values() {
-        world.chunk_map.stop_generation_refill_loop();
-        world.chunk_map.task_tracker.close();
-        world.chunk_map.task_tracker.wait().await;
-    }
-
-    let mut players_to_save = Vec::new();
-    for player in players {
-        let domain = player.get_world().domain().to_owned();
-        player.award_custom_stat(&vanilla_custom_stats::LEAVE_GAME);
-        let data = PersistentPlayerData::from_player(&player);
-        player.store_ender_pearls_with_player();
-        players_to_save.push((player, domain, data));
-    }
-
-    // Save all dirty chunks before shutdown
-    log::info!("Saving world data...");
-    let command_data = server.save_command_data().await;
-    match command_data.scoreboards {
-        Ok(saved) => log::info!("Saved {saved} domain scoreboards"),
-        Err(error) => log::error!("Failed to save domain scoreboards: {error}"),
-    }
-    match command_data.storage {
-        Ok(saved) => log::info!("Saved {saved} domain command storages"),
-        Err(error) => log::error!("Failed to save domain command storage: {error}"),
-    }
-    let mut total_saved = 0;
-    for world in server.worlds.values() {
-        world.cleanup(&mut total_saved).await;
-    }
-    log::info!("Saved {total_saved} chunks");
-
-    // Save all player data before shutdown
-    log::info!("Saving player data...");
-    let mut saved = 0;
-    for (player, domain, data) in players_to_save {
-        let uuid = player.gameprofile.id;
-        match server
-            .player_data_storage
-            .save_domain_data(&domain, uuid, &data)
-            .await
-        {
-            Ok(()) => {
-                saved += 1;
-            }
-            Err(e) => {
-                log::error!("Failed to save player {uuid} domain data during shutdown: {e}");
-            }
-        }
-        if let Err(e) = server
-            .player_data_storage
-            .save_global(
-                uuid,
-                &GlobalPlayerData {
-                    last_active_domain: domain,
-                },
-            )
-            .await
-        {
-            log::error!("Failed to save player {uuid} global data during shutdown: {e}");
-        }
-    }
-    log::info!("Saved {saved} players");
 }


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

`shutdown_worlds` was a private `async fn` in `steel/src/main.rs`: the whole save-on-exit
sequence, flushing the known-player cache, disconnecting players, draining each world's
task tracker, saving scoreboards and command storage, cleaning up dirty chunks, then
writing player data.

everything it calls is already `pub`, so anyone driving `steel-core` as a library can copy
it. that is the problem. a copy works the day it is written and then silently stops saving
whatever steel later adds to the sequence, which loses worlds long after the change that
caused it. the pomme client is about to embed `steel-core` for singleplayer and needs to
run this on quit-to-title.

- **the sequence is now `Server::save_and_shutdown`.** the body moved verbatim apart from
  the receiver, which was `&Arc<Server>` but only ever used as `&Server`, and two comments
  that restated the `log::info!` line directly below them. both call sites in the binary
  now call the method: the early return when `prepare_spawn_area` fails, and the one after
  the task tracker drains. the doc comment records the ordering precondition, which was
  previously only discoverable by tripping the menu-removal assert.

- **players now get vanilla's disconnect reason.** vanilla `PlayerList.removeAll` sends
  `multiplayer.disconnect.server_shutdown`, so clients show "Server closed". steel closed
  the socket, so clients got a generic connection-lost. `Player::disconnect` still closes
  on every path, so the `MenuItemDisposition::Drop` behaviour that `close_connection`
  exists for is unchanged.

- **shutdown now claims each removal.** it closed connections without reserving the
  disconnect, so an embedder that kept ticking would have had
  `process_player_disconnects` pick the closed connections back up and run the ordinary
  path again: a second leave-game stat, a second save and a leave message per player.
  standalone was safe only by ordering. it now calls the same `reserve_player_disconnect`
  that the ordinary path checks.

- **`steel` no longer depends on `steel-registry`.** the moved function held the only
  reference to it in the whole package.

## How this was tested

`cargo fmt --all --check`, `cargo clippy -r --all-targets --all-features` under
`-Dwarnings`, `typos .`, and `cargo test --workspace` all pass.

two tests, both checked against the pre-fix code rather than only observed passing:

- `save_and_shutdown_writes_player_and_world_data` starts a server and asserts the
  known-player cache and the world level data reach disk, so the sequence is checked for
  reaching disk rather than merely returning. skipping the call fails it.
- `save_and_shutdown_disconnects_players_and_claims_their_removal` asserts the shutdown
  translation reached the client and that `process_player_disconnects` is then empty.
  reverting either fix fails it.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments
