### PR TITLE
feat(command): add /whitelist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ small-map = "0.1.5"
 smallvec = "1.15.2"
 bitflags = "2.13.1"
 phf = { version = "0.14.0", features = ["macros"] }
-chrono = "0.4.45"
+chrono = { version = "0.4.45", features = ["serde"] }
 
 # UUID
 uuid = { version = "1.24.0", features = ["serde", "v4"] }

--- a/steel-core/src/ban.rs
+++ b/steel-core/src/ban.rs
@@ -31,9 +31,10 @@ pub struct BanEntry {
     /// When the ban expires. `None` means it never expires.
     #[serde(default)]
     pub expires: Option<DateTime<Utc>>,
-    /// The ban reason, if any.
+    /// The ban reason, if any. Supports rich text (colors, hover events, ...)
+    /// via SNBT, matching a plain `TextComponent::plain` for ordinary text.
     #[serde(default)]
-    pub reason: Option<String>,
+    pub reason: Option<TextComponent>,
 }
 
 impl BanEntry {
@@ -43,14 +44,13 @@ impl BanEntry {
         self.expires.is_some_and(|expires| expires <= Utc::now())
     }
 
-    /// Returns vanilla's `BanListEntry.getReasonMessage`: the literal reason,
+    /// Returns vanilla's `BanListEntry.getReasonMessage`: the given reason,
     /// or a translated default when none was given.
     #[must_use]
     pub fn reason_message(&self) -> TextComponent {
-        self.reason.as_deref().map_or_else(
-            || TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT),
-            |reason| TextComponent::plain(reason.to_owned()),
-        )
+        self.reason.clone().unwrap_or_else(|| {
+            TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT)
+        })
     }
 
     /// Builds vanilla's `PlayerList.canPlayerLogin` rejection message for this
@@ -244,7 +244,10 @@ mod tests {
     use steel_utils::locks::SyncMutex;
     use uuid::Uuid;
 
-    use super::{BanEntry, BanListConfig, BanListManager, BanListStore, BanListStoreError, Utc};
+    use super::{
+        BanEntry, BanListConfig, BanListManager, BanListStore, BanListStoreError, TextComponent,
+        Utc,
+    };
 
     #[derive(Debug)]
     struct CapturingStore {
@@ -283,7 +286,7 @@ mod tests {
             created: Utc::now(),
             source: "Console".to_owned(),
             expires: None,
-            reason: Some(reason.to_owned()),
+            reason: Some(TextComponent::plain(reason.to_owned())),
         }
     }
 
@@ -302,7 +305,10 @@ mod tests {
 
         let entries = manager.entries();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].reason.as_deref(), Some("second"));
+        assert_eq!(
+            entries[0].reason,
+            Some(TextComponent::plain("second".to_owned()))
+        );
     }
 
     #[tokio::test]

--- a/steel-core/src/ban.rs
+++ b/steel-core/src/ban.rs
@@ -250,9 +250,10 @@ pub struct IpBanEntry {
     /// When the ban expires. `None` means it never expires.
     #[serde(default)]
     pub expires: Option<DateTime<Utc>>,
-    /// The ban reason, if any.
+    /// The ban reason, if any. Supports rich text (colors, hover events, ...)
+    /// via SNBT, matching a plain `TextComponent::plain` for ordinary text.
     #[serde(default)]
-    pub reason: Option<String>,
+    pub reason: Option<TextComponent>,
 }
 
 impl IpBanEntry {
@@ -262,14 +263,13 @@ impl IpBanEntry {
         self.expires.is_some_and(|expires| expires <= Utc::now())
     }
 
-    /// Returns vanilla's `BanListEntry.getReasonMessage`: the literal reason,
+    /// Returns vanilla's `BanListEntry.getReasonMessage`: the given reason,
     /// or a translated default when none was given.
     #[must_use]
     pub fn reason_message(&self) -> TextComponent {
-        self.reason.as_deref().map_or_else(
-            || TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT),
-            |reason| TextComponent::plain(reason.to_owned()),
-        )
+        self.reason.clone().unwrap_or_else(|| {
+            TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT)
+        })
     }
 
     /// Builds vanilla's `PlayerList.canPlayerLogin` IP-ban rejection message:
@@ -539,7 +539,7 @@ mod tests {
             created: Utc::now(),
             source: "Console".to_owned(),
             expires: None,
-            reason: Some(reason.to_owned()),
+            reason: Some(TextComponent::plain(reason.to_owned())),
         }
     }
 
@@ -558,7 +558,10 @@ mod tests {
         let entry = manager
             .find("127.0.0.1")
             .expect("entry should still be banned");
-        assert_eq!(entry.reason.as_deref(), Some("second"));
+        assert_eq!(
+            entry.reason,
+            Some(TextComponent::plain("second".to_owned()))
+        );
     }
 
     #[tokio::test]

--- a/steel-core/src/ban.rs
+++ b/steel-core/src/ban.rs
@@ -362,6 +362,18 @@ impl IpBanListManager {
         self.find(ip).is_some()
     }
 
+    /// Returns all active (non-expired) ban entries.
+    #[must_use]
+    pub fn entries(&self) -> Vec<IpBanEntry> {
+        self.state
+            .read()
+            .bans
+            .iter()
+            .filter(|entry| !entry.has_expired())
+            .cloned()
+            .collect()
+    }
+
     /// Adds or replaces the ban entry for `entry.ip`, persisting first.
     ///
     /// # Errors

--- a/steel-core/src/ban.rs
+++ b/steel-core/src/ban.rs
@@ -236,6 +236,173 @@ impl From<BanListStoreError> for BanListManagerError {
     }
 }
 
+/// A single IP ban entry, keyed by the banned IP address, matching vanilla's
+/// `IpBanListEntry`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IpBanEntry {
+    /// The banned IP address, as text (e.g. `"127.0.0.1"`).
+    pub ip: String,
+    /// When the ban was created.
+    pub created: DateTime<Utc>,
+    /// Who (or what) created the ban, e.g. a command sender's name.
+    pub source: String,
+    /// When the ban expires. `None` means it never expires.
+    #[serde(default)]
+    pub expires: Option<DateTime<Utc>>,
+    /// The ban reason, if any.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+impl IpBanEntry {
+    /// Returns whether this ban has expired and should no longer apply.
+    #[must_use]
+    pub fn has_expired(&self) -> bool {
+        self.expires.is_some_and(|expires| expires <= Utc::now())
+    }
+
+    /// Returns vanilla's `BanListEntry.getReasonMessage`: the literal reason,
+    /// or a translated default when none was given.
+    #[must_use]
+    pub fn reason_message(&self) -> TextComponent {
+        self.reason.as_deref().map_or_else(
+            || TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT),
+            |reason| TextComponent::plain(reason.to_owned()),
+        )
+    }
+
+    /// Builds vanilla's `PlayerList.canPlayerLogin` IP-ban rejection message:
+    /// the reason, with an expiration line appended when the ban isn't
+    /// permanent.
+    #[must_use]
+    pub fn disconnect_message(&self) -> TextComponent {
+        let message = translations::MULTIPLAYER_DISCONNECT_BANNED_IP_REASON
+            .message([self.reason_message()])
+            .component();
+        let Some(expires) = self.expires else {
+            return message;
+        };
+        let expiration = translations::MULTIPLAYER_DISCONNECT_BANNED_IP_EXPIRATION
+            .message([TextComponent::plain(
+                expires.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+            )])
+            .component();
+        message.add_child(expiration)
+    }
+}
+
+/// Parsed `banned-ips.toml` root.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IpBanListConfig {
+    /// The list of IP ban entries.
+    #[serde(default)]
+    pub bans: Vec<IpBanEntry>,
+}
+
+/// Persists the IP ban list configuration owned outside `steel-core`.
+pub trait IpBanListStore: Send + Sync {
+    /// Saves the complete IP ban list configuration.
+    fn save_bans(
+        &self,
+        config: IpBanListConfig,
+    ) -> BoxFuture<'static, Result<(), BanListStoreError>>;
+}
+
+/// Runtime IP ban list with persistence-first updates.
+pub struct IpBanListManager {
+    updates: AsyncMutex<()>,
+    state: SyncRwLock<IpBanListConfig>,
+    store: Option<Arc<dyn IpBanListStore>>,
+}
+
+impl fmt::Debug for IpBanListManager {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("IpBanListManager")
+            .field("updates", &self.updates)
+            .field("state", &self.state)
+            .field("store", &self.store.as_ref().map(|_| "<ip ban list store>"))
+            .finish()
+    }
+}
+
+impl IpBanListManager {
+    /// Builds a manager from an initial config and an optional persistence store.
+    #[must_use]
+    pub fn new(config: IpBanListConfig, store: Option<Arc<dyn IpBanListStore>>) -> Self {
+        Self {
+            updates: AsyncMutex::new(()),
+            state: SyncRwLock::new(config),
+            store,
+        }
+    }
+
+    /// Builds a manager without persistence.
+    #[must_use]
+    pub fn transient() -> Self {
+        Self::new(IpBanListConfig::default(), None)
+    }
+
+    /// Returns the active (non-expired) ban entry for an IP, if any.
+    #[must_use]
+    pub fn find(&self, ip: &str) -> Option<IpBanEntry> {
+        self.state
+            .read()
+            .bans
+            .iter()
+            .find(|entry| entry.ip == ip && !entry.has_expired())
+            .cloned()
+    }
+
+    /// Returns whether an IP currently has an active ban.
+    #[must_use]
+    pub fn is_banned(&self, ip: &str) -> bool {
+        self.find(ip).is_some()
+    }
+
+    /// Adds or replaces the ban entry for `entry.ip`, persisting first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn add(&self, entry: IpBanEntry) -> Result<(), BanListManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        config.bans.retain(|existing| existing.ip != entry.ip);
+        config.bans.push(entry);
+        self.persist_locked(config).await
+    }
+
+    /// Removes the ban entry for an IP, persisting first.
+    ///
+    /// Returns whether an entry was actually removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn remove(&self, ip: &str) -> Result<bool, BanListManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        let previous_len = config.bans.len();
+        config.bans.retain(|entry| entry.ip != ip);
+        if config.bans.len() == previous_len {
+            return Ok(false);
+        }
+        self.persist_locked(config).await?;
+        Ok(true)
+    }
+
+    async fn persist_locked(&self, config: IpBanListConfig) -> Result<(), BanListManagerError> {
+        if let Some(store) = &self.store {
+            store.save_bans(config.clone()).await?;
+        }
+        *self.state.write() = config;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -245,8 +412,8 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        BanEntry, BanListConfig, BanListManager, BanListStore, BanListStoreError, TextComponent,
-        Utc,
+        BanEntry, BanListConfig, BanListManager, BanListStore, BanListStoreError, IpBanEntry,
+        IpBanListManager, TextComponent, Utc,
     };
 
     #[derive(Debug)]
@@ -364,5 +531,66 @@ mod tests {
             "failed to store ban list: test store failure"
         );
         assert!(!failing.is_banned(uuid));
+    }
+
+    fn ip_entry(ip: &str, reason: &str) -> IpBanEntry {
+        IpBanEntry {
+            ip: ip.to_owned(),
+            created: Utc::now(),
+            source: "Console".to_owned(),
+            expires: None,
+            reason: Some(reason.to_owned()),
+        }
+    }
+
+    #[tokio::test]
+    async fn ip_add_replaces_existing_entry_for_the_same_ip() {
+        let manager = IpBanListManager::transient();
+        manager
+            .add(ip_entry("127.0.0.1", "first"))
+            .await
+            .expect("add should succeed");
+        manager
+            .add(ip_entry("127.0.0.1", "second"))
+            .await
+            .expect("add should succeed");
+
+        let entry = manager
+            .find("127.0.0.1")
+            .expect("entry should still be banned");
+        assert_eq!(entry.reason.as_deref(), Some("second"));
+    }
+
+    #[tokio::test]
+    async fn ip_expired_bans_are_not_active() {
+        let manager = IpBanListManager::transient();
+        let mut expired = ip_entry("127.0.0.1", "stale");
+        expired.expires = Some(Utc::now() - chrono::Duration::seconds(1));
+        manager.add(expired).await.expect("add should succeed");
+
+        assert!(!manager.is_banned("127.0.0.1"));
+    }
+
+    #[tokio::test]
+    async fn ip_remove_reports_whether_an_entry_existed() {
+        let manager = IpBanListManager::transient();
+        assert!(
+            !manager
+                .remove("127.0.0.1")
+                .await
+                .expect("remove should succeed")
+        );
+
+        manager
+            .add(ip_entry("127.0.0.1", "reason"))
+            .await
+            .expect("add should succeed");
+        assert!(
+            manager
+                .remove("127.0.0.1")
+                .await
+                .expect("remove should succeed")
+        );
+        assert!(!manager.is_banned("127.0.0.1"));
     }
 }

