### PR TITLE
feat(command): add /kick

### DIFF
--- a/steel-core/src/command/builtins/kick.rs
+++ b/steel-core/src/command/builtins/kick.rs
@@ -1,0 +1,122 @@
+//! Vanilla player-kicking command.
+
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandSource, SteelArgumentType, SteelCommandContext, SteelCommandRuntime, argument,
+        literal,
+    },
+    registration::CommandRegistration,
+};
+use crate::entity::Entity as _;
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("kick"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("kick").then(
+        argument("targets", SteelArgumentType::players())
+            .executes(kick_default_reason)
+            .then(argument("reason", SteelArgumentType::message()).executes(kick_with_reason)),
+    )
+}
+
+fn kick_default_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<i32, CommandSyntaxError> {
+    kick_players(
+        context,
+        TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_KICKED),
+    )
+}
+
+fn kick_with_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<i32, CommandSyntaxError> {
+    let reason = context.message("reason")?;
+    kick_players(context, TextComponent::plain(reason.to_owned()))
+}
+
+fn kick_players(
+    context: &SteelCommandContext<CommandSource>,
+    reason: TextComponent,
+) -> Result<i32, CommandSyntaxError> {
+    let targets = context.players("targets")?;
+    let Ok(count) = i32::try_from(targets.len()) else {
+        return Err(CommandSyntaxError::dynamic(
+            "Target player count exceeds the command result range",
+        ));
+    };
+
+    for target in &targets {
+        target.disconnect(reason.clone());
+        let message = translations::COMMANDS_KICK_SUCCESS
+            .message([
+                TextComponent::plain(target.plain_text_name()),
+                reason.clone(),
+            ])
+            .component();
+        context.source().send_success(&message, true);
+    }
+
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn kick_graph_requires_targets_then_optionally_accepts_a_reason() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(kick) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "kick")
+            })
+        }) else {
+            panic!("kick root should exist");
+        };
+        let Some(kick_node) = dispatcher.node(kick) else {
+            panic!("kick root node should exist");
+        };
+        assert!(!kick_node.is_executable());
+
+        let Some(targets) = dispatcher
+            .children(kick)
+            .and_then(|children| children.first())
+        else {
+            panic!("kick targets should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*targets),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::players())
+        ));
+
+        let Some(reason) = dispatcher
+            .children(*targets)
+            .and_then(|children| children.first())
+        else {
+            panic!("kick reason should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*reason),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::message())
+        ));
+    }
+}

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod gamemode;
 mod gamerule;
 mod give;
 mod invsee;
+mod kick;
 mod kill;
 mod list;
 mod locate;
@@ -77,6 +78,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.register(gamemode::registration()?)?;
     builder.register(gamerule::registration())?;
     builder.register(give::registration())?;
+    builder.register(kick::registration())?;
     builder.register(kill::registration())?;
     builder.register(list::registration())?;
     builder.register(locate::registration())?;
@@ -156,6 +158,7 @@ mod tests {
                 "gamemode",
                 "gamerule",
                 "give",
+                "kick",
                 "kill",
                 "list",
                 "locate",

--- a/steel-core/src/command/execution/argument.rs
+++ b/steel-core/src/command/execution/argument.rs
@@ -335,6 +335,10 @@ impl SteelArgumentType {
         Self::new(ComponentParser)
     }
 
+    pub(crate) fn message() -> Self {
+        Self::new(MessageParser)
+    }
+
     pub(crate) fn nbt_path() -> Self {
         Self::new(NbtPathParser)
     }
@@ -533,6 +537,7 @@ argument_value_wrapper!(
     ComponentValue(TextComponent),
     "steel:command/value/component"
 );
+argument_value_wrapper!(MessageValue(Box<str>), "steel:command/value/message");
 argument_value_wrapper!(NbtPathValue(NbtPath), "steel:command/value/nbt_path");
 argument_value_wrapper!(
     IdentifierValue(Identifier),
@@ -1097,6 +1102,16 @@ unit_argument_parser!(
     suggest | _context,
     _builder | {},
     protocol(ProtocolArgumentType::Component, None)
+);
+unit_argument_parser!(
+    MessageParser,
+    "steel:command/parser/message",
+    MessageValue,
+    parse | reader,
+    _source | { Ok(MessageValue(reader.read_remaining().into())) },
+    suggest | _context,
+    _builder | {},
+    protocol(ProtocolArgumentType::Message, None)
 );
 unit_argument_parser!(
     NbtPathParser,

--- a/steel-core/src/command/execution/runtime.rs
+++ b/steel-core/src/command/execution/runtime.rs
@@ -27,7 +27,7 @@ use super::{
     SteelArgumentType, StructureOrTagKey, WorldArgument,
     argument::{
         ComponentValue, CoordinateAxes, DomainValue, EnchantmentValue, EntityTypeValue,
-        GameModeValue, IdentifierValue, ItemStackValue, NbtPathValue, ObjectiveValue,
+        GameModeValue, IdentifierValue, ItemStackValue, MessageValue, NbtPathValue, ObjectiveValue,
         SteelArgumentValue, TimeValue, TimelineValue, WorldClockValue,
     },
     selector::EntitySelector,
@@ -350,6 +350,11 @@ where
     pub(crate) fn text_component(&self, name: &str) -> Result<&TextComponent, CommandSyntaxError> {
         self.typed_argument::<ComponentValue>(name)
             .map(|value| &value.0)
+    }
+
+    pub(crate) fn message(&self, name: &str) -> Result<&str, CommandSyntaxError> {
+        self.typed_argument::<MessageValue>(name)
+            .map(|value| &*value.0)
     }
 
     pub(crate) fn nbt_path(&self, name: &str) -> Result<&NbtPath, CommandSyntaxError> {


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [x] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

Implements vanilla's `/kick <targets> [reason]`, the first of a small batch of
moderation commands (`/kick`, `/ban`, `/ban-ip`, `/pardon`, `/pardon-ip`,
`/banlist`, `/whitelist`) being added as separate PRs so each lands
independently rather than as one large change.

`/kick` disconnects the given online players with an optional free-text
reason, defaulting to `multiplayer.disconnect.kicked` when none is given -
matching `KickCommand.java`. Steel has no singleplayer/LAN concept, so the
vanilla `isPublished()`/owner-kick guards don't apply here.

This also adds a `message` command argument type
(`SteelArgumentType::message()`), matching vanilla's `MessageArgument`: a
greedy, unquoted rest-of-line string (`steel-protocol`'s
`ArgumentType::Message`, id 20, was already defined but unused). `/ban` and
`/ban-ip`'s reason arguments will reuse it in the follow-up PRs.

## How this was tested

`command::builtins::kick::tests::kick_graph_requires_targets_then_optionally_accepts_a_reason`
checks the command graph shape (targets required, reason optional, correct
argument types at each node), matching the existing test style for the other
built-in commands (e.g. `kill`).

`cargo test`, `cargo clippy -r --all-targets --all-features`, `cargo fmt --all --check`,
`typos`, and `prek run --all-files` all pass.

## Screenshots / logs

<!-- n/a -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

- New: `/kick`
- New: `SteelArgumentType::message()` / `MessageParser` / `MessageValue`

## Additional notes

- Scoped deliberately small: no ban/whitelist storage in this PR. See #172
  for prior context on why bundling ban/ban-ip/whitelist/shadowban/kick into
  one PR didn't work out.
