### PR TITLE
feat(command): add /ban and /pardon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ small-map = "0.1.5"
 smallvec = "1.15.2"
 bitflags = "2.13.1"
 phf = { version = "0.14.0", features = ["macros"] }
-chrono = "0.4.45"
+chrono = { version = "0.4.45", features = ["serde"] }
 
 # UUID
 uuid = { version = "1.24.0", features = ["serde", "v4"] }

--- a/steel-core/src/ban.rs
+++ b/steel-core/src/ban.rs
@@ -31,9 +31,10 @@ pub struct BanEntry {
     /// When the ban expires. `None` means it never expires.
     #[serde(default)]
     pub expires: Option<DateTime<Utc>>,
-    /// The ban reason, if any.
+    /// The ban reason, if any. Supports rich text (colors, hover events, ...)
+    /// via SNBT, matching a plain `TextComponent::plain` for ordinary text.
     #[serde(default)]
-    pub reason: Option<String>,
+    pub reason: Option<TextComponent>,
 }
 
 impl BanEntry {
@@ -43,14 +44,13 @@ impl BanEntry {
         self.expires.is_some_and(|expires| expires <= Utc::now())
     }
 
-    /// Returns vanilla's `BanListEntry.getReasonMessage`: the literal reason,
+    /// Returns vanilla's `BanListEntry.getReasonMessage`: the given reason,
     /// or a translated default when none was given.
     #[must_use]
     pub fn reason_message(&self) -> TextComponent {
-        self.reason.as_deref().map_or_else(
-            || TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT),
-            |reason| TextComponent::plain(reason.to_owned()),
-        )
+        self.reason.clone().unwrap_or_else(|| {
+            TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT)
+        })
     }
 
     /// Builds vanilla's `PlayerList.canPlayerLogin` rejection message for this
@@ -244,7 +244,10 @@ mod tests {
     use steel_utils::locks::SyncMutex;
     use uuid::Uuid;
 
-    use super::{BanEntry, BanListConfig, BanListManager, BanListStore, BanListStoreError, Utc};
+    use super::{
+        BanEntry, BanListConfig, BanListManager, BanListStore, BanListStoreError, TextComponent,
+        Utc,
+    };
 
     #[derive(Debug)]
     struct CapturingStore {
@@ -283,7 +286,7 @@ mod tests {
             created: Utc::now(),
             source: "Console".to_owned(),
             expires: None,
-            reason: Some(reason.to_owned()),
+            reason: Some(TextComponent::plain(reason.to_owned())),
         }
     }
 
@@ -302,7 +305,10 @@ mod tests {
 
         let entries = manager.entries();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].reason.as_deref(), Some("second"));
+        assert_eq!(
+            entries[0].reason,
+            Some(TextComponent::plain("second".to_owned()))
+        );
     }
 
     #[tokio::test]