--- a/steel-core/src/ban.rs
+++ b/steel-core/src/ban.rs
@@ -1,0 +1,362 @@
+//! Persisted player ban list.
+//!
+//! Mirrors vanilla's `UserBanList`, but stored as Steel's own
+//! `banned-players.toml` for consistency with the rest of Steel's
+//! TOML-backed configuration rather than vanilla's `banned-players.json`.
+
+use std::{error::Error, fmt, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+use steel_utils::{
+    locks::{AsyncMutex, SyncRwLock},
+    translations,
+};
+use text_components::{Modifier as _, TextComponent};
+use uuid::Uuid;
+
+/// A single ban entry, keyed by player UUID.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BanEntry {
+    /// The banned player's UUID.
+    pub uuid: Uuid,
+    /// The banned player's last-known name, for display purposes only.
+    pub name: String,
+    /// When the ban was created.
+    pub created: DateTime<Utc>,
+    /// Who (or what) created the ban, e.g. a command sender's name.
+    pub source: String,
+    /// When the ban expires. `None` means it never expires.
+    #[serde(default)]
+    pub expires: Option<DateTime<Utc>>,
+    /// The ban reason, if any.
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+impl BanEntry {
+    /// Returns whether this ban has expired and should no longer apply.
+    #[must_use]
+    pub fn has_expired(&self) -> bool {
+        self.expires.is_some_and(|expires| expires <= Utc::now())
+    }
+
+    /// Returns vanilla's `BanListEntry.getReasonMessage`: the literal reason,
+    /// or a translated default when none was given.
+    #[must_use]
+    pub fn reason_message(&self) -> TextComponent {
+        self.reason.as_deref().map_or_else(
+            || TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_BANNED_REASON_DEFAULT),
+            |reason| TextComponent::plain(reason.to_owned()),
+        )
+    }
+
+    /// Builds vanilla's `PlayerList.canPlayerLogin` rejection message for this
+    /// ban: the reason, with an expiration line appended when the ban isn't
+    /// permanent.
+    #[must_use]
+    pub fn disconnect_message(&self) -> TextComponent {
+        let message = translations::MULTIPLAYER_DISCONNECT_BANNED_REASON
+            .message([self.reason_message()])
+            .component();
+        let Some(expires) = self.expires else {
+            return message;
+        };
+        let expiration = translations::MULTIPLAYER_DISCONNECT_BANNED_EXPIRATION
+            .message([TextComponent::plain(
+                expires.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+            )])
+            .component();
+        message.add_child(expiration)
+    }
+}
+
+/// Parsed `banned-players.toml` root.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BanListConfig {
+    /// The list of ban entries.
+    #[serde(default)]
+    pub bans: Vec<BanEntry>,
+}
+
+/// Persists the ban list configuration owned outside `steel-core`.
+pub trait BanListStore: Send + Sync {
+    /// Saves the complete ban list configuration.
+    fn save_bans(&self, config: BanListConfig)
+    -> BoxFuture<'static, Result<(), BanListStoreError>>;
+}
+
+/// Ban list persistence failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BanListStoreError {
+    message: String,
+}
+
+impl BanListStoreError {
+    /// Creates a persistence error from a displayable message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for BanListStoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for BanListStoreError {}
+
+/// Runtime ban list with persistence-first updates.
+pub struct BanListManager {
+    updates: AsyncMutex<()>,
+    state: SyncRwLock<BanListConfig>,
+    store: Option<Arc<dyn BanListStore>>,
+}
+
+impl fmt::Debug for BanListManager {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BanListManager")
+            .field("updates", &self.updates)
+            .field("state", &self.state)
+            .field("store", &self.store.as_ref().map(|_| "<ban list store>"))
+            .finish()
+    }
+}
+
+impl BanListManager {
+    /// Builds a manager from an initial config and an optional persistence store.
+    #[must_use]
+    pub fn new(config: BanListConfig, store: Option<Arc<dyn BanListStore>>) -> Self {
+        Self {
+            updates: AsyncMutex::new(()),
+            state: SyncRwLock::new(config),
+            store,
+        }
+    }
+
+    /// Builds a manager without persistence.
+    #[must_use]
+    pub fn transient() -> Self {
+        Self::new(BanListConfig::default(), None)
+    }
+
+    /// Returns the active (non-expired) ban entry for a UUID, if any.
+    #[must_use]
+    pub fn find(&self, uuid: Uuid) -> Option<BanEntry> {
+        self.state
+            .read()
+            .bans
+            .iter()
+            .find(|entry| entry.uuid == uuid && !entry.has_expired())
+            .cloned()
+    }
+
+    /// Returns whether a UUID currently has an active ban.
+    #[must_use]
+    pub fn is_banned(&self, uuid: Uuid) -> bool {
+        self.find(uuid).is_some()
+    }
+
+    /// Returns all active (non-expired) ban entries.
+    #[must_use]
+    pub fn entries(&self) -> Vec<BanEntry> {
+        self.state
+            .read()
+            .bans
+            .iter()
+            .filter(|entry| !entry.has_expired())
+            .cloned()
+            .collect()
+    }
+
+    /// Adds or replaces the ban entry for `entry.uuid`, persisting first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn add(&self, entry: BanEntry) -> Result<(), BanListManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        config.bans.retain(|existing| existing.uuid != entry.uuid);
+        config.bans.push(entry);
+        self.persist_locked(config).await
+    }
+
+    /// Removes the ban entry for a UUID, persisting first.
+    ///
+    /// Returns whether an entry was actually removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn remove(&self, uuid: Uuid) -> Result<bool, BanListManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        let previous_len = config.bans.len();
+        config.bans.retain(|entry| entry.uuid != uuid);
+        if config.bans.len() == previous_len {
+            return Ok(false);
+        }
+        self.persist_locked(config).await?;
+        Ok(true)
+    }
+
+    async fn persist_locked(&self, config: BanListConfig) -> Result<(), BanListManagerError> {
+        if let Some(store) = &self.store {
+            store.save_bans(config.clone()).await?;
+        }
+        *self.state.write() = config;
+        Ok(())
+    }
+}
+
+/// Ban list manager update failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BanListManagerError(BanListStoreError);
+
+impl fmt::Display for BanListManagerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "failed to store ban list: {}", self.0)
+    }
+}
+
+impl Error for BanListManagerError {}
+
+impl From<BanListStoreError> for BanListManagerError {
+    fn from(value: BanListStoreError) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::future::BoxFuture;
+    use steel_utils::locks::SyncMutex;
+    use uuid::Uuid;
+
+    use super::{BanEntry, BanListConfig, BanListManager, BanListStore, BanListStoreError, Utc};
+
+    #[derive(Debug)]
+    struct CapturingStore {
+        saved: Arc<SyncMutex<Vec<BanListConfig>>>,
+    }
+
+    impl BanListStore for CapturingStore {
+        fn save_bans(
+            &self,
+            config: BanListConfig,
+        ) -> BoxFuture<'static, Result<(), BanListStoreError>> {
+            let saved = Arc::clone(&self.saved);
+            Box::pin(async move {
+                saved.lock().push(config);
+                Ok(())
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingStore;
+
+    impl BanListStore for FailingStore {
+        fn save_bans(
+            &self,
+            _config: BanListConfig,
+        ) -> BoxFuture<'static, Result<(), BanListStoreError>> {
+            Box::pin(async { Err(BanListStoreError::new("test store failure")) })
+        }
+    }
+
+    fn entry(uuid: Uuid, reason: &str) -> BanEntry {
+        BanEntry {
+            uuid,
+            name: "Steve".to_owned(),
+            created: Utc::now(),
+            source: "Console".to_owned(),
+            expires: None,
+            reason: Some(reason.to_owned()),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_replaces_existing_entry_for_the_same_uuid() {
+        let manager = BanListManager::transient();
+        let uuid = Uuid::nil();
+        manager
+            .add(entry(uuid, "first"))
+            .await
+            .expect("add should succeed");
+        manager
+            .add(entry(uuid, "second"))
+            .await
+            .expect("add should succeed");
+
+        let entries = manager.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].reason.as_deref(), Some("second"));
+    }
+
+    #[tokio::test]
+    async fn expired_bans_are_not_active() {
+        let manager = BanListManager::transient();
+        let uuid = Uuid::nil();
+        let mut expired = entry(uuid, "stale");
+        expired.expires = Some(Utc::now() - chrono::Duration::seconds(1));
+        manager.add(expired).await.expect("add should succeed");
+
+        assert!(!manager.is_banned(uuid));
+        assert_eq!(manager.entries(), Vec::new());
+    }
+
+    #[tokio::test]
+    async fn remove_reports_whether_an_entry_existed() {
+        let manager = BanListManager::transient();
+        let uuid = Uuid::nil();
+        assert!(!manager.remove(uuid).await.expect("remove should succeed"));
+
+        manager
+            .add(entry(uuid, "reason"))
+            .await
+            .expect("add should succeed");
+        assert!(manager.remove(uuid).await.expect("remove should succeed"));
+        assert!(!manager.is_banned(uuid));
+    }
+
+    #[tokio::test]
+    async fn add_persists_before_applying_and_surfaces_store_errors() {
+        let saved = Arc::new(SyncMutex::new(Vec::new()));
+        let manager = BanListManager::new(
+            BanListConfig::default(),
+            Some(Arc::new(CapturingStore {
+                saved: Arc::clone(&saved),
+            })),
+        );
+        let uuid = Uuid::nil();
+        manager
+            .add(entry(uuid, "reason"))
+            .await
+            .expect("add should succeed");
+        assert_eq!(saved.lock().len(), 1);
+        assert!(manager.is_banned(uuid));
+
+        let failing = BanListManager::new(BanListConfig::default(), Some(Arc::new(FailingStore)));
+        let error = failing
+            .add(entry(uuid, "reason"))
+            .await
+            .expect_err("store failure should surface");
+        assert_eq!(
+            error.to_string(),
+            "failed to store ban list: test store failure"
+        );
+        assert!(!failing.is_banned(uuid));
+    }
+}

--- a/steel-core/src/command/builtins/ban.rs
+++ b/steel-core/src/command/builtins/ban.rs
@@ -1,0 +1,208 @@
+//! Vanilla player-banning command.
+
+use chrono::Utc;
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandResultSuspension, CommandResultSuspensionPoll, CommandSource,
+        CommandSuspensionOrder, GameProfileArgument, SteelArgumentType, SteelCommandContext,
+        SteelCommandRuntime, argument, literal,
+    },
+    registration::CommandRegistration,
+};
+use crate::ban::BanEntry;
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("ban"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("ban").then(
+        argument("targets", SteelArgumentType::game_profile())
+            .executes_suspended(ban_without_reason)
+            .then(
+                argument("reason", SteelArgumentType::message())
+                    .executes_suspended(ban_with_reason),
+            ),
+    )
+}
+
+fn ban_without_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<BanCommandSuspension, CommandSyntaxError> {
+    start_ban(context, None)
+}
+
+fn ban_with_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<BanCommandSuspension, CommandSyntaxError> {
+    let reason = context.message("reason")?.to_owned();
+    start_ban(context, Some(reason))
+}
+
+fn start_ban(
+    context: &SteelCommandContext<CommandSource>,
+    reason: Option<String>,
+) -> Result<BanCommandSuspension, CommandSyntaxError> {
+    let argument = context.game_profile_argument("targets").cloned()?;
+    let source = context.source().clone();
+    let task_source = source.clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = run_ban(&task_source, argument, reason).await;
+        let _ = sender.send(result);
+    });
+    Ok(BanCommandSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+struct BanCommandResult {
+    banned: Vec<(String, TextComponent)>,
+}
+
+async fn run_ban(
+    source: &CommandSource,
+    argument: GameProfileArgument,
+    reason: Option<String>,
+) -> Result<BanCommandResult, CommandSyntaxError> {
+    let targets = argument.resolve(source).await?;
+    let source_name = source.sender().to_string();
+    let mut banned = Vec::new();
+
+    for target in targets {
+        if source.server().ban_list.is_banned(target.uuid) {
+            continue;
+        }
+
+        let entry = BanEntry {
+            uuid: target.uuid,
+            name: target.name.clone(),
+            created: Utc::now(),
+            source: source_name.clone(),
+            expires: None,
+            reason: reason.clone(),
+        };
+        let reason_message = entry.reason_message();
+        source
+            .server()
+            .ban_list
+            .add(entry)
+            .await
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()))?;
+
+        if let Some(online) = source.server().online_player(target.uuid) {
+            online.disconnect(TextComponent::from(
+                &translations::MULTIPLAYER_DISCONNECT_BANNED,
+            ));
+        }
+
+        banned.push((target.name, reason_message));
+    }
+
+    if banned.is_empty() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_BAN_FAILED,
+        )));
+    }
+    Ok(BanCommandResult { banned })
+}
+
+struct BanCommandSuspension {
+    source: CommandSource,
+    receiver: oneshot::Receiver<Result<BanCommandResult, CommandSyntaxError>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl CommandResultSuspension for BanCommandSuspension {
+    fn order(&self) -> CommandSuspensionOrder {
+        CommandSuspensionOrder::Global
+    }
+
+    fn poll(&mut self) -> CommandResultSuspensionPoll {
+        match self.receiver.try_recv() {
+            Ok(result) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(result.map(|result| {
+                    let count = result.banned.len().min(i32::MAX as usize) as i32;
+                    for (name, reason) in result.banned {
+                        let message = translations::COMMANDS_BAN_SUCCESS
+                            .message([TextComponent::plain(name), reason])
+                            .component();
+                        self.source.send_success(&message, true);
+                    }
+                    count
+                }))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => CommandResultSuspensionPoll::Pending,
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(Err(CommandSyntaxError::dynamic(
+                    "ban command task ended without a result",
+                )))
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn ban_targets_use_vanillas_game_profile_argument_and_optional_reason() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(ban) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "ban")
+            })
+        }) else {
+            panic!("ban root should exist");
+        };
+        let Some(targets) = dispatcher
+            .children(ban)
+            .and_then(|children| children.first())
+        else {
+            panic!("ban targets should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*targets),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::game_profile())
+        ));
+
+        let Some(reason) = dispatcher
+            .children(*targets)
+            .and_then(|children| children.first())
+        else {
+            panic!("ban reason should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*reason),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::message())
+        ));
+    }
+}

