### PR TITLE
refactor: use wildcard export for vegetation blocks

### DIFF
--- a/steel-core/src/behavior/blocks/mod.rs
+++ b/steel-core/src/behavior/blocks/mod.rs
@@ -54,25 +54,4 @@ pub use redstone::{
 };
 pub(crate) use redstone::{MAX_REDSTONE_SIGNAL, MIN_REDSTONE_SIGNAL};
 pub(crate) use utils::multiface_face_property;
-pub use vegetation::{
-    AttachedStemBlock, AzaleaBlock, BambooSaplingBlock, BambooStalkBlock, BeetrootBlock,
-    CactusBlock, CactusFlowerBlock, CarrotBlock, CarvedPumpkinBlock, CocoaBlock, CoralBlock,
-    CropBlock, DoublePlantBlock, FlowerBlock, GrassBlock, MangroveLeavesBlock, MultifaceBlock,
-    MyceliumBlock, NetherSproutsBlock, NetherWartBlock, PitcherCropBlock, PotatoBlock,
-    PumpkinBlock, RootedDirtBlock, SeagrassBlock, SnowyBlock, SpreadingGrassBlock, StemBlock,
-    SugarCaneBlock, SweetBerryBushBlock, TallFlowerBlock, TallGrassBlock, TallSeagrassBlock,
-    TintedParticleLeavesBlock, TorchflowerCropBlock, UntintedParticleLeavesBlock,
-};
-pub use vegetation::{
-    BaseCoralFanBlock, BaseCoralPlantBlock, BaseCoralWallFanBlock, BigDripleafBlock,
-    BigDripleafStemBlock, BushBlock, CarpetBlock, CaveVinesBlock, CaveVinesPlantBlock,
-    ChorusFlowerBlock, ChorusPlantBlock, CoralFanBlock, CoralPlantBlock, CoralWallFanBlock,
-    DirtPathBlock, DryVegetationBlock, EyeblossomBlock, EyeblossomType, FarmlandBlock,
-    FireflyBushBlock, FlowerBedBlock, GlowLichenBlock, HangingMossBlock, HangingRootsBlock,
-    HugeMushroomBlock, KelpBlock, KelpPlantBlock, LeafLitterBlock, LilyPadBlock,
-    MangrovePropaguleBlock, MangroveRootsBlock, MossyCarpetBlock, MushroomBlock, NetherFungusBlock,
-    NetherRootsBlock, PointedDripstoneBlock, SaplingBlock, SculkVeinBlock, SeaPickleBlock,
-    ShortDryGrassBlock, SmallDripleafBlock, SporeBlossomBlock, SulfurSpikeBlock, TallDryGrassBlock,
-    TurtleEggBlock, TwistingVinesBlock, TwistingVinesPlantBlock, VineBlock, WeepingVinesBlock,
-    WeepingVinesPlantBlock, WitherRoseBlock, WoolCarpetBlock,
-};
+pub use vegetation::*;


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

replaces the vegetation re-export list in steel-core/src/behavior/blocks/mod.rs with a wildcard export (`pub use vegetation::*;`) to avoid frequent merge conflicts.

## How this was tested

ran `cargo fmt --all --check`, `cargo check`, and `cargo test -p steel-core --lib behavior::blocks`.

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

<!-- This is optional, and you don't need to do it for chores or foundation. -->
<!-- Classes and commands need to be written in the same way as they are written in the [tracker](https://steelmc.dev/tracker/) to appear in it. -->

## Additional notes

<!-- Anything else reviewers should know -->