--- a/steel-core/src/ban.rs
+++ b/steel-core/src/ban.rs
@@ -1,0 +1,362 @@
+//! Persisted player ban list.
+//!
+//! Mirrors vanilla's `UserBanList`, but stored as Steel's own
+//! `banned-players.toml` for consistency with the rest of Steel's
+//! TOML-backed configuration rather than vanilla's `banned-players.json`.
+
+use std::{error::Error, fmt, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+use steel_utils::{
+    locks::{AsyncMutex, SyncRwLock},
+    translations,
+};
+use text_components::{Modifier as _, TextComponent};
+use uuid::Uuid;
+
+/// A single ban entry, keyed by player UUID.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BanEntry {
+    /// The banned player's UUID.
+    pub uuid: Uuid,
+    /// The banned player's last-known name, for display purposes only.
+    pub name: String,
+    /// When the ban was created.
+    pub created: DateTime<Utc>,
+    /// Who (or what) created the ban, e.g. a command sender's name.
+    pub source: String,
+    /// When the ban expires. `None` means it never expires.
+    #[serde(default)]
+    pub expires: Option<DateTime<Utc>>,
+    /// The ban reason, if any.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+impl BanEntry {
+    /// Returns whether this ban has expired and should no longer apply.
+    #[must_use]
+    pub fn has_expired(&self) -> bool {
+        self.expires.is_some_and(|expires| expires <= Utc::now())
+    }
+
+    /// Returns vanilla's `BanListEntry.getReasonMessage`: the literal reason,
+    /// or a translated default when none was given.
+    #[must_use]
+    pub fn reason_message(&self) -> TextComponent {
+        self.reason.as_deref().map_or_else(
+            || TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT),
+            |reason| TextComponent::plain(reason.to_owned()),
+        )
+    }
+
+    /// Builds vanilla's `PlayerList.canPlayerLogin` rejection message for this
+    /// ban: the reason, with an expiration line appended when the ban isn't
+    /// permanent.
+    #[must_use]
+    pub fn disconnect_message(&self) -> TextComponent {
+        let message = translations::MULTIPLAYER_DISCONNECT_BANNED_REASON
+            .message([self.reason_message()])
+            .component();
+        let Some(expires) = self.expires else {
+            return message;
+        };
+        let expiration = translations::MULTIPLAYER_DISCONNECT_BANNED_EXPIRATION
+            .message([TextComponent::plain(
+                expires.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+            )])
+            .component();
+        message.add_child(expiration)
+    }
+}
+
+/// Parsed `banned-players.toml` root.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BanListConfig {
+    /// The list of ban entries.
+    #[serde(default)]
+    pub bans: Vec<BanEntry>,
+}
+
+/// Persists the ban list configuration owned outside `steel-core`.
+pub trait BanListStore: Send + Sync {
+    /// Saves the complete ban list configuration.
+    fn save_bans(&self, config: BanListConfig)
+    -> BoxFuture<'static, Result<(), BanListStoreError>>;
+}
+
+/// Ban list persistence failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BanListStoreError {
+    message: String,
+}
+
+impl BanListStoreError {
+    /// Creates a persistence error from a displayable message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BanListStoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for BanListStoreError {}
+
+/// Runtime ban list with persistence-first updates.
+pub struct BanListManager {
+    updates: AsyncMutex<()>,
+    state: SyncRwLock<BanListConfig>,
+    store: Option<Arc<dyn BanListStore>>,
+}
+
+impl fmt::Debug for BanListManager {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BanListManager")
+            .field("updates", &self.updates)
+            .field("state", &self.state)
+            .field("store", &self.store.as_ref().map(|_| "<ban list store>"))
+            .finish()
+    }
+}
+
+impl BanListManager {
+    /// Builds a manager from an initial config and an optional persistence store.
+    #[must_use]
+    pub fn new(config: BanListConfig, store: Option<Arc<dyn BanListStore>>) -> Self {
+        Self {
+            updates: AsyncMutex::new(()),
+            state: SyncRwLock::new(config),
+            store,
+        }
+    }
+
+    /// Builds a manager without persistence.
+    #[must_use]
+    pub fn transient() -> Self {
+        Self::new(BanListConfig::default(), None)
+    }
+
+    /// Returns the active (non-expired) ban entry for a UUID, if any.
+    #[must_use]
+    pub fn find(&self, uuid: Uuid) -> Option<BanEntry> {
+        self.state
+            .read()
+            .bans
+            .iter()
+            .find(|entry| entry.uuid == uuid && !entry.has_expired())
+            .cloned()
+    }
+
+    /// Returns whether a UUID currently has an active ban.
+    #[must_use]
+    pub fn is_banned(&self, uuid: Uuid) -> bool {
+        self.find(uuid).is_some()
+    }
+
+    /// Returns all active (non-expired) ban entries.
+    #[must_use]
+    pub fn entries(&self) -> Vec<BanEntry> {
+        self.state
+            .read()
+            .bans
+            .iter()
+            .filter(|entry| !entry.has_expired())
+            .cloned()
+            .collect()
+    }
+
+    /// Adds or replaces the ban entry for `entry.uuid`, persisting first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn add(&self, entry: BanEntry) -> Result<(), BanListManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        config.bans.retain(|existing| existing.uuid != entry.uuid);
+        config.bans.push(entry);
+        self.persist_locked(config).await
+    }
+
+    /// Removes the ban entry for a UUID, persisting first.
+    ///
+    /// Returns whether an entry was actually removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn remove(&self, uuid: Uuid) -> Result<bool, BanListManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        let previous_len = config.bans.len();
+        config.bans.retain(|entry| entry.uuid != uuid);
+        if config.bans.len() == previous_len {
+            return Ok(false);
+        }
+        self.persist_locked(config).await?;
+        Ok(true)
+    }
+
+    async fn persist_locked(&self, config: BanListConfig) -> Result<(), BanListManagerError> {
+        if let Some(store) = &self.store {
+            store.save_bans(config.clone()).await?;
+        }
+        *self.state.write() = config;
+        Ok(())
+    }
+}
+
+/// Ban list manager update failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BanListManagerError(BanListStoreError);
+
+impl fmt::Display for BanListManagerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "failed to store ban list: {}", self.0)
+    }
+}
+
+impl Error for BanListManagerError {}
+
+impl From<BanListStoreError> for BanListManagerError {
+    fn from(value: BanListStoreError) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::future::BoxFuture;
+    use steel_utils::locks::SyncMutex;
+    use uuid::Uuid;
+
+    use super::{BanEntry, BanListConfig, BanListManager, BanListStore, BanListStoreError, Utc};
+
+    #[derive(Debug)]
+    struct CapturingStore {
+        saved: Arc<SyncMutex<Vec<BanListConfig>>>,
+    }
+
+    impl BanListStore for CapturingStore {
+        fn save_bans(
+            &self,
+            config: BanListConfig,
+        ) -> BoxFuture<'static, Result<(), BanListStoreError>> {
+            let saved = Arc::clone(&self.saved);
+            Box::pin(async move {
+                saved.lock().push(config);
+                Ok(())
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingStore;
+
+    impl BanListStore for FailingStore {
+        fn save_bans(
+            &self,
+            _config: BanListConfig,
+        ) -> BoxFuture<'static, Result<(), BanListStoreError>> {
+            Box::pin(async { Err(BanListStoreError::new("test store failure")) })
+        }
+    }
+
+    fn entry(uuid: Uuid, reason: &str) -> BanEntry {
+        BanEntry {
+            uuid,
+            name: "Steve".to_owned(),
+            created: Utc::now(),
+            source: "Console".to_owned(),
+            expires: None,
+            reason: Some(reason.to_owned()),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_replaces_existing_entry_for_the_same_uuid() {
+        let manager = BanListManager::transient();
+        let uuid = Uuid::nil();
+        manager
+            .add(entry(uuid, "first"))
+            .await
+            .expect("add should succeed");
+        manager
+            .add(entry(uuid, "second"))
+            .await
+            .expect("add should succeed");
+
+        let entries = manager.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].reason.as_deref(), Some("second"));
+    }
+
+    #[tokio::test]
+    async fn expired_bans_are_not_active() {
+        let manager = BanListManager::transient();
+        let uuid = Uuid::nil();
+        let mut expired = entry(uuid, "stale");
+        expired.expires = Some(Utc::now() - chrono::Duration::seconds(1));
+        manager.add(expired).await.expect("add should succeed");
+
+        assert!(!manager.is_banned(uuid));
+        assert_eq!(manager.entries(), Vec::new());
+    }
+
+    #[tokio::test]
+    async fn remove_reports_whether_an_entry_existed() {
+        let manager = BanListManager::transient();
+        let uuid = Uuid::nil();
+        assert!(!manager.remove(uuid).await.expect("remove should succeed"));
+
+        manager
+            .add(entry(uuid, "reason"))
+            .await
+            .expect("add should succeed");
+        assert!(manager.remove(uuid).await.expect("remove should succeed"));
+        assert!(!manager.is_banned(uuid));
+    }
+
+    #[tokio::test]
+    async fn add_persists_before_applying_and_surfaces_store_errors() {
+        let saved = Arc::new(SyncMutex::new(Vec::new()));
+        let manager = BanListManager::new(
+            BanListConfig::default(),
+            Some(Arc::new(CapturingStore {
+                saved: Arc::clone(&saved),
+            })),
+        );
+        let uuid = Uuid::nil();
+        manager
+            .add(entry(uuid, "reason"))
+            .await
+            .expect("add should succeed");
+        assert_eq!(saved.lock().len(), 1);
+        assert!(manager.is_banned(uuid));
+
+        let failing = BanListManager::new(BanListConfig::default(), Some(Arc::new(FailingStore)));
+        let error = failing
+            .add(entry(uuid, "reason"))
+            .await
+            .expect_err("store failure should surface");
+        assert_eq!(
+            error.to_string(),
+            "failed to store ban list: test store failure"
+        );
+        assert!(!failing.is_banned(uuid));
+    }
+}

--- a/steel-core/src/command/builtins/ban.rs
+++ b/steel-core/src/command/builtins/ban.rs
@@ -1,0 +1,208 @@
+//! Vanilla player-banning command.
+
+use chrono::Utc;
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandResultSuspension, CommandResultSuspensionPoll, CommandSource,
+        CommandSuspensionOrder, GameProfileArgument, SteelArgumentType, SteelCommandContext,
+        SteelCommandRuntime, argument, literal,
+    },
+    registration::CommandRegistration,
+};
+use crate::ban::BanEntry;
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("ban"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("ban").then(
+        argument("targets", SteelArgumentType::game_profile())
+            .executes_suspended(ban_without_reason)
+            .then(
+                argument("reason", SteelArgumentType::message())
+                    .executes_suspended(ban_with_reason),
+            ),
+    )
+}
+
+fn ban_without_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<BanCommandSuspension, CommandSyntaxError> {
+    start_ban(context, None)
+}
+
+fn ban_with_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<BanCommandSuspension, CommandSyntaxError> {
+    let reason = context.message("reason")?.to_owned();
+    start_ban(context, Some(reason))
+}
+
+fn start_ban(
+    context: &SteelCommandContext<CommandSource>,
+    reason: Option<String>,
+) -> Result<BanCommandSuspension, CommandSyntaxError> {
+    let argument = context.game_profile_argument("targets").cloned()?;
+    let source = context.source().clone();
+    let task_source = source.clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = run_ban(&task_source, argument, reason).await;
+        let _ = sender.send(result);
+    });
+    Ok(BanCommandSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+struct BanCommandResult {
+    banned: Vec<(String, TextComponent)>,
+}
+
+async fn run_ban(
+    source: &CommandSource,
+    argument: GameProfileArgument,
+    reason: Option<String>,
+) -> Result<BanCommandResult, CommandSyntaxError> {
+    let targets = argument.resolve(source).await?;
+    let source_name = source.sender().to_string();
+    let mut banned = Vec::new();
+
+    for target in targets {
+        if source.server().ban_list.is_banned(target.uuid) {
+            continue;
+        }
+
+        let entry = BanEntry {
+            uuid: target.uuid,
+            name: target.name.clone(),
+            created: Utc::now(),
+            source: source_name.clone(),
+            expires: None,
+            reason: reason.clone(),
+        };
+        let reason_message = entry.reason_message();
+        source
+            .server()
+            .ban_list
+            .add(entry)
+            .await
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()))?;
+
+        if let Some(online) = source.server().online_player(target.uuid) {
+            online.disconnect(TextComponent::from(
+                &translations::MULTIPLAYER_DISCONNECT_BANNED,
+            ));
+        }
+
+        banned.push((target.name, reason_message));
+    }
+
+    if banned.is_empty() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_BAN_FAILED,
+        )));
+    }
+    Ok(BanCommandResult { banned })
+}
+
+struct BanCommandSuspension {
+    source: CommandSource,
+    receiver: oneshot::Receiver<Result<BanCommandResult, CommandSyntaxError>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl CommandResultSuspension for BanCommandSuspension {
+    fn order(&self) -> CommandSuspensionOrder {
+        CommandSuspensionOrder::Global
+    }
+
+    fn poll(&mut self) -> CommandResultSuspensionPoll {
+        match self.receiver.try_recv() {
+            Ok(result) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(result.map(|result| {
+                    let count = result.banned.len().min(i32::MAX as usize) as i32;
+                    for (name, reason) in result.banned {
+                        let message = translations::COMMANDS_BAN_SUCCESS
+                            .message([TextComponent::plain(name), reason])
+                            .component();
+                        self.source.send_success(&message, true);
+                    }
+                    count
+                }))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => CommandResultSuspensionPoll::Pending,
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(Err(CommandSyntaxError::dynamic(
+                    "ban command task ended without a result",
+                )))
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn ban_targets_use_vanillas_game_profile_argument_and_optional_reason() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(ban) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "ban")
+            })
+        }) else {
+            panic!("ban root should exist");
+        };
+        let Some(targets) = dispatcher
+            .children(ban)
+            .and_then(|children| children.first())
+        else {
+            panic!("ban targets should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*targets),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::game_profile())
+        ));
+
+        let Some(reason) = dispatcher
+            .children(*targets)
+            .and_then(|children| children.first())
+        else {
+            panic!("ban reason should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*reason),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::message())
+        ));
+    }
+}