--- a/steel-core/src/command/builtins/ban.rs
+++ b/steel-core/src/command/builtins/ban.rs
@@ -40,13 +40,15 @@ fn ban_without_reason(
 fn ban_with_reason(
     context: &SteelCommandContext<CommandSource>,
 ) -> Result<BanCommandSuspension, CommandSyntaxError> {
-    let reason = context.message("reason")?.to_owned();
+    let reason = context.message("reason")?;
+    let reason = TextComponent::from_snbt(reason)
+        .unwrap_or_else(|_| TextComponent::plain(reason.to_owned()));
     start_ban(context, Some(reason))
 }
 
 fn start_ban(
     context: &SteelCommandContext<CommandSource>,
-    reason: Option<String>,
+    reason: Option<TextComponent>,
 ) -> Result<BanCommandSuspension, CommandSyntaxError> {
     let argument = context.game_profile_argument("targets").cloned()?;
     let source = context.source().clone();
@@ -70,7 +72,7 @@ struct BanCommandResult {
 async fn run_ban(
     source: &CommandSource,
     argument: GameProfileArgument,
-    reason: Option<String>,
+    reason: Option<TextComponent>,
 ) -> Result<BanCommandResult, CommandSyntaxError> {
     let targets = argument.resolve(source).await?;
     let source_name = source.sender().to_string();

--- a/steel-core/src/command/builtins/ban_ip.rs
+++ b/steel-core/src/command/builtins/ban_ip.rs
@@ -1,0 +1,203 @@
+//! Vanilla IP-banning command.
+//!
+//! Unlike vanilla's `BanIpCommands`, the target must be a literal IP address:
+//! Steel doesn't currently track a connected player's remote address past
+//! login, so resolving a player name to their current IP (and kicking every
+//! other player sharing a freshly banned IP) isn't possible yet.
+
+use std::net::IpAddr;
+
+use chrono::Utc;
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandResultSuspension, CommandResultSuspensionPoll, CommandSource,
+        CommandSuspensionOrder, SteelArgumentType, SteelCommandContext, SteelCommandRuntime,
+        argument, literal,
+    },
+    registration::CommandRegistration,
+};
+use crate::ban::IpBanEntry;
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("ban-ip"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("ban-ip").then(
+        argument("target", SteelArgumentType::word())
+            .executes_suspended(ban_ip_without_reason)
+            .then(
+                argument("reason", SteelArgumentType::message())
+                    .executes_suspended(ban_ip_with_reason),
+            ),
+    )
+}
+
+fn ban_ip_without_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<BanIpCommandSuspension, CommandSyntaxError> {
+    start_ban_ip(context, None)
+}
+
+fn ban_ip_with_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<BanIpCommandSuspension, CommandSyntaxError> {
+    let reason = context.message("reason")?.to_owned();
+    start_ban_ip(context, Some(reason))
+}
+
+fn start_ban_ip(
+    context: &SteelCommandContext<CommandSource>,
+    reason: Option<String>,
+) -> Result<BanIpCommandSuspension, CommandSyntaxError> {
+    let target = context.word("target")?.to_owned();
+    let source = context.source().clone();
+    let task_source = source.clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = run_ban_ip(&task_source, target, reason).await;
+        let _ = sender.send(result);
+    });
+    Ok(BanIpCommandSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+struct BanIpCommandResult {
+    ip: String,
+    reason: TextComponent,
+}
+
+async fn run_ban_ip(
+    source: &CommandSource,
+    target: String,
+    reason: Option<String>,
+) -> Result<BanIpCommandResult, CommandSyntaxError> {
+    if target.parse::<IpAddr>().is_err() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_BANIP_INVALID,
+        )));
+    }
+    if source.server().ip_ban_list.is_banned(&target) {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_BANIP_FAILED,
+        )));
+    }
+
+    let entry = IpBanEntry {
+        ip: target.clone(),
+        created: Utc::now(),
+        source: source.sender().to_string(),
+        expires: None,
+        reason,
+    };
+    let reason_message = entry.reason_message();
+    source
+        .server()
+        .ip_ban_list
+        .add(entry)
+        .await
+        .map_err(|error| CommandSyntaxError::dynamic(error.to_string()))?;
+
+    Ok(BanIpCommandResult {
+        ip: target,
+        reason: reason_message,
+    })
+}
+
+struct BanIpCommandSuspension {
+    source: CommandSource,
+    receiver: oneshot::Receiver<Result<BanIpCommandResult, CommandSyntaxError>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl CommandResultSuspension for BanIpCommandSuspension {
+    fn order(&self) -> CommandSuspensionOrder {
+        CommandSuspensionOrder::Global
+    }
+
+    fn poll(&mut self) -> CommandResultSuspensionPoll {
+        match self.receiver.try_recv() {
+            Ok(result) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(result.map(|result| {
+                    let message = translations::COMMANDS_BANIP_SUCCESS
+                        .message([TextComponent::plain(result.ip), result.reason])
+                        .component();
+                    self.source.send_success(&message, true);
+                    1
+                }))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => CommandResultSuspensionPoll::Pending,
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(Err(CommandSyntaxError::dynamic(
+                    "ban-ip command task ended without a result",
+                )))
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn ban_ip_target_is_a_word_with_an_optional_reason() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(ban_ip) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "ban-ip")
+            })
+        }) else {
+            panic!("ban-ip root should exist");
+        };
+        let Some(target) = dispatcher
+            .children(ban_ip)
+            .and_then(|children| children.first())
+        else {
+            panic!("ban-ip target should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*target),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::word())
+        ));
+
+        let Some(reason) = dispatcher
+            .children(*target)
+            .and_then(|children| children.first())
+        else {
+            panic!("ban-ip reason should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*reason),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::message())
+        ));
+    }
+}

--- a/steel-core/src/command/builtins/ban_ip.rs
+++ b/steel-core/src/command/builtins/ban_ip.rs
@@ -47,13 +47,15 @@ fn ban_ip_without_reason(
 fn ban_ip_with_reason(
     context: &SteelCommandContext<CommandSource>,
 ) -> Result<BanIpCommandSuspension, CommandSyntaxError> {
-    let reason = context.message("reason")?.to_owned();
+    let reason = context.message("reason")?;
+    let reason = TextComponent::from_snbt(reason)
+        .unwrap_or_else(|_| TextComponent::plain(reason.to_owned()));
     start_ban_ip(context, Some(reason))
 }
 
 fn start_ban_ip(
     context: &SteelCommandContext<CommandSource>,
-    reason: Option<String>,
+    reason: Option<TextComponent>,
 ) -> Result<BanIpCommandSuspension, CommandSyntaxError> {
     let target = context.word("target")?.to_owned();
     let source = context.source().clone();
@@ -78,7 +80,7 @@ struct BanIpCommandResult {
 async fn run_ban_ip(
     source: &CommandSource,
     target: String,
-    reason: Option<String>,
+    reason: Option<TextComponent>,
 ) -> Result<BanIpCommandResult, CommandSyntaxError> {
     if target.parse::<IpAddr>().is_err() {
         return Err(CommandSyntaxError::dynamic(TextComponent::from(

--- a/steel-core/src/command/builtins/banlist.rs
+++ b/steel-core/src/command/builtins/banlist.rs
@@ -1,0 +1,141 @@
+//! Vanilla ban-list-listing command.
+
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{CommandSource, SteelCommandContext, SteelCommandRuntime, literal},
+    registration::CommandRegistration,
+};
+use crate::ban::{BanEntry, IpBanEntry};
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("banlist"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("banlist")
+        .executes(banlist_all)
+        .then(literal("ips").executes(banlist_ips))
+        .then(literal("players").executes(banlist_players))
+}
+
+fn banlist_all(context: &SteelCommandContext<CommandSource>) -> Result<i32, CommandSyntaxError> {
+    let server = context.source().server();
+    let mut rows = player_rows(&server.ban_list.entries());
+    rows.extend(ip_rows(&server.ip_ban_list.entries()));
+    show_list(context, rows)
+}
+
+fn banlist_ips(context: &SteelCommandContext<CommandSource>) -> Result<i32, CommandSyntaxError> {
+    let rows = ip_rows(&context.source().server().ip_ban_list.entries());
+    show_list(context, rows)
+}
+
+fn banlist_players(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<i32, CommandSyntaxError> {
+    let rows = player_rows(&context.source().server().ban_list.entries());
+    show_list(context, rows)
+}
+
+fn player_rows(entries: &[BanEntry]) -> Vec<(String, String, TextComponent)> {
+    entries
+        .iter()
+        .map(|entry| {
+            (
+                entry.name.clone(),
+                entry.source.clone(),
+                entry.reason_message(),
+            )
+        })
+        .collect()
+}
+
+fn ip_rows(entries: &[IpBanEntry]) -> Vec<(String, String, TextComponent)> {
+    entries
+        .iter()
+        .map(|entry| {
+            (
+                entry.ip.clone(),
+                entry.source.clone(),
+                entry.reason_message(),
+            )
+        })
+        .collect()
+}
+
+fn show_list(
+    context: &SteelCommandContext<CommandSource>,
+    rows: Vec<(String, String, TextComponent)>,
+) -> Result<i32, CommandSyntaxError> {
+    let Ok(count) = i32::try_from(rows.len()) else {
+        return Err(CommandSyntaxError::dynamic(
+            "Ban list entry count exceeds the command result range",
+        ));
+    };
+
+    if rows.is_empty() {
+        context.source().send_success(
+            &TextComponent::from(&translations::COMMANDS_BANLIST_NONE),
+            false,
+        );
+        return Ok(0);
+    }
+
+    let header = translations::COMMANDS_BANLIST_LIST
+        .message([TextComponent::plain(count.to_string())])
+        .component();
+    context.source().send_success(&header, false);
+
+    for (display_name, source, reason) in rows {
+        let line = translations::COMMANDS_BANLIST_ENTRY
+            .message([
+                TextComponent::plain(display_name),
+                TextComponent::plain(source),
+                reason,
+            ])
+            .component();
+        context.source().send_success(&line, false);
+    }
+
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+
+    #[test]
+    fn banlist_graph_supports_the_bare_ips_and_players_forms() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(banlist) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "banlist")
+            })
+        }) else {
+            panic!("banlist root should exist");
+        };
+        let Some(banlist_node) = dispatcher.node(banlist) else {
+            panic!("banlist root node should exist");
+        };
+        assert!(banlist_node.is_executable());
+
+        let mut subcommand_names = Vec::new();
+        for child in dispatcher.children(banlist).into_iter().flatten() {
+            if let Some(node) = dispatcher.node(*child) {
+                subcommand_names.push(node.name());
+            }
+        }
+        assert!(subcommand_names.contains(&"ips"));
+        assert!(subcommand_names.contains(&"players"));
+    }
+}

--- a/steel-core/src/command/builtins/kick.rs
+++ b/steel-core/src/command/builtins/kick.rs
@@ -1,0 +1,122 @@
+//! Vanilla player-kicking command.
+
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandSource, SteelArgumentType, SteelCommandContext, SteelCommandRuntime, argument,
+        literal,
+    },
+    registration::CommandRegistration,
+};
+use crate::entity::Entity as _;
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("kick"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("kick").then(
+        argument("targets", SteelArgumentType::players())
+            .executes(kick_default_reason)
+            .then(argument("reason", SteelArgumentType::message()).executes(kick_with_reason)),
+    )
+}
+
+fn kick_default_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<i32, CommandSyntaxError> {
+    kick_players(
+        context,
+        TextComponent::from(&translations::MULTIPLAYER_DISCONNECT_KICKED),
+    )
+}
+
+fn kick_with_reason(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<i32, CommandSyntaxError> {
+    let reason = context.message("reason")?;
+    kick_players(context, TextComponent::plain(reason.to_owned()))
+}
+
+fn kick_players(
+    context: &SteelCommandContext<CommandSource>,
+    reason: TextComponent,
+) -> Result<i32, CommandSyntaxError> {
+    let targets = context.players("targets")?;
+    let Ok(count) = i32::try_from(targets.len()) else {
+        return Err(CommandSyntaxError::dynamic(
+            "Target player count exceeds the command result range",
+        ));
+    };
+
+    for target in &targets {
+        target.disconnect(reason.clone());
+        let message = translations::COMMANDS_KICK_SUCCESS
+            .message([
+                TextComponent::plain(target.plain_text_name()),
+                reason.clone(),
+            ])
+            .component();
+        context.source().send_success(&message, true);
+    }
+
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn kick_graph_requires_targets_then_optionally_accepts_a_reason() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(kick) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "kick")
+            })
+        }) else {
+            panic!("kick root should exist");
+        };
+        let Some(kick_node) = dispatcher.node(kick) else {
+            panic!("kick root node should exist");
+        };
+        assert!(!kick_node.is_executable());
+
+        let Some(targets) = dispatcher
+            .children(kick)
+            .and_then(|children| children.first())
+        else {
+            panic!("kick targets should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*targets),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::players())
+        ));
+
+        let Some(reason) = dispatcher
+            .children(*targets)
+            .and_then(|children| children.first())
+        else {
+            panic!("kick reason should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*reason),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::message())
+        ));
+    }
+}

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -2,6 +2,7 @@
 
 mod ban;
 mod ban_ip;
+mod banlist;
 mod clear;
 mod damage;
 mod difficulty;
@@ -71,6 +72,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.declare_permission(perms::METADATA_PERMISSION)?;
     builder.register(ban::registration())?;
     builder.register(ban_ip::registration())?;
+    builder.register(banlist::registration())?;
     builder.register(clear::registration())?;
     builder.register(operator::deop_registration())?;
     builder.register(damage::registration())?;
@@ -154,6 +156,7 @@ mod tests {
             [
                 "ban",
                 "ban-ip",
+                "banlist",
                 "clear",
                 "deop",
                 "damage",

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -39,6 +39,7 @@ mod tick;
 mod time;
 mod title;
 mod weather;
+mod whitelist;
 mod worldborder;
 
 pub(crate) use difficulty::player_can_change_difficulty;
@@ -109,6 +110,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.register(time::registration())?;
     builder.register(title::registration())?;
     builder.register(weather::registration())?;
+    builder.register(whitelist::registration())?;
     builder.register(worldborder::registration())?;
     builder.register(invsee::registration()?)?;
     builder.extend(extension_commands.into_inner())?;
@@ -195,6 +197,7 @@ mod tests {
                 "time",
                 "title",
                 "weather",
+                "whitelist",
                 "worldborder",
                 "invsee"
             ]

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod gamemode;
 mod gamerule;
 mod give;
 mod invsee;
+mod kick;
 mod kill;
 mod list;
 mod locate;
@@ -77,6 +78,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.register(gamemode::registration()?)?;
     builder.register(gamerule::registration())?;
     builder.register(give::registration())?;
+    builder.register(kick::registration())?;
     builder.register(kill::registration())?;
     builder.register(list::registration())?;
     builder.register(locate::registration())?;
@@ -156,6 +158,7 @@ mod tests {
                 "gamemode",
                 "gamerule",
                 "give",
+                "kick",
                 "kill",
                 "list",
                 "locate",

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -1,6 +1,7 @@
 //! Steel-owned built-in command declarations.
 
 mod ban;
+mod ban_ip;
 mod clear;
 mod damage;
 mod difficulty;
@@ -20,6 +21,7 @@ mod list;
 mod locate;
 mod operator;
 mod pardon;
+mod pardon_ip;
 mod perms;
 mod playsound;
 mod return_command;
@@ -68,6 +70,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.declare_permission(perms::GROUP_ALL_PERMISSION)?;
     builder.declare_permission(perms::METADATA_PERMISSION)?;
     builder.register(ban::registration())?;
+    builder.register(ban_ip::registration())?;
     builder.register(clear::registration())?;
     builder.register(operator::deop_registration())?;
     builder.register(damage::registration())?;
@@ -87,6 +90,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.register(locate::registration())?;
     builder.register(operator::op_registration())?;
     builder.register(pardon::registration())?;
+    builder.register(pardon_ip::registration())?;
     builder.register(perms::registration())?;
     builder.register(playsound::registration())?;
     builder.register(return_command::registration())?;
@@ -149,6 +153,7 @@ mod tests {
             names,
             [
                 "ban",
+                "ban-ip",
                 "clear",
                 "deop",
                 "damage",
@@ -169,6 +174,7 @@ mod tests {
                 "locate",
                 "op",
                 "pardon",
+                "pardon-ip",
                 "perms",
                 "playsound",
                 "return",

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -1,5 +1,6 @@
 //! Steel-owned built-in command declarations.
 
+mod ban;
 mod clear;
 mod damage;
 mod difficulty;
@@ -18,6 +19,7 @@ mod kill;
 mod list;
 mod locate;
 mod operator;
+mod pardon;
 mod perms;
 mod playsound;
 mod return_command;
@@ -65,6 +67,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.declare_permission(perms::MANAGE_ALL_PERMISSION)?;
     builder.declare_permission(perms::GROUP_ALL_PERMISSION)?;
     builder.declare_permission(perms::METADATA_PERMISSION)?;
+    builder.register(ban::registration())?;
     builder.register(clear::registration())?;
     builder.register(operator::deop_registration())?;
     builder.register(damage::registration())?;
@@ -83,6 +86,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.register(list::registration())?;
     builder.register(locate::registration())?;
     builder.register(operator::op_registration())?;
+    builder.register(pardon::registration())?;
     builder.register(perms::registration())?;
     builder.register(playsound::registration())?;
     builder.register(return_command::registration())?;
@@ -144,6 +148,7 @@ mod tests {
         assert_eq!(
             names,
             [
+                "ban",
                 "clear",
                 "deop",
                 "damage",
@@ -163,6 +168,7 @@ mod tests {
                 "list",
                 "locate",
                 "op",
+                "pardon",
                 "perms",
                 "playsound",
                 "return",

--- a/steel-core/src/command/builtins/pardon.rs
+++ b/steel-core/src/command/builtins/pardon.rs
@@ -1,0 +1,154 @@
+//! Vanilla player-unbanning command.
+
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandResultSuspension, CommandResultSuspensionPoll, CommandSource,
+        CommandSuspensionOrder, GameProfileArgument, SteelArgumentType, SteelCommandContext,
+        SteelCommandRuntime, argument, literal,
+    },
+    registration::CommandRegistration,
+};
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("pardon"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("pardon").then(
+        argument("targets", SteelArgumentType::game_profile()).executes_suspended(start_pardon),
+    )
+}
+
+fn start_pardon(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<PardonCommandSuspension, CommandSyntaxError> {
+    let argument = context.game_profile_argument("targets").cloned()?;
+    let source = context.source().clone();
+    let task_source = source.clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = run_pardon(&task_source, argument).await;
+        let _ = sender.send(result);
+    });
+    Ok(PardonCommandSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+struct PardonCommandResult {
+    pardoned_names: Vec<String>,
+}
+
+async fn run_pardon(
+    source: &CommandSource,
+    argument: GameProfileArgument,
+) -> Result<PardonCommandResult, CommandSyntaxError> {
+    let targets = argument.resolve(source).await?;
+    let mut pardoned_names = Vec::new();
+
+    for target in targets {
+        let removed = source
+            .server()
+            .ban_list
+            .remove(target.uuid)
+            .await
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()))?;
+        if removed {
+            pardoned_names.push(target.name);
+        }
+    }
+
+    if pardoned_names.is_empty() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_PARDON_FAILED,
+        )));
+    }
+    Ok(PardonCommandResult { pardoned_names })
+}
+
+struct PardonCommandSuspension {
+    source: CommandSource,
+    receiver: oneshot::Receiver<Result<PardonCommandResult, CommandSyntaxError>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl CommandResultSuspension for PardonCommandSuspension {
+    fn order(&self) -> CommandSuspensionOrder {
+        CommandSuspensionOrder::Global
+    }
+
+    fn poll(&mut self) -> CommandResultSuspensionPoll {
+        match self.receiver.try_recv() {
+            Ok(result) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(result.map(|result| {
+                    let count = result.pardoned_names.len().min(i32::MAX as usize) as i32;
+                    for name in result.pardoned_names {
+                        let message = translations::COMMANDS_PARDON_SUCCESS
+                            .message([TextComponent::plain(name)])
+                            .component();
+                        self.source.send_success(&message, true);
+                    }
+                    count
+                }))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => CommandResultSuspensionPoll::Pending,
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(Err(CommandSyntaxError::dynamic(
+                    "pardon command task ended without a result",
+                )))
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn pardon_targets_use_vanillas_game_profile_argument() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(pardon) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "pardon")
+            })
+        }) else {
+            panic!("pardon root should exist");
+        };
+        let Some(targets) = dispatcher
+            .children(pardon)
+            .and_then(|children| children.first())
+        else {
+            panic!("pardon targets should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*targets),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::game_profile())
+        ));
+    }
+}

--- a/steel-core/src/command/builtins/pardon_ip.rs
+++ b/steel-core/src/command/builtins/pardon_ip.rs
@@ -1,0 +1,145 @@
+//! Vanilla IP-unbanning command.
+
+use std::net::IpAddr;
+
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandResultSuspension, CommandResultSuspensionPoll, CommandSource,
+        CommandSuspensionOrder, SteelArgumentType, SteelCommandContext, SteelCommandRuntime,
+        argument, literal,
+    },
+    registration::CommandRegistration,
+};
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("pardon-ip"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("pardon-ip")
+        .then(argument("target", SteelArgumentType::word()).executes_suspended(start_pardon_ip))
+}
+
+fn start_pardon_ip(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<PardonIpCommandSuspension, CommandSyntaxError> {
+    let target = context.word("target")?.to_owned();
+    let source = context.source().clone();
+    let task_source = source.clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = run_pardon_ip(&task_source, target).await;
+        let _ = sender.send(result);
+    });
+    Ok(PardonIpCommandSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+async fn run_pardon_ip(
+    source: &CommandSource,
+    target: String,
+) -> Result<String, CommandSyntaxError> {
+    if target.parse::<IpAddr>().is_err() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_PARDONIP_INVALID,
+        )));
+    }
+
+    let removed = source
+        .server()
+        .ip_ban_list
+        .remove(&target)
+        .await
+        .map_err(|error| CommandSyntaxError::dynamic(error.to_string()))?;
+    if !removed {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_PARDONIP_FAILED,
+        )));
+    }
+    Ok(target)
+}
+
+struct PardonIpCommandSuspension {
+    source: CommandSource,
+    receiver: oneshot::Receiver<Result<String, CommandSyntaxError>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl CommandResultSuspension for PardonIpCommandSuspension {
+    fn order(&self) -> CommandSuspensionOrder {
+        CommandSuspensionOrder::Global
+    }
+
+    fn poll(&mut self) -> CommandResultSuspensionPoll {
+        match self.receiver.try_recv() {
+            Ok(result) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(result.map(|ip| {
+                    let message = translations::COMMANDS_PARDONIP_SUCCESS
+                        .message([TextComponent::plain(ip)])
+                        .component();
+                    self.source.send_success(&message, true);
+                    1
+                }))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => CommandResultSuspensionPoll::Pending,
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(Err(CommandSyntaxError::dynamic(
+                    "pardon-ip command task ended without a result",
+                )))
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn pardon_ip_target_is_a_word() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(pardon_ip) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "pardon-ip")
+            })
+        }) else {
+            panic!("pardon-ip root should exist");
+        };
+        let Some(target) = dispatcher
+            .children(pardon_ip)
+            .and_then(|children| children.first())
+        else {
+            panic!("pardon-ip target should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*target),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::word())
+        ));
+    }
+}

--- a/steel-core/src/command/builtins/whitelist.rs
+++ b/steel-core/src/command/builtins/whitelist.rs
@@ -1,0 +1,417 @@
+//! Vanilla whitelist command.
+
+use std::sync::Arc;
+
+use steel_utils::{Identifier, translations};
+use text_components::TextComponent;
+use tokio::{sync::oneshot, task::JoinHandle};
+
+use super::super::{
+    brigadier::{CommandNodeBuilder, CommandSyntaxError},
+    execution::{
+        CommandResultSuspension, CommandResultSuspensionPoll, CommandSource,
+        CommandSuspensionOrder, GameProfileArgument, SteelArgumentType, SteelCommandContext,
+        SteelCommandRuntime, argument, literal,
+    },
+    registration::CommandRegistration,
+};
+use crate::{entity::Entity as _, server::Server, whitelist::WhitelistEntry};
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("whitelist"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("whitelist")
+        .then(literal("on").executes_suspended(whitelist_on))
+        .then(literal("off").executes_suspended(whitelist_off))
+        .then(literal("list").executes(whitelist_list))
+        .then(
+            literal("add").then(
+                argument("targets", SteelArgumentType::game_profile())
+                    .executes_suspended(whitelist_add),
+            ),
+        )
+        .then(
+            literal("remove").then(
+                argument("targets", SteelArgumentType::game_profile())
+                    .executes_suspended(whitelist_remove),
+            ),
+        )
+        .then(literal("reload").executes_suspended(whitelist_reload))
+}
+
+/// Disconnects online players who are no longer whitelisted, matching
+/// vanilla's `PlayerList.kickUnlistedPlayers`. A no-op while the whitelist
+/// isn't enabled.
+fn kick_unlisted_players(server: &Server) {
+    if !server.whitelist.is_enabled() {
+        return;
+    }
+    for player in server.online_players_snapshot() {
+        if !server.whitelist.is_whitelisted(player.uuid()) {
+            player.disconnect(TextComponent::from(
+                &translations::MULTIPLAYER_DISCONNECT_NOT_WHITELISTED,
+            ));
+        }
+    }
+}
+
+struct WhitelistActionSuspension {
+    source: CommandSource,
+    receiver: oneshot::Receiver<Result<TextComponent, CommandSyntaxError>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl CommandResultSuspension for WhitelistActionSuspension {
+    fn order(&self) -> CommandSuspensionOrder {
+        CommandSuspensionOrder::Global
+    }
+
+    fn poll(&mut self) -> CommandResultSuspensionPoll {
+        match self.receiver.try_recv() {
+            Ok(result) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(result.map(|message| {
+                    self.source.send_success(&message, true);
+                    1
+                }))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => CommandResultSuspensionPoll::Pending,
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(Err(CommandSyntaxError::dynamic(
+                    "whitelist command task ended without a result",
+                )))
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+fn whitelist_on(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<WhitelistActionSuspension, CommandSyntaxError> {
+    let server = Arc::clone(context.source().server());
+    if server.whitelist.is_enabled() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_WHITELIST_ALREADY_ON,
+        )));
+    }
+    let source = context.source().clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = server
+            .whitelist
+            .set_enabled(true)
+            .await
+            .map(|()| {
+                kick_unlisted_players(&server);
+                TextComponent::from(&translations::COMMANDS_WHITELIST_ENABLED)
+            })
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()));
+        let _ = sender.send(result);
+    });
+    Ok(WhitelistActionSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+fn whitelist_off(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<WhitelistActionSuspension, CommandSyntaxError> {
+    let server = Arc::clone(context.source().server());
+    if !server.whitelist.is_enabled() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_WHITELIST_ALREADY_OFF,
+        )));
+    }
+    let source = context.source().clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = server
+            .whitelist
+            .set_enabled(false)
+            .await
+            .map(|()| TextComponent::from(&translations::COMMANDS_WHITELIST_DISABLED))
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()));
+        let _ = sender.send(result);
+    });
+    Ok(WhitelistActionSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Command executors use a shared fallible callback signature."
+)]
+fn whitelist_reload(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<WhitelistActionSuspension, CommandSyntaxError> {
+    let server = Arc::clone(context.source().server());
+    let source = context.source().clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = server
+            .whitelist
+            .reload()
+            .await
+            .map(|()| {
+                kick_unlisted_players(&server);
+                TextComponent::from(&translations::COMMANDS_WHITELIST_RELOADED)
+            })
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()));
+        let _ = sender.send(result);
+    });
+    Ok(WhitelistActionSuspension {
+        source,
+        receiver,
+        task: Some(task),
+    })
+}
+
+fn whitelist_list(context: &SteelCommandContext<CommandSource>) -> Result<i32, CommandSyntaxError> {
+    let entries = context.source().server().whitelist.entries();
+    let Ok(count) = i32::try_from(entries.len()) else {
+        return Err(CommandSyntaxError::dynamic(
+            "Whitelist entry count exceeds the command result range",
+        ));
+    };
+
+    let message = if entries.is_empty() {
+        TextComponent::from(&translations::COMMANDS_WHITELIST_NONE)
+    } else {
+        let names = entries
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        translations::COMMANDS_WHITELIST_LIST
+            .message([
+                TextComponent::plain(count.to_string()),
+                TextComponent::plain(names),
+            ])
+            .component()
+    };
+    context.source().send_success(&message, false);
+    Ok(count)
+}
+
+struct WhitelistTargetsSuspension {
+    source: CommandSource,
+    receiver: oneshot::Receiver<Result<Vec<String>, CommandSyntaxError>>,
+    task: Option<JoinHandle<()>>,
+    success: fn(String) -> TextComponent,
+}
+
+impl CommandResultSuspension for WhitelistTargetsSuspension {
+    fn order(&self) -> CommandSuspensionOrder {
+        CommandSuspensionOrder::Global
+    }
+
+    fn poll(&mut self) -> CommandResultSuspensionPoll {
+        match self.receiver.try_recv() {
+            Ok(result) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(result.map(|names| {
+                    let count = names.len().min(i32::MAX as usize) as i32;
+                    for name in names {
+                        self.source.send_success(&(self.success)(name), true);
+                    }
+                    count
+                }))
+            }
+            Err(oneshot::error::TryRecvError::Empty) => CommandResultSuspensionPoll::Pending,
+            Err(oneshot::error::TryRecvError::Closed) => {
+                self.task = None;
+                CommandResultSuspensionPoll::Ready(Err(CommandSyntaxError::dynamic(
+                    "whitelist command task ended without a result",
+                )))
+            }
+        }
+    }
+
+    fn cancel(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+fn whitelist_add(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<WhitelistTargetsSuspension, CommandSyntaxError> {
+    let argument = context.game_profile_argument("targets").cloned()?;
+    let source = context.source().clone();
+    let task_source = source.clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = run_whitelist_add(&task_source, argument).await;
+        let _ = sender.send(result);
+    });
+    Ok(WhitelistTargetsSuspension {
+        source,
+        receiver,
+        task: Some(task),
+        success: |name| {
+            translations::COMMANDS_WHITELIST_ADD_SUCCESS
+                .message([TextComponent::plain(name)])
+                .component()
+        },
+    })
+}
+
+async fn run_whitelist_add(
+    source: &CommandSource,
+    argument: GameProfileArgument,
+) -> Result<Vec<String>, CommandSyntaxError> {
+    let targets = argument.resolve(source).await?;
+    let mut added = Vec::new();
+
+    for target in targets {
+        let entry = WhitelistEntry {
+            uuid: target.uuid,
+            name: target.name.clone(),
+        };
+        let newly_added = source
+            .server()
+            .whitelist
+            .add(entry)
+            .await
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()))?;
+        if newly_added {
+            added.push(target.name);
+        }
+    }
+
+    if added.is_empty() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_WHITELIST_ADD_FAILED,
+        )));
+    }
+    Ok(added)
+}
+
+fn whitelist_remove(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<WhitelistTargetsSuspension, CommandSyntaxError> {
+    let argument = context.game_profile_argument("targets").cloned()?;
+    let source = context.source().clone();
+    let task_source = source.clone();
+    let (sender, receiver) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let result = run_whitelist_remove(&task_source, argument).await;
+        let _ = sender.send(result);
+    });
+    Ok(WhitelistTargetsSuspension {
+        source,
+        receiver,
+        task: Some(task),
+        success: |name| {
+            translations::COMMANDS_WHITELIST_REMOVE_SUCCESS
+                .message([TextComponent::plain(name)])
+                .component()
+        },
+    })
+}
+
+async fn run_whitelist_remove(
+    source: &CommandSource,
+    argument: GameProfileArgument,
+) -> Result<Vec<String>, CommandSyntaxError> {
+    let targets = argument.resolve(source).await?;
+    let mut removed = Vec::new();
+
+    for target in targets {
+        let was_removed = source
+            .server()
+            .whitelist
+            .remove(target.uuid)
+            .await
+            .map_err(|error| CommandSyntaxError::dynamic(error.to_string()))?;
+        if was_removed {
+            removed.push(target.name);
+        }
+    }
+
+    if removed.is_empty() {
+        return Err(CommandSyntaxError::dynamic(TextComponent::from(
+            &translations::COMMANDS_WHITELIST_REMOVE_FAILED,
+        )));
+    }
+    kick_unlisted_players(source.server());
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use steel_registry::init_vanilla_registry;
+
+    use super::super::create_dispatcher;
+    use crate::command::execution::SteelArgumentType;
+
+    #[test]
+    fn whitelist_graph_supports_every_vanilla_subcommand() {
+        init_vanilla_registry();
+        let Ok(dispatcher) = create_dispatcher() else {
+            panic!("built-in commands should register");
+        };
+        let Some(whitelist) = dispatcher.children(dispatcher.root()).and_then(|children| {
+            children.iter().copied().find(|child| {
+                dispatcher
+                    .node(*child)
+                    .is_some_and(|node| node.name() == "whitelist")
+            })
+        }) else {
+            panic!("whitelist root should exist");
+        };
+
+        let mut subcommand_names = Vec::new();
+        for child in dispatcher.children(whitelist).into_iter().flatten() {
+            if let Some(node) = dispatcher.node(*child) {
+                subcommand_names.push(node.name());
+            }
+        }
+        for expected in ["on", "off", "list", "add", "remove", "reload"] {
+            assert!(
+                subcommand_names.contains(&expected),
+                "missing whitelist subcommand {expected}"
+            );
+        }
+
+        let Some(add) = dispatcher
+            .children(whitelist)
+            .into_iter()
+            .flatten()
+            .find(|child| {
+                dispatcher
+                    .node(**child)
+                    .is_some_and(|node| node.name() == "add")
+            })
+        else {
+            panic!("whitelist add should exist");
+        };
+        let Some(add_targets) = dispatcher
+            .children(*add)
+            .and_then(|children| children.first())
+        else {
+            panic!("whitelist add targets should exist");
+        };
+        assert!(matches!(
+            dispatcher.node(*add_targets),
+            Some(node)
+                if node.is_executable()
+                    && node.argument_type() == Some(&SteelArgumentType::game_profile())
+        ));
+    }
+}