--- a/steel-core/src/command/builtins/ban.rs
+++ b/steel-core/src/command/builtins/ban.rs
@@ -40,13 +40,15 @@ fn ban_without_reason(
 fn ban_with_reason(
     context: &SteelCommandContext<CommandSource>,
 ) -> Result<BanCommandSuspension, CommandSyntaxError> {
-    let reason = context.message("reason")?.to_owned();
+    let reason = context.message("reason")?;
+    let reason = TextComponent::from_snbt(reason)
+        .unwrap_or_else(|_| TextComponent::plain(reason.to_owned()));
     start_ban(context, Some(reason))
 }
 
 fn start_ban(
     context: &SteelCommandContext<CommandSource>,
-    reason: Option<String>,
+    reason: Option<TextComponent>,
 ) -> Result<BanCommandSuspension, CommandSyntaxError> {
     let argument = context.game_profile_argument("targets").cloned()?;
     let source = context.source().clone();
@@ -70,7 +72,7 @@ struct BanCommandResult {
 async fn run_ban(
     source: &CommandSource,
     argument: GameProfileArgument,
-    reason: Option<String>,
+    reason: Option<TextComponent>,
 ) -> Result<BanCommandResult, CommandSyntaxError> {
     let targets = argument.resolve(source).await?;
     let source_name = source.sender().to_string();

--- a/steel-core/src/command/builtins/kick.rs
+++ b/steel-core/src/command/builtins/kick.rs
@@ -1,0 +1,122 @@
+//! Vanilla player-kicking command.
+
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandSource, SteelArgumentType, SteelCommandContext, SteelCommandRuntime, argument,
+        literal,
+    },
+    registration::CommandRegistration,
+};
+use crate::entity::Entity as _;
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("kick"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("kick").then(
+        argument("targets", SteelArgumentType::players())
+            .executes(kick_default_reason)
+            .then(argument("reason", SteelArgumentType::message()).executes(kick_with_reason)),
+    )
+}
+
+fn kick_default_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<i32, CommandSyntaxError> {
+    kick_players(
+        context,
+        TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_KICKED),
+    )
+}
+
+fn kick_with_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<i32, CommandSyntaxError> {
+    let reason = context.message("reason")?;
+    kick_players(context, TextComponent::plain(reason.to_owned()))
+}
+
+fn kick_players(
+    context: &SteelCommandContext<CommandSource>,
+    reason: TextComponent,
+) -> Result<i32, CommandSyntaxError> {
+    let targets = context.players("targets")?;
+    let Ok(count) = i32::try_from(targets.len()) else {
+        return Err(CommandSyntaxError::dynamic(
+            "Target player count exceeds the command result range",
+        ));
+    };
+
+    for target in &targets {
+        target.disconnect(reason.clone());
+        let message = translations::COMMANDS_KICK_SUCCESS
+            .message([
+                TextComponent::plain(target.plain_text_name()),
+                reason.clone(),
+            ])
+            .component();
+        context.source().send_success(&message, true);
+    }
+
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn kick_graph_requires_targets_then_optionally_accepts_a_reason() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(kick) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "kick")
+            })
+        }) else {
+            panic!("kick root should exist");
+        };
+        let Some(kick_node) = dispatcher.node(kick) else {
+            panic!("kick root node should exist");
+        };
+        assert!(!kick_node.is_executable());
+
+        let Some(targets) = dispatcher
+            .children(kick)
+            .and_then(|children| children.first())
+        else {
+            panic!("kick targets should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*targets),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::players())
+        ));
+
+        let Some(reason) = dispatcher
+            .children(*targets)
+            .and_then(|children| children.first())
+        else {
+            panic!("kick reason should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*reason),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::message())
+        ));
+    }
+}

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod gamemode;
 mod gamerule;
 mod give;
 mod invsee;