--- a/steel-core/src/command/execution/argument.rs
+++ b/steel-core/src/command/execution/argument.rs
@@ -335,6 +335,10 @@ impl SteelArgumentType {
         Self::new(ComponentParser)
     }
 
+    pub(crate) fn message() -> Self {
+        Self::new(MessageParser)
+    }
+
     pub(crate) fn nbt_path() -> Self {
         Self::new(NbtPathParser)
     }
@@ -533,6 +537,7 @@ argument_value_wrapper!(
     ComponentValue(TextComponent),
     "steel:command/value/component"
 );
+argument_value_wrapper!(MessageValue(Box<str>), "steel:command/value/message");
 argument_value_wrapper!(NbtPathValue(NbtPath), "steel:command/value/nbt_path");
 argument_value_wrapper!(
     IdentifierValue(Identifier),
@@ -1097,6 +1102,16 @@ unit_argument_parser!(
     suggest | _context,
     _builder | {},
     protocol(ProtocolArgumentType::Component, None)
+);
+unit_argument_parser!(
+    MessageParser,
+    "steel:command/parser/message",
+    MessageValue,
+    parse | reader,
+    _source | { Ok(MessageValue(reader.read_remaining().into())) },
+    suggest | _context,
+    _builder | {},
+    protocol(ProtocolArgumentType::Message, None)
 );
 unit_argument_parser!(
     NbtPathParser,

--- a/steel-core/src/command/execution/argument.rs
+++ b/steel-core/src/command/execution/argument.rs
@@ -30,7 +30,8 @@ use crate::command::protocol::protocol_argument_type;
 use crate::entity::{ENTITIES, EntityAnchor};
 use glam::DVec3;
 use steel_protocol::packets::game::{
-    ArgumentType as ProtocolArgumentType, SuggestionType as ProtocolSuggestionType,
+    ArgumentStringTypeBehavior, ArgumentType as ProtocolArgumentType,
+    SuggestionType as ProtocolSuggestionType,
 };
 use steel_registry::damage_type::DamageTypeRef;
 use steel_registry::{
@@ -339,6 +340,10 @@ impl SteelArgumentType {
         Self::new(MessageParser)
     }
 
+    pub(crate) fn word() -> Self {
+        Self::new(WordParser)
+    }
+
     pub(crate) fn nbt_path() -> Self {
         Self::new(NbtPathParser)
     }
@@ -538,6 +543,7 @@ argument_value_wrapper!(
     "steel:command/value/component"
 );
 argument_value_wrapper!(MessageValue(Box<str>), "steel:command/value/message");
+argument_value_wrapper!(WordValue(Box<str>), "steel:command/value/word");
 argument_value_wrapper!(NbtPathValue(NbtPath), "steel:command/value/nbt_path");
 argument_value_wrapper!(
     IdentifierValue(Identifier),
@@ -1112,6 +1118,21 @@ unit_argument_parser!(
     suggest | _context,
     _builder | {},
     protocol(ProtocolArgumentType::Message, None)
+);
+unit_argument_parser!(
+    WordParser,
+    "steel:command/parser/word",
+    WordValue,
+    parse | reader,
+    _source | { Ok(WordValue(reader.read_unquoted_string().into())) },
+    suggest | _context,
+    _builder | {},
+    protocol(
+        ProtocolArgumentType::String {
+            behavior: ArgumentStringTypeBehavior::SingleWord
+        },
+        None,
+    )
 );
 unit_argument_parser!(
     NbtPathParser,

--- a/steel-core/src/command/execution/runtime.rs
+++ b/steel-core/src/command/execution/runtime.rs
@@ -28,7 +28,7 @@ use super::{
     argument::{
         ComponentValue, CoordinateAxes, DomainValue, EnchantmentValue, EntityTypeValue,
         GameModeValue, IdentifierValue, ItemStackValue, MessageValue, NbtPathValue, ObjectiveValue,
-        SteelArgumentValue, TimeValue, TimelineValue, WorldClockValue,
+        SteelArgumentValue, TimeValue, TimelineValue, WordValue, WorldClockValue,
     },
     selector::EntitySelector,
 };
@@ -354,6 +354,11 @@ where
 
     pub(crate) fn message(&self, name: &str) -> Result<&str, CommandSyntaxError> {
         self.typed_argument::<MessageValue>(name)
+            .map(|value| &*value.0)
+    }
+
+    pub(crate) fn word(&self, name: &str) -> Result<&str, CommandSyntaxError> {
+        self.typed_argument::<WordValue>(name)
             .map(|value| &*value.0)
     }
 

--- a/steel-core/src/command/execution/runtime.rs
+++ b/steel-core/src/command/execution/runtime.rs
@@ -27,7 +27,7 @@ use super::{
     SteelArgumentType, StructureOrTagKey, WorldArgument,
     argument::{
         ComponentValue, CoordinateAxes, DomainValue, EnchantmentValue, EntityTypeValue,
-        GameModeValue, IdentifierValue, ItemStackValue, NbtPathValue, ObjectiveValue,
+        GameModeValue, IdentifierValue, ItemStackValue, MessageValue, NbtPathValue, ObjectiveValue,
         SteelArgumentValue, TimeValue, TimelineValue, WorldClockValue,
     },
     selector::EntitySelector,
@@ -350,6 +350,11 @@ where
     pub(crate) fn text_component(&self, name: &str) -> Result<&TextComponent, CommandSyntaxError> {
         self.typed_argument::<ComponentValue>(name)
             .map(|value| &value.0)
+    }
+
+    pub(crate) fn message(&self, name: &str) -> Result<&str, CommandSyntaxError> {
+        self.typed_argument::<MessageValue>(name)
+            .map(|value| &*value.0)
     }
 
     pub(crate) fn nbt_path(&self, name: &str) -> Result<&NbtPath, CommandSyntaxError> {

--- a/steel-core/src/command/execution/source.rs
+++ b/steel-core/src/command/execution/source.rs
@@ -312,10 +312,6 @@ impl CommandSource {
         }
     }
 
-    #[expect(
-        dead_code,
-        reason = "source-aware runtime extensions need access to the original sender"
-    )]
     pub(crate) const fn sender(&self) -> &CommandSender {
         &self.sender
     }

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 use crate::chunk::chunk_map::ChunkMap;
 
+pub mod ban;
 pub mod behavior;
 pub mod block_entity;
 pub mod bootstrap;

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod server;
 #[cfg(test)]
 #[path = "../tests/support/mod.rs"]
 pub(crate) mod test_support;
+pub mod whitelist;
 pub mod world;
 pub mod worldgen;
 

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -37,6 +37,7 @@ use crate::entity::{
     Entity, EntityBase, PendingWorldChangeToken, RemovalReason, SharedEntity, change_entity_world,
 };
 
+use crate::ban::BanListManager;
 use crate::chunk_saver::{ChunkStorage, PersistentEntity, registry::WorldStorageRegistry};
 use crate::level_data::{LevelDataManager, RespawnData, WorldGenerationSettings};
 use crate::permission::{
@@ -379,6 +380,8 @@ pub struct Server {
     pub config: Arc<RuntimeConfig>,
     /// Runtime permission groups and their persistence boundary.
     pub permission_groups: PermissionGroupManager,
+    /// Runtime player ban list and its persistence boundary.
+    pub ban_list: BanListManager,
     /// The cancellation token for graceful shutdown.
     pub cancel_token: CancellationToken,
     /// The key store for the server.
@@ -524,6 +527,7 @@ impl Server {
         config: RuntimeConfig,
         worlds_config: WorldsConfig,
         permission_groups: PermissionGroupManager,
+        ban_list: BanListManager,
     ) -> Result<Self, String> {
         Self::new_with_commands(
             chunk_runtime,
@@ -531,6 +535,7 @@ impl Server {
             config,
             worlds_config,
             permission_groups,
+            ban_list,
             CommandRegistry::new(),
         )
         .await
@@ -547,6 +552,7 @@ impl Server {
         config: RuntimeConfig,
         worlds_config: WorldsConfig,
         permission_groups: PermissionGroupManager,
+        ban_list: BanListManager,
         command_registry: CommandRegistry,
     ) -> Result<Self, String> {
         validate_login_security(config.online_mode, config.encryption).map_err(str::to_owned)?;
@@ -709,6 +715,7 @@ impl Server {
         Ok(Server {
             config,
             permission_groups,
+            ban_list,
             cancel_token,
             key_store: KeyStore::create(),
             worlds,

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -37,7 +37,7 @@ use crate::entity::{
     Entity, EntityBase, PendingWorldChangeToken, RemovalReason, SharedEntity, change_entity_world,
 };
 
-use crate::ban::BanListManager;
+use crate::ban::{BanListManager, IpBanListManager};
 use crate::chunk_saver::{ChunkStorage, PersistentEntity, registry::WorldStorageRegistry};
 use crate::level_data::{LevelDataManager, RespawnData, WorldGenerationSettings};
 use crate::permission::{
@@ -382,6 +382,8 @@ pub struct Server {
     pub permission_groups: PermissionGroupManager,
     /// Runtime player ban list and its persistence boundary.
     pub ban_list: BanListManager,
+    /// Runtime IP ban list and its persistence boundary.
+    pub ip_ban_list: IpBanListManager,
     /// The cancellation token for graceful shutdown.
     pub cancel_token: CancellationToken,
     /// The key store for the server.
@@ -528,6 +530,7 @@ impl Server {
         worlds_config: WorldsConfig,
         permission_groups: PermissionGroupManager,
         ban_list: BanListManager,
+        ip_ban_list: IpBanListManager,
     ) -> Result<Self, String> {
         Self::new_with_commands(
             chunk_runtime,
@@ -536,6 +539,7 @@ impl Server {
             worlds_config,
             permission_groups,
             ban_list,
+            ip_ban_list,
             CommandRegistry::new(),
         )
         .await
@@ -546,6 +550,10 @@ impl Server {
         clippy::too_many_lines,
         reason = "server initialization is a single cohesive flow"
     )]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "each parameter is an independently constructed startup dependency"
+    )]
     pub async fn new_with_commands(
         chunk_runtime: Arc<Runtime>,
         cancel_token: CancellationToken,
@@ -553,6 +561,7 @@ impl Server {
         worlds_config: WorldsConfig,
         permission_groups: PermissionGroupManager,
         ban_list: BanListManager,
+        ip_ban_list: IpBanListManager,
         command_registry: CommandRegistry,
     ) -> Result<Self, String> {
         validate_login_security(config.online_mode, config.encryption).map_err(str::to_owned)?;
@@ -716,6 +725,7 @@ impl Server {
             config,
             permission_groups,
             ban_list,
+            ip_ban_list,
             cancel_token,
             key_store: KeyStore::create(),
             worlds,

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -68,6 +68,7 @@ pub(crate) use crate::server::packet_processor::PlayerPacketTransition;
 use crate::server::registry_cache::RegistryCache;
 use crate::server::service_keys::ServiceKeyStore;
 use crate::server::worlds::WorldMap;
+use crate::whitelist::WhitelistManager;
 use crate::world::player_spawn_finder::{PlayerSpawnSearch, PlayerSpawnSearchPoll};
 use crate::world::{PlayerMap, World, WorldConfig};
 use crate::worldgen::WorldGeneratorRegistry;
@@ -384,6 +385,8 @@ pub struct Server {
     pub ban_list: BanListManager,
     /// Runtime IP ban list and its persistence boundary.
     pub ip_ban_list: IpBanListManager,
+    /// Runtime whitelist and its persistence boundary.
+    pub whitelist: WhitelistManager,
     /// The cancellation token for graceful shutdown.
     pub cancel_token: CancellationToken,
     /// The key store for the server.
@@ -523,6 +526,10 @@ impl Server {
     }
 
     /// Creates a new server with only Steel's built-in commands.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "each parameter is an independently constructed startup dependency"
+    )]
     pub async fn new(
         chunk_runtime: Arc<Runtime>,
         cancel_token: CancellationToken,
@@ -531,6 +538,7 @@ impl Server {
         permission_groups: PermissionGroupManager,
         ban_list: BanListManager,
         ip_ban_list: IpBanListManager,
+        whitelist: WhitelistManager,
     ) -> Result<Self, String> {
         Self::new_with_commands(
             chunk_runtime,
@@ -540,6 +548,7 @@ impl Server {
             permission_groups,
             ban_list,
             ip_ban_list,
+            whitelist,
             CommandRegistry::new(),
         )
         .await
@@ -562,6 +571,7 @@ impl Server {
         permission_groups: PermissionGroupManager,
         ban_list: BanListManager,
         ip_ban_list: IpBanListManager,
+        whitelist: WhitelistManager,
         command_registry: CommandRegistry,
     ) -> Result<Self, String> {
         validate_login_security(config.online_mode, config.encryption).map_err(str::to_owned)?;
@@ -726,6 +736,7 @@ impl Server {
             permission_groups,
             ban_list,
             ip_ban_list,
+            whitelist,
             cancel_token,
             key_store: KeyStore::create(),
             worlds,

--- a/steel-core/src/server/player_lifecycle.rs
+++ b/steel-core/src/server/player_lifecycle.rs
@@ -468,6 +468,12 @@ impl Server {
         self.online_players.len()
     }
 
+    /// Returns the currently connected player with this UUID, if any.
+    #[must_use]
+    pub fn online_player(&self, uuid: Uuid) -> Option<Arc<Player>> {
+        self.online_players.get_by_uuid(&uuid)
+    }
+
     /// Returns a sample of up to 12 online players for the server list ping.
     #[must_use]
     pub fn player_sample(&self) -> Vec<(String, String)> {

--- a/steel-core/src/server/player_lifecycle.rs
+++ b/steel-core/src/server/player_lifecycle.rs
@@ -474,6 +474,17 @@ impl Server {
         self.online_players.get_by_uuid(&uuid)
     }
 
+    /// Returns every currently connected player.
+    #[must_use]
+    pub fn online_players_snapshot(&self) -> Vec<Arc<Player>> {
+        let mut players = Vec::new();
+        self.online_players.iter_players(|_, player| {
+            players.push(Arc::clone(player));
+            true
+        });
+        players
+    }
+
     /// Returns a sample of up to 12 online players for the server list ping.
     #[must_use]
     pub fn player_sample(&self) -> Vec<(String, String)> {

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -66,6 +66,7 @@ use crate::test_support::{
     TestPlayerBuilder, fresh_test_world, fresh_test_world_in_domain, insert_ready_full_chunk,
     test_world,
 };
+use crate::whitelist::WhitelistManager;
 use crate::world::World;
 
 use super::DEBUG_STACK_SIZE;
@@ -235,6 +236,7 @@ async fn test_server_with_worlds(
         .map_err(|error| format!("test permission groups should resolve: {error}"))?;
     let ban_list = BanListManager::transient();
     let ip_ban_list = IpBanListManager::transient();
+    let whitelist = WhitelistManager::transient();
     let config = test_runtime_config();
     let registry_cache = RegistryCache::new(config.compression);
 
@@ -243,6 +245,7 @@ async fn test_server_with_worlds(
         permission_groups,
         ban_list,
         ip_ban_list,
+        whitelist,
         cancel_token: CancellationToken::new(),
         key_store: KeyStore::create(),
         registry_cache,
@@ -3891,6 +3894,7 @@ default = true
             .expect("default permission groups should resolve"),
         BanListManager::transient(),
         IpBanListManager::transient(),
+        WhitelistManager::transient(),
     )
     .await
 }

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -41,7 +41,7 @@ use tokio::{
 };
 use uuid::Uuid;
 
-use crate::ban::BanListManager;
+use crate::ban::{BanListManager, IpBanListManager};
 use crate::behavior::init_behaviors;
 use crate::command::execution::{
     CommandArgumentSource, CommandExecutionContext, CommandPermissionSource, CommandResultCallback,
@@ -234,6 +234,7 @@ async fn test_server_with_worlds(
     let permission_groups = PermissionGroupManager::transient(PermissionGroupsConfig::default())
         .map_err(|error| format!("test permission groups should resolve: {error}"))?;
     let ban_list = BanListManager::transient();
+    let ip_ban_list = IpBanListManager::transient();
     let config = test_runtime_config();
     let registry_cache = RegistryCache::new(config.compression);
 
@@ -241,6 +242,7 @@ async fn test_server_with_worlds(
         config,
         permission_groups,
         ban_list,
+        ip_ban_list,
         cancel_token: CancellationToken::new(),
         key_store: KeyStore::create(),
         registry_cache,
@@ -3888,6 +3890,7 @@ default = true
         PermissionGroupManager::transient(PermissionGroupsConfig::default())
             .expect("default permission groups should resolve"),
         BanListManager::transient(),
+        IpBanListManager::transient(),
     )
     .await
 }

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -41,6 +41,7 @@ use tokio::{
 };
 use uuid::Uuid;
 
+use crate::ban::BanListManager;
 use crate::behavior::init_behaviors;
 use crate::command::execution::{
     CommandArgumentSource, CommandExecutionContext, CommandPermissionSource, CommandResultCallback,
@@ -232,12 +233,14 @@ async fn test_server_with_worlds(
         .collect();
     let permission_groups = PermissionGroupManager::transient(PermissionGroupsConfig::default())
         .map_err(|error| format!("test permission groups should resolve: {error}"))?;
+    let ban_list = BanListManager::transient();
     let config = test_runtime_config();
     let registry_cache = RegistryCache::new(config.compression);
 
     Ok(Arc::new(Server {
         config,
         permission_groups,
+        ban_list,
         cancel_token: CancellationToken::new(),
         key_store: KeyStore::create(),
         registry_cache,
@@ -3884,6 +3887,7 @@ default = true
         worlds_config,
         PermissionGroupManager::transient(PermissionGroupsConfig::default())
             .expect("default permission groups should resolve"),
+        BanListManager::transient(),
     )
     .await
 }

--- a/steel-core/src/whitelist.rs
+++ b/steel-core/src/whitelist.rs
@@ -1,0 +1,368 @@
+//! Persisted player whitelist.
+//!
+//! Mirrors vanilla's `UserWhiteList` plus the server's `use-whitelist` toggle,
+//! both stored together in Steel's own `whitelist.toml`.
+
+use std::{error::Error, fmt, sync::Arc};
+
+use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+use steel_utils::locks::{AsyncMutex, SyncRwLock};
+use uuid::Uuid;
+
+/// A single whitelist entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WhitelistEntry {
+    /// The whitelisted player's UUID.
+    pub uuid: Uuid,
+    /// The whitelisted player's last-known name, for display purposes only.
+    pub name: String,
+}
+
+/// Parsed `whitelist.toml` root.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WhitelistConfig {
+    /// Whether the whitelist is enforced at login.
+    #[serde(default)]
+    pub enabled: bool,
+    /// The list of whitelisted players.
+    #[serde(default)]
+    pub entries: Vec<WhitelistEntry>,
+}
+
+/// Persists the whitelist configuration owned outside `steel-core`.
+pub trait WhitelistStore: Send + Sync {
+    /// Saves the complete whitelist configuration.
+    fn save(&self, config: WhitelistConfig) -> BoxFuture<'static, Result<(), WhitelistStoreError>>;
+
+    /// Reloads the whitelist configuration from its backing storage, picking
+    /// up out-of-band edits (e.g. hand-editing `whitelist.toml` while the
+    /// server is running).
+    fn load(&self) -> BoxFuture<'static, Result<WhitelistConfig, WhitelistStoreError>>;
+}
+
+/// Whitelist persistence failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WhitelistStoreError {
+    message: String,
+}
+
+impl WhitelistStoreError {
+    /// Creates a persistence error from a displayable message.
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for WhitelistStoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for WhitelistStoreError {}
+
+/// Runtime whitelist with persistence-first updates.
+pub struct WhitelistManager {
+    updates: AsyncMutex<()>,
+    state: SyncRwLock<WhitelistConfig>,
+    store: Option<Arc<dyn WhitelistStore>>,
+}
+
+impl fmt::Debug for WhitelistManager {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WhitelistManager")
+            .field("updates", &self.updates)
+            .field("state", &self.state)
+            .field("store", &self.store.as_ref().map(|_| "<whitelist store>"))
+            .finish()
+    }
+}
+
+impl WhitelistManager {
+    /// Builds a manager from an initial config and an optional persistence store.
+    #[must_use]
+    pub fn new(config: WhitelistConfig, store: Option<Arc<dyn WhitelistStore>>) -> Self {
+        Self {
+            updates: AsyncMutex::new(()),
+            state: SyncRwLock::new(config),
+            store,
+        }
+    }
+
+    /// Builds a manager without persistence.
+    #[must_use]
+    pub fn transient() -> Self {
+        Self::new(WhitelistConfig::default(), None)
+    }
+
+    /// Returns whether the whitelist is currently enforced at login.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.state.read().enabled
+    }
+
+    /// Returns whether a UUID is currently whitelisted.
+    #[must_use]
+    pub fn is_whitelisted(&self, uuid: Uuid) -> bool {
+        self.state
+            .read()
+            .entries
+            .iter()
+            .any(|entry| entry.uuid == uuid)
+    }
+
+    /// Returns every whitelisted entry.
+    #[must_use]
+    pub fn entries(&self) -> Vec<WhitelistEntry> {
+        self.state.read().entries.clone()
+    }
+
+    /// Enables or disables the whitelist, persisting first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn set_enabled(&self, enabled: bool) -> Result<(), WhitelistManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        config.enabled = enabled;
+        self.persist_locked(config).await
+    }
+
+    /// Adds a whitelist entry, persisting first.
+    ///
+    /// Returns whether the player was newly added (a player who's already
+    /// whitelisted is left untouched, matching vanilla).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn add(&self, entry: WhitelistEntry) -> Result<bool, WhitelistManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        if config
+            .entries
+            .iter()
+            .any(|existing| existing.uuid == entry.uuid)
+        {
+            return Ok(false);
+        }
+        config.entries.push(entry);
+        self.persist_locked(config).await?;
+        Ok(true)
+    }
+
+    /// Removes a whitelist entry, persisting first.
+    ///
+    /// Returns whether an entry was actually removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persistence fails.
+    pub async fn remove(&self, uuid: Uuid) -> Result<bool, WhitelistManagerError> {
+        let _guard = self.updates.lock().await;
+        let mut config = self.state.read().clone();
+        let previous_len = config.entries.len();
+        config.entries.retain(|entry| entry.uuid != uuid);
+        if config.entries.len() == previous_len {
+            return Ok(false);
+        }
+        self.persist_locked(config).await?;
+        Ok(true)
+    }
+
+    /// Reloads the whitelist from its backing store, discarding any
+    /// in-memory state that hasn't been persisted.
+    ///
+    /// Does nothing when the manager has no store.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the reload fails.
+    pub async fn reload(&self) -> Result<(), WhitelistManagerError> {
+        let _guard = self.updates.lock().await;
+        let Some(store) = &self.store else {
+            return Ok(());
+        };
+        let config = store.load().await?;
+        *self.state.write() = config;
+        Ok(())
+    }
+
+    async fn persist_locked(&self, config: WhitelistConfig) -> Result<(), WhitelistManagerError> {
+        if let Some(store) = &self.store {
+            store.save(config.clone()).await?;
+        }
+        *self.state.write() = config;
+        Ok(())
+    }
+}
+
+/// Whitelist manager update failure.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WhitelistManagerError(WhitelistStoreError);
+
+impl fmt::Display for WhitelistManagerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "failed to store whitelist: {}", self.0)
+    }
+}
+
+impl Error for WhitelistManagerError {}
+
+impl From<WhitelistStoreError> for WhitelistManagerError {
+    fn from(value: WhitelistStoreError) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::future::BoxFuture;
+    use steel_utils::locks::SyncMutex;
+
+    use super::{
+        WhitelistConfig, WhitelistEntry, WhitelistManager, WhitelistStore, WhitelistStoreError,
+    };
+
+    #[derive(Debug)]
+    struct CapturingStore {
+        saved: Arc<SyncMutex<Vec<WhitelistConfig>>>,
+    }
+
+    impl WhitelistStore for CapturingStore {
+        fn save(
+            &self,
+            config: WhitelistConfig,
+        ) -> BoxFuture<'static, Result<(), WhitelistStoreError>> {
+            let saved = Arc::clone(&self.saved);
+            Box::pin(async move {
+                saved.lock().push(config);
+                Ok(())
+            })
+        }
+
+        fn load(&self) -> BoxFuture<'static, Result<WhitelistConfig, WhitelistStoreError>> {
+            let saved = Arc::clone(&self.saved);
+            Box::pin(async move { Ok(saved.lock().last().cloned().unwrap_or_default()) })
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingStore;
+
+    impl WhitelistStore for FailingStore {
+        fn save(
+            &self,
+            _config: WhitelistConfig,
+        ) -> BoxFuture<'static, Result<(), WhitelistStoreError>> {
+            Box::pin(async { Err(WhitelistStoreError::new("test store failure")) })
+        }
+
+        fn load(&self) -> BoxFuture<'static, Result<WhitelistConfig, WhitelistStoreError>> {
+            Box::pin(async { Err(WhitelistStoreError::new("test store failure")) })
+        }
+    }
+
+    fn entry(uuid: uuid::Uuid, name: &str) -> WhitelistEntry {
+        WhitelistEntry {
+            uuid,
+            name: name.to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_skips_an_already_whitelisted_player() {
+        let manager = WhitelistManager::transient();
+        let uuid = uuid::Uuid::nil();
+        assert!(
+            manager
+                .add(entry(uuid, "Steve"))
+                .await
+                .expect("add should succeed")
+        );
+        assert!(
+            !manager
+                .add(entry(uuid, "Steve"))
+                .await
+                .expect("add should succeed")
+        );
+        assert_eq!(manager.entries().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn remove_reports_whether_an_entry_existed() {
+        let manager = WhitelistManager::transient();
+        let uuid = uuid::Uuid::nil();
+        assert!(!manager.remove(uuid).await.expect("remove should succeed"));
+
+        manager
+            .add(entry(uuid, "Steve"))
+            .await
+            .expect("add should succeed");
+        assert!(manager.remove(uuid).await.expect("remove should succeed"));
+        assert!(!manager.is_whitelisted(uuid));
+    }
+
+    #[tokio::test]
+    async fn set_enabled_persists_and_updates_state() {
+        let manager = WhitelistManager::transient();
+        assert!(!manager.is_enabled());
+        manager
+            .set_enabled(true)
+            .await
+            .expect("set_enabled should succeed");
+        assert!(manager.is_enabled());
+    }
+
+    #[tokio::test]
+    async fn reload_replaces_in_memory_state_from_the_store() {
+        let saved = Arc::new(SyncMutex::new(Vec::new()));
+        let manager = WhitelistManager::new(
+            WhitelistConfig::default(),
+            Some(Arc::new(CapturingStore {
+                saved: Arc::clone(&saved),
+            })),
+        );
+        let uuid = uuid::Uuid::nil();
+        manager
+            .add(entry(uuid, "Steve"))
+            .await
+            .expect("add should succeed");
+
+        // Simulate an out-of-band edit landing in the backing store.
+        saved.lock().push(WhitelistConfig {
+            enabled: true,
+            entries: Vec::new(),
+        });
+
+        manager.reload().await.expect("reload should succeed");
+        assert!(manager.is_enabled());
+        assert!(!manager.is_whitelisted(uuid));
+    }
+
+    #[tokio::test]
+    async fn add_persists_before_applying_and_surfaces_store_errors() {
+        let failing =
+            WhitelistManager::new(WhitelistConfig::default(), Some(Arc::new(FailingStore)));
+        let uuid = uuid::Uuid::nil();
+        let error = failing
+            .add(entry(uuid, "Steve"))
+            .await
+            .expect_err("store failure should surface");
+        assert_eq!(
+            error.to_string(),
+            "failed to store whitelist: test store failure"
+        );
+        assert!(!failing.is_whitelisted(uuid));
+    }
+}

--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -50,6 +50,10 @@ impl JavaTcpClient {
         profile: GameProfile,
         reader_encryption: Option<[u8; 16]>,
     ) -> ConnectionAction {
+        if let Some(ban) = self.server.ban_list.find(profile.id) {
+            self.kick(ban.disconnect_message()).await;
+            return ConnectionAction::none();
+        }
         let action = self.send_login_compression().await;
         if !self.disconnect_duplicate_player(&profile).await {
             return ConnectionAction::none();

--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -54,6 +54,13 @@ impl JavaTcpClient {
             self.kick(ban.disconnect_message()).await;
             return ConnectionAction::none();
         }
+        if self.server.whitelist.is_enabled() && !self.server.whitelist.is_whitelisted(profile.id) {
+            self.kick(TextComponent::from(
+                &translations::MULTIPLAYER_DISCONNECT_NOT_WHITELISTED,
+            ))
+            .await;
+            return ConnectionAction::none();
+        }
         if let Some(ban) = self.server.ip_ban_list.find(&self.address.ip().to_string()) {
             self.kick(ban.disconnect_message()).await;
             return ConnectionAction::none();

--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -54,6 +54,10 @@ impl JavaTcpClient {
             self.kick(ban.disconnect_message()).await;
             return ConnectionAction::none();
         }
+        if let Some(ban) = self.server.ip_ban_list.find(&self.address.ip().to_string()) {
+            self.kick(ban.disconnect_message()).await;
+            return ConnectionAction::none();
+        }
         let action = self.send_login_compression().await;
         if !self.disconnect_duplicate_player(&profile).await {
             return ConnectionAction::none();

--- a/steel/src/config/ban_list.rs
+++ b/steel/src/config/ban_list.rs
@@ -1,0 +1,72 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use futures::future::BoxFuture;
+use steel_core::ban::{BanListConfig, BanListStore, BanListStoreError};
+use tokio::fs as async_fs;
+
+const DEFAULT_BAN_LIST: &str = "bans = []\n";
+
+/// TOML-backed ban list store.
+#[derive(Clone, Debug)]
+pub struct FileBanListStore {
+    path: PathBuf,
+}
+
+impl FileBanListStore {
+    /// Creates a file-backed ban list store.
+    #[must_use]
+    pub const fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl BanListStore for FileBanListStore {
+    fn save_bans(
+        &self,
+        config: BanListConfig,
+    ) -> BoxFuture<'static, Result<(), BanListStoreError>> {
+        let path = self.path.clone();
+        Box::pin(async move {
+            let serialized = toml::to_string_pretty(&config).map_err(|error| {
+                BanListStoreError::new(format!("failed to serialize ban list: {error}"))
+            })?;
+            write_atomic_config(&path, serialized)
+                .await
+                .map_err(|error| {
+                    BanListStoreError::new(format!(
+                        "failed to write ban list {}: {error}",
+                        path.display()
+                    ))
+                })
+        })
+    }
+}
+
+async fn write_atomic_config(path: &Path, contents: String) -> io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "config path has no parent",
+        ));
+    };
+    async_fs::create_dir_all(parent).await?;
+    let temp_path = path.with_extension("toml.tmp");
+    async_fs::write(&temp_path, contents).await?;
+    async_fs::rename(temp_path, path).await
+}
+
+pub(super) fn load_or_create_ban_list(path: &Path) -> Result<BanListConfig, String> {
+    if path.exists() {
+        let contents = fs::read_to_string(path)
+            .map_err(|error| format!("failed to read ban list {}: {error}", path.display()))?;
+        toml::from_str(&contents)
+            .map_err(|error| format!("failed to parse ban list {}: {error}", path.display()))
+    } else {
+        fs::write(path, DEFAULT_BAN_LIST)
+            .map_err(|error| format!("failed to write ban list {}: {error}", path.display()))?;
+        Ok(BanListConfig::default())
+    }
+}

--- a/steel/src/config/ban_list.rs
+++ b/steel/src/config/ban_list.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use futures::future::BoxFuture;
-use steel_core::ban::{BanListConfig, BanListStore, BanListStoreError};
+use steel_core::ban::{
+    BanListConfig, BanListStore, BanListStoreError, IpBanListConfig, IpBanListStore,
+};
 use tokio::fs as async_fs;
 
 const DEFAULT_BAN_LIST: &str = "bans = []\n";
@@ -68,5 +70,54 @@ pub(super) fn load_or_create_ban_list(path: &Path) -> Result<BanListConfig, Stri
         fs::write(path, DEFAULT_BAN_LIST)
             .map_err(|error| format!("failed to write ban list {}: {error}", path.display()))?;
         Ok(BanListConfig::default())
+    }
+}
+
+/// TOML-backed IP ban list store.
+#[derive(Clone, Debug)]
+pub struct FileIpBanListStore {
+    path: PathBuf,
+}
+
+impl FileIpBanListStore {
+    /// Creates a file-backed IP ban list store.
+    #[must_use]
+    pub const fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl IpBanListStore for FileIpBanListStore {
+    fn save_bans(
+        &self,
+        config: IpBanListConfig,
+    ) -> BoxFuture<'static, Result<(), BanListStoreError>> {
+        let path = self.path.clone();
+        Box::pin(async move {
+            let serialized = toml::to_string_pretty(&config).map_err(|error| {
+                BanListStoreError::new(format!("failed to serialize IP ban list: {error}"))
+            })?;
+            write_atomic_config(&path, serialized)
+                .await
+                .map_err(|error| {
+                    BanListStoreError::new(format!(
+                        "failed to write IP ban list {}: {error}",
+                        path.display()
+                    ))
+                })
+        })
+    }
+}
+
+pub(super) fn load_or_create_ip_ban_list(path: &Path) -> Result<IpBanListConfig, String> {
+    if path.exists() {
+        let contents = fs::read_to_string(path)
+            .map_err(|error| format!("failed to read IP ban list {}: {error}", path.display()))?;
+        toml::from_str(&contents)
+            .map_err(|error| format!("failed to parse IP ban list {}: {error}", path.display()))
+    } else {
+        fs::write(path, DEFAULT_BAN_LIST)
+            .map_err(|error| format!("failed to write IP ban list {}: {error}", path.display()))?;
+        Ok(IpBanListConfig::default())
     }
 }

--- a/steel/src/config/mod.rs
+++ b/steel/src/config/mod.rs
@@ -9,7 +9,7 @@ mod groups;
 mod logging;
 mod server;
 
-pub use ban_list::FileBanListStore;
+pub use ban_list::{FileBanListStore, FileIpBanListStore};
 pub use groups::FilePermissionGroupStore;
 pub use logging::{LogConfig, LogLevel, LogTimeFormat, RotationTimeFormat};
 pub use server::{ServerConfig, ThreadConfig};
@@ -23,12 +23,16 @@ use std::{
 
 use serde::Deserialize;
 use steel_core::{
-    ban::{BanListConfig, BanListStore},
+    ban::{BanListConfig, BanListStore, IpBanListConfig, IpBanListStore},
     config::WorldsConfig,
     permission::{PermissionGroupStore, PermissionGroupsConfig},
 };
 
-use self::{ban_list::load_or_create_ban_list, groups::load_or_create_groups, server::validate};
+use self::{
+    ban_list::{load_or_create_ban_list, load_or_create_ip_ban_list},
+    groups::load_or_create_groups,
+    server::validate,
+};
 
 #[cfg(feature = "stand-alone")]
 const DEFAULT_FAVICON: &[u8] = include_bytes!("../../../package-content/favicon.png");
@@ -59,6 +63,12 @@ pub struct SteelConfig {
     /// Path to the loaded `banned-players.toml`.
     #[serde(skip, default)]
     pub ban_list_path: Option<PathBuf>,
+    /// IP ban list configuration from `banned-ips.toml`.
+    #[serde(skip, default)]
+    pub ip_ban_list: IpBanListConfig,
+    /// Path to the loaded `banned-ips.toml`.
+    #[serde(skip, default)]
+    pub ip_ban_list_path: Option<PathBuf>,
 }
 
 impl SteelConfig {
@@ -76,6 +86,14 @@ impl SteelConfig {
         self.ban_list_path
             .as_ref()
             .map(|path| Arc::new(FileBanListStore::new(path.clone())) as Arc<dyn BanListStore>)
+    }
+
+    /// Builds the store used for persistence-first IP ban list updates.
+    #[must_use]
+    pub fn ip_ban_list_store(&self) -> Option<Arc<dyn IpBanListStore>> {
+        self.ip_ban_list_path
+            .as_ref()
+            .map(|path| Arc::new(FileIpBanListStore::new(path.clone())) as Arc<dyn IpBanListStore>)
     }
 }
 
@@ -135,6 +153,12 @@ pub fn load_or_create(path: &Path) -> Result<SteelConfig, String> {
         .join("banned-players.toml");
     config.ban_list = load_or_create_ban_list(&ban_list_path)?;
     config.ban_list_path = Some(ban_list_path);
+    let ip_ban_list_path = path
+        .parent()
+        .ok_or_else(|| format!("failed to get config directory for {}", path.display()))?
+        .join("banned-ips.toml");
+    config.ip_ban_list = load_or_create_ip_ban_list(&ip_ban_list_path)?;
+    config.ip_ban_list_path = Some(ip_ban_list_path);
 
     // If icon file doesnt exist, write it
     #[cfg(feature = "stand-alone")]

--- a/steel/src/config/mod.rs
+++ b/steel/src/config/mod.rs
@@ -4,10 +4,12 @@
 //! The config is loaded once at startup, split into creation-time values
 //! (consumed by the server constructor) and a `RuntimeConfig` (stored on `Server`).
 
+mod ban_list;
 mod groups;
 mod logging;
 mod server;
 
+pub use ban_list::FileBanListStore;
 pub use groups::FilePermissionGroupStore;
 pub use logging::{LogConfig, LogLevel, LogTimeFormat, RotationTimeFormat};
 pub use server::{ServerConfig, ThreadConfig};
@@ -21,11 +23,12 @@ use std::{
 
 use serde::Deserialize;
 use steel_core::{
+    ban::{BanListConfig, BanListStore},
     config::WorldsConfig,
     permission::{PermissionGroupStore, PermissionGroupsConfig},
 };
 
-use self::{groups::load_or_create_groups, server::validate};
+use self::{ban_list::load_or_create_ban_list, groups::load_or_create_groups, server::validate};
 
 #[cfg(feature = "stand-alone")]
 const DEFAULT_FAVICON: &[u8] = include_bytes!("../../../package-content/favicon.png");
@@ -50,6 +53,12 @@ pub struct SteelConfig {
     /// Path to the loaded `groups.toml`.
     #[serde(skip, default)]
     pub groups_path: Option<PathBuf>,
+    /// Ban list configuration from `banned-players.toml`.
+    #[serde(skip, default)]
+    pub ban_list: BanListConfig,
+    /// Path to the loaded `banned-players.toml`.
+    #[serde(skip, default)]
+    pub ban_list_path: Option<PathBuf>,
 }
 
 impl SteelConfig {
@@ -59,6 +68,14 @@ impl SteelConfig {
         self.groups_path.as_ref().map(|path| {
             Arc::new(FilePermissionGroupStore::new(path.clone())) as Arc<dyn PermissionGroupStore>
         })
+    }
+
+    /// Builds the store used for persistence-first ban list updates.
+    #[must_use]
+    pub fn ban_list_store(&self) -> Option<Arc<dyn BanListStore>> {
+        self.ban_list_path
+            .as_ref()
+            .map(|path| Arc::new(FileBanListStore::new(path.clone())) as Arc<dyn BanListStore>)
     }
 }
 
@@ -112,6 +129,12 @@ pub fn load_or_create(path: &Path) -> Result<SteelConfig, String> {
         .join("groups.toml");
     config.groups = load_or_create_groups(&groups_path)?;
     config.groups_path = Some(groups_path);
+    let ban_list_path = path
+        .parent()
+        .ok_or_else(|| format!("failed to get config directory for {}", path.display()))?
+        .join("banned-players.toml");
+    config.ban_list = load_or_create_ban_list(&ban_list_path)?;
+    config.ban_list_path = Some(ban_list_path);
 
     // If icon file doesnt exist, write it
     #[cfg(feature = "stand-alone")]

--- a/steel/src/config/mod.rs
+++ b/steel/src/config/mod.rs
@@ -8,11 +8,13 @@ mod ban_list;
 mod groups;
 mod logging;
 mod server;
+mod whitelist;
 
 pub use ban_list::{FileBanListStore, FileIpBanListStore};
 pub use groups::FilePermissionGroupStore;
 pub use logging::{LogConfig, LogLevel, LogTimeFormat, RotationTimeFormat};
 pub use server::{ServerConfig, ThreadConfig};
+pub use whitelist::FileWhitelistStore;
 
 use std::{
     collections::BTreeMap,
@@ -26,12 +28,14 @@ use steel_core::{
     ban::{BanListConfig, BanListStore, IpBanListConfig, IpBanListStore},
     config::WorldsConfig,
     permission::{PermissionGroupStore, PermissionGroupsConfig},
+    whitelist::{WhitelistConfig, WhitelistStore},
 };
 
 use self::{
     ban_list::{load_or_create_ban_list, load_or_create_ip_ban_list},
     groups::load_or_create_groups,
     server::validate,
+    whitelist::load_or_create_whitelist,
 };
 
 #[cfg(feature = "stand-alone")]
@@ -69,6 +73,12 @@ pub struct SteelConfig {
     /// Path to the loaded `banned-ips.toml`.
     #[serde(skip, default)]
     pub ip_ban_list_path: Option<PathBuf>,
+    /// Whitelist configuration from `whitelist.toml`.
+    #[serde(skip, default)]
+    pub whitelist: WhitelistConfig,
+    /// Path to the loaded `whitelist.toml`.
+    #[serde(skip, default)]
+    pub whitelist_path: Option<PathBuf>,
 }
 
 impl SteelConfig {
@@ -94,6 +104,14 @@ impl SteelConfig {
         self.ip_ban_list_path
             .as_ref()
             .map(|path| Arc::new(FileIpBanListStore::new(path.clone())) as Arc<dyn IpBanListStore>)
+    }
+
+    /// Builds the store used for persistence-first whitelist updates.
+    #[must_use]
+    pub fn whitelist_store(&self) -> Option<Arc<dyn WhitelistStore>> {
+        self.whitelist_path
+            .as_ref()
+            .map(|path| Arc::new(FileWhitelistStore::new(path.clone())) as Arc<dyn WhitelistStore>)
     }
 }
 
@@ -159,6 +177,12 @@ pub fn load_or_create(path: &Path) -> Result<SteelConfig, String> {
         .join("banned-ips.toml");
     config.ip_ban_list = load_or_create_ip_ban_list(&ip_ban_list_path)?;
     config.ip_ban_list_path = Some(ip_ban_list_path);
+    let whitelist_path = path
+        .parent()
+        .ok_or_else(|| format!("failed to get config directory for {}", path.display()))?
+        .join("whitelist.toml");
+    config.whitelist = load_or_create_whitelist(&whitelist_path)?;
+    config.whitelist_path = Some(whitelist_path);
 
     // If icon file doesnt exist, write it
     #[cfg(feature = "stand-alone")]

--- a/steel/src/config/whitelist.rs
+++ b/steel/src/config/whitelist.rs
@@ -1,0 +1,87 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use futures::future::BoxFuture;
+use steel_core::whitelist::{WhitelistConfig, WhitelistStore, WhitelistStoreError};
+use tokio::fs as async_fs;
+
+const DEFAULT_WHITELIST: &str = "enabled = false\nentries = []\n";
+
+/// TOML-backed whitelist store.
+#[derive(Clone, Debug)]
+pub struct FileWhitelistStore {
+    path: PathBuf,
+}
+
+impl FileWhitelistStore {
+    /// Creates a file-backed whitelist store.
+    #[must_use]
+    pub const fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl WhitelistStore for FileWhitelistStore {
+    fn save(&self, config: WhitelistConfig) -> BoxFuture<'static, Result<(), WhitelistStoreError>> {
+        let path = self.path.clone();
+        Box::pin(async move {
+            let serialized = toml::to_string_pretty(&config).map_err(|error| {
+                WhitelistStoreError::new(format!("failed to serialize whitelist: {error}"))
+            })?;
+            write_atomic_config(&path, serialized)
+                .await
+                .map_err(|error| {
+                    WhitelistStoreError::new(format!(
+                        "failed to write whitelist {}: {error}",
+                        path.display()
+                    ))
+                })
+        })
+    }
+
+    fn load(&self) -> BoxFuture<'static, Result<WhitelistConfig, WhitelistStoreError>> {
+        let path = self.path.clone();
+        Box::pin(async move {
+            let contents = async_fs::read_to_string(&path).await.map_err(|error| {
+                WhitelistStoreError::new(format!(
+                    "failed to read whitelist {}: {error}",
+                    path.display()
+                ))
+            })?;
+            toml::from_str(&contents).map_err(|error| {
+                WhitelistStoreError::new(format!(
+                    "failed to parse whitelist {}: {error}",
+                    path.display()
+                ))
+            })
+        })
+    }
+}
+
+async fn write_atomic_config(path: &Path, contents: String) -> io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "config path has no parent",
+        ));
+    };
+    async_fs::create_dir_all(parent).await?;
+    let temp_path = path.with_extension("toml.tmp");
+    async_fs::write(&temp_path, contents).await?;
+    async_fs::rename(temp_path, path).await
+}
+
+pub(super) fn load_or_create_whitelist(path: &Path) -> Result<WhitelistConfig, String> {
+    if path.exists() {
+        let contents = fs::read_to_string(path)
+            .map_err(|error| format!("failed to read whitelist {}: {error}", path.display()))?;
+        toml::from_str(&contents)
+            .map_err(|error| format!("failed to parse whitelist {}: {error}", path.display()))
+    } else {
+        fs::write(path, DEFAULT_WHITELIST)
+            .map_err(|error| format!("failed to write whitelist {}: {error}", path.display()))?;
+        Ok(WhitelistConfig::default())
+    }
+}

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -16,6 +16,7 @@ use steel_core::{
     command::CommandRegistry,
     permission::PermissionGroupManager,
     server::Server,
+    whitelist::WhitelistManager,
 };
 use steel_login::{JavaTcpClient, ServerConnectionSession};
 use tokio::{net::TcpListener, runtime::Runtime, select};
@@ -99,10 +100,12 @@ impl SteelServer {
         let permission_group_store = steel_config.permission_group_store();
         let ban_list_store = steel_config.ban_list_store();
         let ip_ban_list_store = steel_config.ip_ban_list_store();
+        let whitelist_store = steel_config.whitelist_store();
         let server_port = steel_config.server.server_port;
         let worlds_config = steel_config.worlds;
         let ban_list = BanListManager::new(steel_config.ban_list, ban_list_store);
         let ip_ban_list = IpBanListManager::new(steel_config.ip_ban_list, ip_ban_list_store);
+        let whitelist = WhitelistManager::new(steel_config.whitelist, whitelist_store);
         let permission_groups =
             PermissionGroupManager::new(steel_config.groups, permission_group_store).map_err(
                 |error| {
@@ -120,6 +123,7 @@ impl SteelServer {
             permission_groups,
             ban_list,
             ip_ban_list,
+            whitelist,
             command_registry,
         )
         .await

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -11,7 +11,8 @@ use std::{
 };
 
 use steel_core::{
-    GIT_HASH_SHORT, command::CommandRegistry, permission::PermissionGroupManager, server::Server,
+    GIT_HASH_SHORT, ban::BanListManager, command::CommandRegistry,
+    permission::PermissionGroupManager, server::Server,
 };
 use steel_login::{JavaTcpClient, ServerConnectionSession};
 use tokio::{net::TcpListener, runtime::Runtime, select};
@@ -93,8 +94,10 @@ impl SteelServer {
         log::info!("Starting Steel Server ({GIT_HASH_SHORT})");
 
         let permission_group_store = steel_config.permission_group_store();
+        let ban_list_store = steel_config.ban_list_store();
         let server_port = steel_config.server.server_port;
         let worlds_config = steel_config.worlds;
+        let ban_list = BanListManager::new(steel_config.ban_list, ban_list_store);
         let permission_groups =
             PermissionGroupManager::new(steel_config.groups, permission_group_store).map_err(
                 |error| {
@@ -110,6 +113,7 @@ impl SteelServer {
             runtime_config,
             worlds_config,
             permission_groups,
+            ban_list,
             command_registry,
         )
         .await

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -11,8 +11,11 @@ use std::{
 };
 
 use steel_core::{
-    GIT_HASH_SHORT, ban::BanListManager, command::CommandRegistry,
-    permission::PermissionGroupManager, server::Server,
+    GIT_HASH_SHORT,
+    ban::{BanListManager, IpBanListManager},
+    command::CommandRegistry,
+    permission::PermissionGroupManager,
+    server::Server,
 };
 use steel_login::{JavaTcpClient, ServerConnectionSession};
 use tokio::{net::TcpListener, runtime::Runtime, select};
@@ -95,9 +98,11 @@ impl SteelServer {
 
         let permission_group_store = steel_config.permission_group_store();
         let ban_list_store = steel_config.ban_list_store();
+        let ip_ban_list_store = steel_config.ip_ban_list_store();
         let server_port = steel_config.server.server_port;
         let worlds_config = steel_config.worlds;
         let ban_list = BanListManager::new(steel_config.ban_list, ban_list_store);
+        let ip_ban_list = IpBanListManager::new(steel_config.ip_ban_list, ip_ban_list_store);
         let permission_groups =
             PermissionGroupManager::new(steel_config.groups, permission_group_store).map_err(
                 |error| {
@@ -114,6 +119,7 @@ impl SteelServer {
             worlds_config,
             permission_groups,
             ban_list,
+            ip_ban_list,
             command_registry,
         )
         .await


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [x] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

Fifth and last PR in the moderation-commands batch (#664 `/kick`, #665
`/ban` + `/pardon`, #666 `/ban-ip` + `/pardon-ip`, #667 `/banlist`). This
one implements the full `/whitelist` command, matching vanilla's
`WhitelistCommand`: `on`, `off`, `list`, `add <targets>`,
`remove <targets>`, `reload`.

**Storage**: `WhitelistEntry`/`WhitelistConfig`/`WhitelistManager` in a new
`steel_core::whitelist` module, following the same persistence-first
pattern as `BanListManager`/`IpBanListManager`, persisted to
`whitelist.toml`. Unlike the ban stores, `WhitelistStore` also has a `load`
method (not just `save`): `/whitelist reload` needs to re-read
`whitelist.toml` from disk to pick up an operator hand-editing the file
while the server is running, which is a real vanilla use case the ban
commands don't have an equivalent of.

**`add`/`remove`**: resolve targets through the existing `GameProfileArgument`
(works offline, same as `/ban`/`/pardon`), skip a target that's already
whitelisted / not whitelisted (matching vanilla), and error only when none
of the targets changed anything.

**Kicking unlisted players**: `/whitelist on`, `/whitelist remove`, and
`/whitelist reload` all disconnect currently-connected players who are no
longer whitelisted, matching `PlayerList.kickUnlistedPlayers`. This is the
first command in the batch that needs to act on already-connected players
by iterating everyone online, which none of the ban commands needed (a ban
only ever affects the single banned player) - added a small
`Server::online_players_snapshot()` for it.

**Login enforcement**: `steel-login`'s `finish_verified_login` now also
checks the whitelist, in vanilla's `canPlayerLogin` order: ban check, then
whitelist check, then IP ban check.

## How this was tested

- `whitelist::tests`: add skips an already-whitelisted player, remove
  reports whether an entry existed, `set_enabled` persists and updates
  state, `reload` replaces in-memory state from the store (simulating an
  out-of-band edit), and a persistence-first round trip through a
  capturing/failing `WhitelistStore`.
- `command::builtins::whitelist::tests`: command graph has all six
  subcommands, and `add`'s targets use `GameProfileArgument`.

`cargo test`, `cargo clippy -r --all-targets --all-features`,
`cargo fmt --all --check`, `typos`, and `prek run --all-files` all pass.

## Screenshots / logs

<!-- n/a -->

## Checklist

- [x] Code builds w/o errors or warnings
- [ ] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes / commands modified:

- New: `/whitelist on`, `/whitelist off`, `/whitelist list`,
  `/whitelist add`, `/whitelist remove`, `/whitelist reload`
- New: `steel_core::whitelist` (`WhitelistEntry`, `WhitelistConfig`,
  `WhitelistManager`, `WhitelistStore`), `steel::config::FileWhitelistStore`
- New: `Server::whitelist`, `Server::online_players_snapshot()`
- Changed: `Server::new` / `Server::new_with_commands` now also take a
  `WhitelistManager`
- Changed: `steel-login`'s `finish_verified_login` now also rejects
  non-whitelisted connections while the whitelist is enabled

## Additional notes

- Stacked on #664, #665, #666, and #667 - the diff currently includes their
  commits too, and will shrink as each merges into `master`.
- This closes out the batch of commands requested for this round; ban reason
  storage follows #665's `TextComponent` review feedback throughout (ban and
  IP ban reasons), though `/whitelist` entries have no reason field to begin
  with (matches vanilla's `UserWhiteListEntry`).