+mod kick;
 mod kill;
 mod list;
 mod locate;
@@ -77,6 +78,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.register(gamemode::registration()?)?;
     builder.register(gamerule::registration())?;
     builder.register(give::registration())?;
+    builder.register(kick::registration())?;
     builder.register(kill::registration())?;
     builder.register(list::registration())?;
     builder.register(locate::registration())?;
@@ -156,6 +158,7 @@ mod tests {
                 "gamemode",
                 "gamerule",
                 "give",
+                "kick",
                 "kill",
                 "list",
                 "locate",

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -1,5 +1,6 @@
 //! Steel-owned built-in command declarations.
 
+mod ban;
 mod clear;
 mod damage;
 mod difficulty;
@@ -18,6 +19,7 @@ mod kill;
 mod list;
 mod locate;
 mod operator;
+mod pardon;
 mod perms;
 mod playsound;
 mod return_command;
@@ -65,6 +67,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.declare_permission(perms::MANAGE_ALL_PERMISSION)?;
     builder.declare_permission(perms::GROUP_ALL_PERMISSION)?;
     builder.declare_permission(perms::METADATA_PERMISSION)?;
+    builder.register(ban::registration())?;
     builder.register(clear::registration())?;
     builder.register(operator::deop_registration())?;
     builder.register(damage::registration())?;
@@ -83,6 +86,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.register(list::registration())?;
     builder.register(locate::registration())?;
     builder.register(operator::op_registration())?;
+    builder.register(pardon::registration())?;
     builder.register(perms::registration())?;
     builder.register(playsound::registration())?;
     builder.register(return_command::registration())?;
@@ -144,6 +148,7 @@ mod tests {
         assert_eq!(
             names,
             [
+                "ban",
                 "clear",
                 "deop",
                 "damage",
@@ -163,6 +168,7 @@ mod tests {
                 "list",
                 "locate",
                 "op",
+                "pardon",
                 "perms",
                 "playsound",
                 "return",

--- a/steel-core/src/command/builtins/pardon.rs
+++ b/steel-core/src/command/builtins/pardon.rs
@@ -1,0 +1,154 @@
+//! Vanilla player-unbanning command.
+
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandResultSuspension, CommandResultSuspensionPoll, CommandSource,
+        CommandSuspensionOrder, GameProfileArgument, SteelArgumentType, SteelCommandContext,
+        SteelCommandRuntime, argument, literal,
+    },
+    registration::CommandRegistration,
+};
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("pardon"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("pardon").then(
+        argument("targets", SteelArgumentType::game_profile()).executes_suspended(start_pardon),
+    )
+}
+
+fn start_pardon(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<PardonCommandSuspension, CommandSyntaxError> {
+    let argument = context.game_profile_argument("targets").cloned()?;
+    let source = context.source().clone();
+    let task_source = source.clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = run_pardon(&task_source, argument).await;
+        let _ = sender.send(result);
+    });
+    Ok(PardonCommandSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+struct PardonCommandResult {
+    pardoned_names: Vec<String>,
+}
+
+async fn run_pardon(
+    source: &CommandSource,
+    argument: GameProfileArgument,
+) -> Result<PardonCommandResult, CommandSyntaxError> {
+    let targets = argument.resolve(source).await?;
+    let mut pardoned_names = Vec::new();
+
+    for target in targets {
+        let removed = source
+            .server()
+            .ban_list
+            .remove(target.uuid)
+            .await
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()))?;
+        if removed {
+            pardoned_names.push(target.name);
+        }
+    }
+
+    if pardoned_names.is_empty() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_PARDON_FAILED,
+        )));
+    }
+    Ok(PardonCommandResult { pardoned_names })
+}
+
+struct PardonCommandSuspension {
+    source: CommandSource,
+    receiver: oneshot::Receiver<Result<PardonCommandResult, CommandSyntaxError>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl CommandResultSuspension for PardonCommandSuspension {
+    fn order(&self) -> CommandSuspensionOrder {
+        CommandSuspensionOrder::Global
+    }
+
+    fn poll(&mut self) -> CommandResultSuspensionPoll {
+        match self.receiver.try_recv() {
+            Ok(result) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(result.map(|result| {
+                    let count = result.pardoned_names.len().min(i32::MAX as usize) as i32;
+                    for name in result.pardoned_names {
+                        let message = translations::COMMANDS_PARDON_SUCCESS
+                            .message([TextComponent::plain(name)])
+                            .component();
+                        self.source.send_success(&message, true);
+                    }
+                    count
+                }))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => CommandResultSuspensionPoll::Pending,
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(Err(CommandSyntaxError::dynamic(
+                    "pardon command task ended without a result",
+                )))
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn pardon_targets_use_vanillas_game_profile_argument() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(pardon) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "pardon")
+            })
+        }) else {
+            panic!("pardon root should exist");
+        };
+        let Some(targets) = dispatcher
+            .children(pardon)
+            .and_then(|children| children.first())
+        else {
+            panic!("pardon targets should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*targets),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::game_profile())
+        ));
+    }
+}

--- a/steel-core/src/command/execution/argument.rs
+++ b/steel-core/src/command/execution/argument.rs
@@ -335,6 +335,10 @@ impl SteelArgumentType {
         Self::new(ComponentParser)
     }
 
+    pub(crate) fn message() -> Self {
+        Self::new(MessageParser)
+    }
+
     pub(crate) fn nbt_path() -> Self {
         Self::new(NbtPathParser)
     }
@@ -533,6 +537,7 @@ argument_value_wrapper!(
     ComponentValue(TextComponent),
     "steel:command/value/component"
 );
+argument_value_wrapper!(MessageValue(Box<str>), "steel:command/value/message");
 argument_value_wrapper!(NbtPathValue(NbtPath), "steel:command/value/nbt_path");
 argument_value_wrapper!(
     IdentifierValue(Identifier),
@@ -1097,6 +1102,16 @@ unit_argument_parser!(
     suggest | _context,
     _builder | {},
     protocol(ProtocolArgumentType::Component, None)
+);
+unit_argument_parser!(
+    MessageParser,
+    "steel:command/parser/message",
+    MessageValue,
+    parse | reader,
+    _source | { Ok(MessageValue(reader.read_remaining().into())) },
+    suggest | _context,
+    _builder | {},
+    protocol(ProtocolArgumentType::Message, None)
 );
 unit_argument_parser!(
     NbtPathParser,

--- a/steel-core/src/command/execution/runtime.rs
+++ b/steel-core/src/command/execution/runtime.rs
@@ -27,7 +27,7 @@ use super::{
     SteelArgumentType, StructureOrTagKey, WorldArgument,
     argument::{
         ComponentValue, CoordinateAxes, DomainValue, EnchantmentValue, EntityTypeValue,
-        GameModeValue, IdentifierValue, ItemStackValue, NbtPathValue, ObjectiveValue,
+        GameModeValue, IdentifierValue, ItemStackValue, MessageValue, NbtPathValue, ObjectiveValue,
         SteelArgumentValue, TimeValue, TimelineValue, WorldClockValue,
     },
     selector::EntitySelector,
@@ -350,6 +350,11 @@ where
     pub(crate) fn text_component(&self, name: &str) -> Result<&TextComponent, CommandSyntaxError> {
         self.typed_argument::<ComponentValue>(name)
             .map(|value| &value.0)
+    }
+
+    pub(crate) fn message(&self, name: &str) -> Result<&str, CommandSyntaxError> {
+        self.typed_argument::<MessageValue>(name)
+            .map(|value| &*value.0)
     }
 
     pub(crate) fn nbt_path(&self, name: &str) -> Result<&NbtPath, CommandSyntaxError> {

--- a/steel-core/src/command/execution/source.rs
+++ b/steel-core/src/command/execution/source.rs
@@ -312,10 +312,6 @@ impl CommandSource {
         }
     }
 
-    #[expect(
-        dead_code,
-        reason = "source-aware runtime extensions need access to the original sender"
-    )]
     pub(crate) const fn sender(&self) -> &CommandSender {
         &self.sender
     }

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 use crate::chunk::chunk_map::ChunkMap;
 
+pub mod ban;
 pub mod behavior;
 pub mod block_entity;
 pub mod bootstrap;

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -37,6 +37,7 @@ use crate::entity::{
     Entity, EntityBase, PendingWorldChangeToken, RemovalReason, SharedEntity, change_entity_world,
 };
 
+use crate::ban::BanListManager;
 use crate::chunk_saver::{ChunkStorage, PersistentEntity, registry::WorldStorageRegistry};
 use crate::level_data::{LevelDataManager, RespawnData, WorldGenerationSettings};
 use crate::permission::{
@@ -379,6 +380,8 @@ pub struct Server {
     pub config: Arc<RuntimeConfig>,
     /// Runtime permission groups and their persistence boundary.
     pub permission_groups: PermissionGroupManager,
+    /// Runtime player ban list and its persistence boundary.
+    pub ban_list: BanListManager,
     /// The cancellation token for graceful shutdown.
     pub cancel_token: CancellationToken,
     /// The key store for the server.
@@ -524,6 +527,7 @@ impl Server {
         config: RuntimeConfig,
         worlds_config: WorldsConfig,
         permission_groups: PermissionGroupManager,
+        ban_list: BanListManager,
     ) -> Result<Self, String> {
         Self::new_with_commands(
             chunk_runtime,
@@ -531,6 +535,7 @@ impl Server {
             config,
             worlds_config,
             permission_groups,
+            ban_list,
             CommandRegistry::new(),
         )
         .await
@@ -547,6 +552,7 @@ impl Server {
         config: RuntimeConfig,
         worlds_config: WorldsConfig,
         permission_groups: PermissionGroupManager,
+        ban_list: BanListManager,
         command_registry: CommandRegistry,
     ) -> Result<Self, String> {
         validate_login_security(config.online_mode, config.encryption).map_err(str::to_owned)?;
@@ -709,6 +715,7 @@ impl Server {
         Ok(Server {
             config,
             permission_groups,
+            ban_list,
             cancel_token,
             key_store: KeyStore::create(),
             worlds,

--- a/steel-core/src/server/player_lifecycle.rs
+++ b/steel-core/src/server/player_lifecycle.rs
@@ -468,6 +468,12 @@ impl Server {
         self.online_players.len()
     }
 
+    /// Returns the currently connected player with this UUID, if any.
+    #[must_use]
+    pub fn online_player(&self, uuid: Uuid) -> Option<Arc<Player>> {
+        self.online_players.get_by_uuid(&uuid)
+    }
+
     /// Returns a sample of up to 12 online players for the server list ping.
     #[must_use]
     pub fn player_sample(&self) -> Vec<(String, String)> {

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -41,6 +41,7 @@ use tokio::{
 };
 use uuid::Uuid;
 
+use crate::ban::BanListManager;
 use crate::behavior::init_behaviors;
 use crate::command::execution::{
     CommandArgumentSource, CommandExecutionContext, CommandPermissionSource, CommandResultCallback,
@@ -232,12 +233,14 @@ async fn test_server_with_worlds(
         .collect();
     let permission_groups = PermissionGroupManager::transient(PermissionGroupsConfig::default())
         .map_err(|error| format!("test permission groups should resolve: {error}"))?;
+    let ban_list = BanListManager::transient();
     let config = test_runtime_config();
     let registry_cache = RegistryCache::new(config.compression);
 
     Ok(Arc::new(Server {
         config,
         permission_groups,
+        ban_list,
         cancel_token: CancellationToken::new(),
         key_store: KeyStore::create(),
         registry_cache,
@@ -3884,6 +3887,7 @@ default = true
         worlds_config,
         PermissionGroupManager::transient(PermissionGroupsConfig::default())
             .expect("default permission groups should resolve"),
+        BanListManager::transient(),
     )
     .await
 }

--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -50,6 +50,10 @@ impl JavaTcpClient {
         profile: GameProfile,
         reader_encryption: Option<[u8; 16]>,
     ) -> ConnectionAction {
+        if let Some(ban) = self.server.ban_list.find(profile.id) {
+            self.kick(ban.disconnect_message()).await;
+            return ConnectionAction::none();
+        }
         let action = self.send_login_compression().await;
         if !self.disconnect_duplicate_player(&profile).await {
             return ConnectionAction::none();

--- a/steel/src/config/ban_list.rs
+++ b/steel/src/config/ban_list.rs
@@ -1,0 +1,72 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use futures::future::BoxFuture;
+use steel_core::ban::{BanListConfig, BanListStore, BanListStoreError};
+use tokio::fs as async_fs;
+
+const DEFAULT_BAN_LIST: &str = "bans = []\n";
+
+/// TOML-backed ban list store.
+#[derive(Clone, Debug)]
+pub struct FileBanListStore {
+    path: PathBuf,
+}
+
+impl FileBanListStore {
+    /// Creates a file-backed ban list store.
+    #[must_use]
+    pub const fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl BanListStore for FileBanListStore {
+    fn save_bans(
+        &self,
+        config: BanListConfig,
+    ) -> BoxFuture<'static, Result<(), BanListStoreError>> {
+        let path = self.path.clone();
+        Box::pin(async move {
+            let serialized = toml::to_string_pretty(&config).map_err(|error| {
+                BanListStoreError::new(format!("failed to serialize ban list: {error}"))
+            })?;
+            write_atomic_config(&path, serialized)
+                .await
+                .map_err(|error| {
+                    BanListStoreError::new(format!(
+                        "failed to write ban list {}: {error}",
+                        path.display()
+                    ))
+                })
+        })
+    }
+}
+
+async fn write_atomic_config(path: &Path, contents: String) -> io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "config path has no parent",
+        ));
+    };
+    async_fs::create_dir_all(parent).await?;
+    let temp_path = path.with_extension("toml.tmp");
+    async_fs::write(&temp_path, contents).await?;
+    async_fs::rename(temp_path, path).await
+}
+
+pub(super) fn load_or_create_ban_list(path: &Path) -> Result<BanListConfig, String> {
+    if path.exists() {
+        let contents = fs::read_to_string(path)
+            .map_err(|error| format!("failed to read ban list {}: {error}", path.display()))?;
+        toml::from_str(&contents)
+            .map_err(|error| format!("failed to parse ban list {}: {error}", path.display()))
+    } else {
+        fs::write(path, DEFAULT_BAN_LIST)
+            .map_err(|error| format!("failed to write ban list {}: {error}", path.display()))?;
+        Ok(BanListConfig::default())
+    }
+}

--- a/steel/src/config/mod.rs
+++ b/steel/src/config/mod.rs
@@ -4,10 +4,12 @@
 //! The config is loaded once at startup, split into creation-time values
 //! (consumed by the server constructor) and a `RuntimeConfig` (stored on `Server`).
 
+mod ban_list;
 mod groups;
 mod logging;
 mod server;
 
+pub use ban_list::FileBanListStore;
 pub use groups::FilePermissionGroupStore;
 pub use logging::{LogConfig, LogLevel, LogTimeFormat, RotationTimeFormat};
 pub use server::{ServerConfig, ThreadConfig};
@@ -21,11 +23,12 @@ use std::{
 
 use serde::Deserialize;
 use steel_core::{
+    ban::{BanListConfig, BanListStore},
     config::WorldsConfig,
     permission::{PermissionGroupStore, PermissionGroupsConfig},
 };
 
-use self::{groups::load_or_create_groups, server::validate};
+use self::{ban_list::load_or_create_ban_list, groups::load_or_create_groups, server::validate};
 
 #[cfg(feature = "stand-alone")]
 const DEFAULT_FAVICON: &[u8] = include_bytes!("../../../package-content/favicon.png");
@@ -50,6 +53,12 @@ pub struct SteelConfig {
     /// Path to the loaded `groups.toml`.
     #[serde(skip, default)]
     pub groups_path: Option<PathBuf>,
+    /// Ban list configuration from `banned-players.toml`.
+    #[serde(skip, default)]
+    pub ban_list: BanListConfig,
+    /// Path to the loaded `banned-players.toml`.
+    #[serde(skip, default)]
+    pub ban_list_path: Option<PathBuf>,
 }
 
 impl SteelConfig {
@@ -59,6 +68,14 @@ impl SteelConfig {
         self.groups_path.as_ref().map(|path| {
             Arc::new(FilePermissionGroupStore::new(path.clone())) as Arc<dyn PermissionGroupStore>
         })
+    }
+
+    /// Builds the store used for persistence-first ban list updates.
+    #[must_use]
+    pub fn ban_list_store(&self) -> Option<Arc<dyn BanListStore>> {
+        self.ban_list_path
+            .as_ref()
+            .map(|path| Arc::new(FileBanListStore::new(path.clone())) as Arc<dyn BanListStore>)
     }
 }
 
@@ -112,6 +129,12 @@ pub fn load_or_create(path: &Path) -> Result<SteelConfig, String> {
         .join("groups.toml");
     config.groups = load_or_create_groups(&groups_path)?;
     config.groups_path = Some(groups_path);
+    let ban_list_path = path
+        .parent()
+        .ok_or_else(|| format!("failed to get config directory for {}", path.display()))?
+        .join("banned-players.toml");
+    config.ban_list = load_or_create_ban_list(&ban_list_path)?;
+    config.ban_list_path = Some(ban_list_path);
 
     // If icon file doesnt exist, write it
     #[cfg(feature = "stand-alone")]

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use steel_core::{
-    GIT_HASH_SHORT, command::CommandRegistry, permission::PermissionGroupManager, server::Server,
+    GIT_HASH_SHORT, ban::BanListManager, command::CommandRegistry,
+    permission::PermissionGroupManager, server::Server,
 };
 use steel_login::{JavaTcpClient, ServerConnectionSession};
 use tokio::{net::TcpListener, runtime::Runtime, select};
@@ -93,8 +94,10 @@ impl SteelServer {
         log::info!("Starting Steel Server ({GIT_HASH_SHORT})");
 
         let permission_group_store = steel_config.permission_group_store();
+        let ban_list_store = steel_config.ban_list_store();
         let server_port = steel_config.server.server_port;
         let worlds_config = steel_config.worlds;
+        let ban_list = BanListManager::new(steel_config.ban_list, ban_list_store);
         let permission_groups =
             PermissionGroupManager::new(steel_config.groups, permission_group_store).map_err(
                 |error| {
@@ -110,6 +113,7 @@ impl SteelServer {
             runtime_config,
             worlds_config,
             permission_groups,
+            ban_list,
             command_registry,
         )
         .await


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [x] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

Second PR in the moderation-commands batch started by #664 (`/kick`). This one
implements `/ban` and `/pardon`, matching vanilla's `BanPlayerCommands` and
`PardonCommand`. `/ban-ip`, `/pardon-ip`, `/banlist`, and `/whitelist` are
intentionally left for follow-up PRs - see #172 for why bundling all of this
together into one PR didn't work out last time. `/shadowban` isn't vanilla
and isn't part of this batch at all; it needs its own design discussion
first.

**Storage**: a new `steel_core::ban` module (`BanEntry`, `BanListConfig`,
`BanListManager`) mirrors the existing `permission::PermissionGroupManager`
pattern - an in-memory `SyncRwLock` snapshot with persistence-first updates
behind an `AsyncMutex`, and a `BanListStore` trait so `steel-core` stays
IO-free. `steel`'s `FileBanListStore` persists it to `banned-players.toml`
next to `config.toml`/`groups.toml`/`worlds.toml` - TOML to stay consistent
with the rest of Steel's own config, not vanilla's `banned-players.json`
(discussed and decided this way, rather than repeating the custom-format
concerns raised on #172).

**Commands**: `/ban <targets> [reason]` and `/pardon <targets>` both resolve
through the existing `GameProfileArgument` (`operator.rs`'s pattern), so
banning/pardoning works for offline players too, not just online ones.
`/ban` skips a target that's already banned (matching vanilla, so re-banning
doesn't clobber the original ban's timestamp/reason) and disconnects the
player immediately if they're currently online
(`multiplayer.disconnect.banned`, matching `BanPlayerCommands`'s live-kick).

**Login enforcement**: `steel-login`'s `finish_verified_login` now checks
`server.ban_list.find(uuid)` before completing login, rejecting with vanilla's
`multiplayer.disconnect.banned.reason` (+ `...expiration` if the ban isn't
permanent), matching `PlayerList.canPlayerLogin`. Without this, `/ban` would
just be a list with no actual effect on future connections.

Also adds a small `Server::online_player(uuid)` lookup (`player_lifecycle.rs`)
since nothing previously exposed a public online-player-by-uuid accessor
outside `server/`.

## How this was tested

- `ban::tests`: entry replacement on re-ban, expiry handling, remove
  reporting whether an entry existed, and a persistence-first round trip
  through a capturing/failing `BanListStore` (mirrors
  `permission::tests::manager`'s store-testing pattern).
- `command::builtins::ban::tests` / `pardon::tests`: command graph shape
  (targets required, `/ban`'s reason optional, correct argument types).

`cargo test`, `cargo clippy -r --all-targets --all-features`,
`cargo fmt --all --check`, `typos`, and `prek run --all-files` all pass.

## Screenshots / logs

<!-- n/a -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

- New: `/ban`, `/pardon`
- New: `steel_core::ban` (`BanEntry`, `BanListConfig`, `BanListManager`,
  `BanListStore`), `steel::config::FileBanListStore`
- New: `Server::ban_list`, `Server::online_player(uuid)`
- Changed: `Server::new` / `Server::new_with_commands` now also take a
  `BanListManager` (same shape as the existing `permission_groups` parameter)
- Changed: `steel-login`'s `finish_verified_login` now rejects banned UUIDs

## Additional notes

- `chrono`'s `serde` feature is now enabled workspace-wide (needed to
  (de)serialize `BanEntry.created`/`expires` to/from `banned-players.toml`).
- This branch is stacked on #664 (`/kick`), since `/ban`'s reason argument
  reuses the `message` argument type added there. The diff currently includes
  #664's commit too - it'll shrink to just this PR's changes automatically
  once #664 merges into `master`.
